### PR TITLE
Enabling PreProcess extension inappropreatel also enables WellForm check

### DIFF
--- a/core/src/main/resources/xsl/builder.xsl
+++ b/core/src/main/resources/xsl/builder.xsl
@@ -67,7 +67,7 @@
                   select="$enablePlainParamCheck"/>
     <xsl:variable name="useWellFormCheck" as="xsd:boolean"
                   select="$enableWellFormCheck or $useXSDContentCheck or $enableElementCheck or
-                          $enablePlainParamCheck or $enablePreProcessExtension"/>
+                          $enablePlainParamCheck"/>
     <xsl:variable name="useHeaderCheck" as="xsd:boolean"
                   select="$enableHeaderCheck"/>
     <xsl:variable name="useMessageExtension" as="xsd:boolean"
@@ -593,12 +593,14 @@
 
     <xsl:template match="wadl:request/wadl:representation[@mediaType]">
         <xsl:variable name="defaultNext" select="$ACCEPT"/>
+        <xsl:variable name="doUseWellFormCheck" as="xsd:boolean"
+                      select="$useWellFormCheck or ($usePreProcessExtension and exists(rax:preprocess))"/>
         <step type="REQ_TYPE">
             <xsl:attribute name="id" select="generate-id()"/>
             <!-- Note that matches on the media type are always case insensitive -->
             <xsl:attribute name="match" select="check:mediaTypeToRegEx(@mediaType)"/>
             <xsl:choose>
-                <xsl:when test="$useWellFormCheck">
+                <xsl:when test="$doUseWellFormCheck">
                     <xsl:choose>
                         <xsl:when test="check:isXML(@mediaType) or check:isJSON(@mediaType)">
                             <xsl:call-template name="check:addWellFormNext"/>
@@ -614,7 +616,7 @@
             </xsl:choose>
             <xsl:call-template name="check:addLabel"/>
         </step>
-        <xsl:if test="$useWellFormCheck">
+        <xsl:if test="$doUseWellFormCheck">
             <xsl:choose>
                 <xsl:when test="check:isXML(@mediaType)">
                     <xsl:call-template name="check:addWellForm">

--- a/core/src/test/scala/wadl/checker-tests-preporc.scala
+++ b/core/src/test/scala/wadl/checker-tests-preporc.scala
@@ -68,6 +68,63 @@ class WADLCheckerPreProcSpec extends BaseCheckerSpec {
         </resources>
       </application>
 
+      val testPreProcWADL =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+        <grammars/>
+        <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="PUT">
+                  <request>
+                      <representation mediaType="application/xml"/>
+                      <representation mediaType="application/json"/>
+                  </request>
+               </method>
+               <method name="POST">
+                  <request>
+                      <representation mediaType="application/xml">
+                        <rax:preprocess>
+                            <xsl:stylesheet version="1.0">
+                              <xsl:output method="xml" encoding="UTF-8"/>
+                            </xsl:stylesheet>
+                        </rax:preprocess>
+                      </representation>
+                  </request>
+               </method>
+           </resource>
+           <resource path="/c">
+               <method name="POST">
+                  <request>
+                      <representation mediaType="application/json"/>
+                  </request>
+               </method>
+               <method name="GET"/>
+           </resource>
+           <resource path="/any">
+              <method name="POST">
+                 <request>
+                    <representation mediaType="*/*"/>
+                 </request>
+              </method>
+           </resource>
+           <resource path="/text">
+              <method name="POST">
+                 <request>
+                    <representation mediaType="text/*"/>
+                 </request>
+              </method>
+           </resource>
+           <resource path="/v">
+              <method name="POST">
+                 <request>
+                    <representation mediaType="text/plain;charset=UTF8"/>
+                 </request>
+              </method>
+           </resource>
+        </resources>
+      </application>
+
       scenario("The testWADL is processed with preporc extension disabled") {
         given("The testWADL with preproc extension disabled")
         when("The WADL is transalted")
@@ -82,6 +139,17 @@ class WADLCheckerPreProcSpec extends BaseCheckerSpec {
         val checker = builder.build(testWADL, TestConfig(false, false, false, false, false, 1, false, false, true))
         then("There should not be any well-form checks")
         assert(checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 0");
+      }
+
+      scenario("The testPreProcWADL is processed with preporc extension enabled") {
+        given("The testPreProcWADL with preproc extension disabled")
+        when("The WADL is transalted")
+        val checker = builder.build(testPreProcWADL, TestConfig(false, false, false, false, false, 1, false, false, true))
+        then("There should be a single WELL_XML step on the POST operation")
+        assert(checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 1")
+        assert(checker, "count(/chk:checker/chk:step[@type='XSL']) = 1")
+        assert(checker, Start, URL("a"), URL("b"), Method("POST"),
+               ReqType("(application/xml)(;.*)?"), WellXML, XSL, Accept)
       }
     }
 }


### PR DESCRIPTION
With preprocess enabled off

![wo-preproc](https://f.cloud.github.com/assets/348314/144072/526daa70-73eb-11e2-8afd-6dd8a72ece5b.png)

with preprocess on

![preproc](https://f.cloud.github.com/assets/348314/144070/3d4a04c2-73eb-11e2-8426-7f38adf5a9ab.png)

Well form check should not be added unless necessary.

This is a big deal because we are planning on enabling preporc by default, so don't want to add WellForm check unnecessarily. 
