### PR TITLE
Error results do no list correct states when converted to strings.

### DIFF
--- a/core/src/main/scala/step/results.scala
+++ b/core/src/main/scala/step/results.scala
@@ -56,7 +56,7 @@ class MultiFailResult(val fails : Array[Result], uriLevel : Int, stepId : String
   override protected val startPath = "{"
   override protected val endPath = "}"
 
-  override def path : String = startPath+(for {f <- fails} yield f.path).reduceLeft(_+" "+_)+endPath
+  override def path : String = startPath+stepIDs.reduceLeft(_+" "+_)+" "+(for {f <- fails} yield f.path).reduceLeft(_+" "+_)+endPath
 
   override def toString : String = {
     reduce match {


### PR DESCRIPTION
When we convert an error result to a string only mismatch states are displayed.  Should list correct states shown.
