### PR TITLE
Update to latest snapshot of WADL tools.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <saxon-ee.version>9.4.0.4</saxon-ee.version>
         <scala.test.version>1.6.1</scala.test.version>
         <junit.version>4.10</junit.version>
-        <wadl-tools.version>1.0.9</wadl-tools.version>
+        <wadl-tools.version>1.0.10-SNAPSHOT</wadl-tools.version>
         <xmlsec.version>1.4.6</xmlsec.version>
         <xerces.version>2.12.0-rax</xerces.version>
         <servlet.version>3.1</servlet.version>


### PR DESCRIPTION
This fixes issue where attaching resource types to "/" produced errors.
