### PR TITLE
Issue: 51: D-12007: API Checker Error Message Propogation

### DIFF
--- a/core/src/main/scala/handler/instrumented-handler.scala
+++ b/core/src/main/scala/handler/instrumented-handler.scala
@@ -72,9 +72,6 @@ class InstrumentedHandler extends ResultHandler with Instrumented with Instrumen
 
   private def markResult (result : Result) : Unit = {
     result.stepIDs.foreach (s => stepMeters(s).mark)
-    if (result.isInstanceOf[MultiFailResult]) {
-      result.asInstanceOf[MultiFailResult].fails.foreach (f => markResult(f))
-    }
   }
 
   private def markFail (result : Result, req : CheckerServletRequest) : Unit = {
@@ -91,7 +88,7 @@ class InstrumentedHandler extends ResultHandler with Instrumented with Instrumen
   }
 
   override def handle (req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, result : Result)  : Unit = {
-    markResult(result)
+    result.allResults.foreach( markResult )
     if (!result.valid) {
       markFail(result, req)
     }

--- a/core/src/main/scala/handler/servlet-result-handler.scala
+++ b/core/src/main/scala/handler/servlet-result-handler.scala
@@ -18,9 +18,6 @@ class ServletResultHandler extends ResultHandler {
   def handle (req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, result : Result)  : Unit = {
     if (!result.valid) {
       result match {
-        case mrf : MultiFailResult =>
-          val re = mrf.reduce.get.asInstanceOf[ErrorResult]
-          sendError(re, resp)
         case errorResult : ErrorResult =>
           sendError(errorResult, resp)
       }

--- a/core/src/main/scala/step/step-base.scala
+++ b/core/src/main/scala/step/step-base.scala
@@ -13,14 +13,12 @@ abstract class Step(val id : String, val label : String) {
   //
   //  Checks the step at the given URI level.
   //
-  def check(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, uriLevel : Int) : Option[Result]
+  def check(req : CheckerServletRequest,
+            resp : CheckerServletResponse,
+            chain : FilterChain,
+            uriLevel : Int,
+            stepCount : Int = 1 ) : Option[Result]
 
-  //
-  //  Checks the step at the beginnig of the PATH
-  //
-  def check(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain) : Option[Result] = {
-    return check(req,resp,chain)
-  }
 }
 
 //
@@ -42,10 +40,15 @@ abstract class ConnectedStep(id : String, label : String, val next : Array[Step]
   //
   //  Go to the next step.
   //
-  def nextStep (req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, uriLevel : Int) : Array[Result] = {
+  def nextStep (req : CheckerServletRequest,
+                resp : CheckerServletResponse,
+                chain : FilterChain,
+                uriLevel : Int,
+                stepCount : Int) : Array[Result] = {
+
     val resultBuffer = new ListBuffer[Result]
     for (i <- 0 to next.length-1) {
-      val oresult = next(i).check(req, resp, chain, uriLevel)
+      val oresult = next(i).check(req, resp, chain, uriLevel, stepCount + 1 )
       if (oresult.isDefined) {
         val result = oresult.get
         if (result.valid) {
@@ -61,21 +64,26 @@ abstract class ConnectedStep(id : String, label : String, val next : Array[Step]
   //
   //  Check this step, if successful, check next relevant steps.
   //
-  override def check(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, uriLevel : Int) : Option[Result] = {
+  override def check(req : CheckerServletRequest,
+                     resp : CheckerServletResponse,
+                     chain : FilterChain,
+                     uriLevel : Int,
+                     stepCount : Int ) : Option[Result] = {
+
     var result : Option[Result] = None
     val nextURILevel = checkStep(req, resp, chain, uriLevel)
 
     if (nextURILevel != -1) {
-      val results : Array[Result] = nextStep (req, resp, chain, nextURILevel)
+      val results : Array[Result] = nextStep (req, resp, chain, nextURILevel, stepCount )
       if (results.size == 1) {
         results(0).addStepId(id)
         result = Some(results(0))
       } else {
-        result = Some(new MultiFailResult (results, uriLevel, id))
+        result = Some(new MultiFailResult (results))
       }
 
     } else {
-      result = Some(new MismatchResult(mismatchMessage, uriLevel, id))
+      result = Some( new MismatchResult( mismatchMessage, uriLevel, id, stepCount ) )
     }
 
     return result

--- a/core/src/test/scala/validator-base.scala
+++ b/core/src/test/scala/validator-base.scala
@@ -449,14 +449,45 @@ class BaseValidatorSuite extends FunSuite {
     result
   }
 
-  def assertResultFailed(f : => Any, code : Int) : Unit = {
+  //
+  // Verify the allResults method is the correct size & has
+  // the correct head element
+  //
+  def assertAllResultsCorrect( f : => Any, size : Int ) : Unit = {
     var result : ErrorResult = null
+
     assertResultFailed(f).get.result match {
-      case mfr : MultiFailResult =>
-        result = mfr.reduce.get.asInstanceOf[ErrorResult]
       case other : ErrorResult =>
         result = other
     }
+
+    val list = result.allResults.toList
+
+    val head = list.head match {
+      case e : ErrorResult => e
+    }
+
+    if ( list.size != size ) {
+      throw new TestFailedException(Some("Expect list of 4 but got " + list.size ), None, 4)
+    }
+
+    if( result.code != head.code
+        || result.message != head.message
+        || result.uriLevel != head.uriLevel
+        || result.stepIDs != head.stepIDs ) {
+      throw new TestFailedException(Some("First item in allResults list did not match main Result" ), None, 4)
+    }
+
+
+  }
+
+  def assertResultFailed(f : => Any, code : Int) : Unit = {
+    var result : ErrorResult = null
+    assertResultFailed(f).get.result match {
+      case other : ErrorResult =>
+        result = other
+    }
+
     if (result.code != code) {
       throw new TestFailedException(Some("Expected error code "+code+" but got "+result.code), None, 4)
     }
@@ -465,11 +496,10 @@ class BaseValidatorSuite extends FunSuite {
   def assertResultFailed(f : => Any, code : Int, message : String) : Unit = {
     var result : ErrorResult = null
     assertResultFailed(f).get.result match {
-      case mfr : MultiFailResult =>
-        result = mfr.reduce.get.asInstanceOf[ErrorResult]
       case other : ErrorResult =>
         result = other
     }
+
     if (result.code != code) {
       throw new TestFailedException(Some("Expected error code "+code+" but got "+result.code), None, 4)
     }
@@ -481,11 +511,10 @@ class BaseValidatorSuite extends FunSuite {
   def assertResultFailed(f : => Any, code : Int, message : List[String]) : Unit = {
     var result : ErrorResult = null
     assertResultFailed(f).get.result match {
-      case mfr : MultiFailResult =>
-        result = mfr.reduce.get.asInstanceOf[ErrorResult]
       case other : ErrorResult =>
         result = other
     }
+
     if (result.code != code) {
       throw new TestFailedException(Some("Expected error code "+code+" but got "+result.code), None, 4)
     }
@@ -499,11 +528,10 @@ class BaseValidatorSuite extends FunSuite {
   def assertResultFailed(f : => Any, code : Int, headers : Map[String, String]) : Unit = {
     var result : ErrorResult = null
     assertResultFailed(f).get.result match {
-      case mfr : MultiFailResult =>
-        result = mfr.reduce.get.asInstanceOf[ErrorResult]
       case other : ErrorResult =>
         result = other
     }
+
     if (result.code != code) {
       throw new TestFailedException(Some("Expected error code "+code+" but got "+result.code), None, 4)
     }

--- a/core/src/test/scala/validator-tests.scala
+++ b/core/src/test/scala/validator-tests.scala
@@ -11,6 +11,12 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class ValidatorSuite extends BaseValidatorSuite {
+
+  //
+  // NOTE:  Result.allResults Traversable construct is verified in the test:
+  // "Ensure allResults returns all Results with main at the head of the list"
+  //
+
   //
   // validator_EMPTY does not allow ANY HTTP requests. The validator
   // is used in the following tests.
@@ -411,6 +417,8 @@ class ValidatorSuite extends BaseValidatorSuite {
   // GET /.*/b
   // PUT /a/b (accepting application/xml)
   // POST /c/b (accepting application/xml and application/json)
+  // PUT /d (accepting application/xml)
+  // POST /d (accepting application/json)
   //
   // The of course means that a GET on /a/b is allowed. As is a get on
   // /c/b.
@@ -430,17 +438,26 @@ class ValidatorSuite extends BaseValidatorSuite {
     val get = new Method("GET", "GET", "GET".r, Array (accept))
     val putIn = new ReqType("ReqType", "XML", "((?i)application/xml)()".r, Array(accept))
     val postIn = new ReqType("ReqType", "XML|JSON", "((?i)application/xml|(?i)application/json)()".r, Array(accept))
+    val postJSON = new ReqType("ReqType", "JSON", "((?i)application/json)()".r, Array(accept))
     val put = new Method("PUT", "PUT", "PUT".r, Array (putIn, reqTFail))
     val post = new Method("POST", "POST", "POST".r, Array (postIn, reqTFail2))
+    val postD = new Method( "POST", "POST", "POST".r, Array (postJSON, reqTFail2))
     val b = new URI("b","b", "b".r, Array(put, urlFail, methodFailPut))
     val b2 = new URI("b2","b2", "b".r, Array(get, urlFail, methodFailGet))
     val b3 = new URI("b3","b3", "b".r, Array(post, urlFail, methodFailPost))
     val a = new URI("a","a", "a".r, Array(b, urlFailB, methodFail))
     val any = new URI("any","any", ".*".r, Array(b2, urlFailB, methodFail))
     val c = new URI("c","c", "c".r, Array(b3, urlFailB, methodFail))
-    val start = new Start("START", "Start", Array(a, c, any, methodFail))
+    val d = new URI("d","d", "d".r, Array(put, postD, urlFail, methodFailGet ))
+    val start = new Start("START", "Start", Array(a, c, d, any, methodFail))
     start
   }, assertConfig)
+
+  // verifies that media type supersedes method error
+  test ("PUT on /d should fail if the media type if application/json" ) {
+    assertResultFailed(validator_AM.validate(request("PUT","/d", "application/json"),
+      response,chain), 415 )
+  }
 
   test ("GET on /a/b should succeed on validator_AM") {
     validator_AM.validate(request("GET","/a/b"),response,chain)
@@ -548,6 +565,8 @@ class ValidatorSuite extends BaseValidatorSuite {
   //
   //  GET /a/b
   //  PUT /a/b (accepting valid application/xml)
+  //  GET /a/b/c
+  //  PUT /a/b/c (accepting valid application/xml)
   //
   val validator_XML = Validator({
     val accept = new Accept("A0", "Accept")
@@ -555,6 +574,7 @@ class ValidatorSuite extends BaseValidatorSuite {
     val methodFail = new MethodFail ("MF", "MethodFail")
     val urlFailA = new URLFailMatch("UFA", "URLFail","a".r)
     val urlFailB = new URLFailMatch("UFA", "URLFail","b".r)
+    val urlFailC = new URLFailMatch("UFA", "URLFail","c".r)
     val get = new Method("GET", "GET", "GET".r, Array (accept))
     val methodFailGetPut = new MethodFailMatch ("MFG", "MethodFail", "GET|PUT".r)
     val reqTFail = new ReqTypeFail("RTF", "RTFail", "((?i)application/xml)()".r)
@@ -562,7 +582,8 @@ class ValidatorSuite extends BaseValidatorSuite {
     val wellXML = new WellFormedXML ("WXML", "WELLXML", Array(accept))
     val putIn = new ReqType("ReqType", "XML", "((?i)application/xml)()".r, Array(wellXML, contentFail))
     val put = new Method("PUT", "PUT", "PUT".r, Array (putIn, reqTFail))
-    val b = new URI("b","b", "b".r, Array(put, get, urlFail, methodFailGetPut))
+    val c = new URI("c","c", "c".r, Array(put, get, urlFail, methodFailGetPut))
+    val b = new URI("b","b", "b".r, Array(c, put, get, urlFailC, methodFailGetPut))
     val a = new URI("a","a", "a".r, Array(b, urlFailB, methodFail))
     val start = new Start("START", "Start", Array(a, urlFailA, methodFail))
     start
@@ -588,13 +609,25 @@ class ValidatorSuite extends BaseValidatorSuite {
 
   test ("a POST on /a/b should fail on validator_XML") {
     assertResultFailed(validator_XML.validate(request("POST","/a/b", "application/xml",
-                                                      <some_xml att='1' xmlns='test.org'>
-                                                        <an_element>
-                                                         <another_element />
-                                                        </an_element>
-                                                      </some_xml>
-                                                    ),response,chain), 405, Map("Allow"->"GET, PUT"))
+      <some_xml att='1' xmlns='test.org'>
+        <an_element>
+          <another_element />
+        </an_element>
+      </some_xml>
+    ),response,chain), 405, Map("Allow"->"GET, PUT"))
   }
+
+  // verifies that method fail supersedes URL fail
+  test ("a POST on /a/b/c should fail on validator_XML") {
+    assertResultFailed(validator_XML.validate(request("POST","/a/b/c", "application/xml",
+      <some_xml att='1' xmlns='test.org'>
+        <an_element>
+          <another_element />
+        </an_element>
+      </some_xml>
+    ),response,chain), 405, Map("Allow"->"GET, PUT"))
+  }
+
 
   test ("PUT on /a/b with valid JSON should fail with 415") {
     assertResultFailed(validator_XML.validate(request("PUT","/a/b","application/json",

--- a/core/src/test/scala/validator-wadl-header-tests.scala
+++ b/core/src/test/scala/validator-wadl-header-tests.scala
@@ -726,6 +726,24 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
     </application>)
     , TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true))
 
+
+  // testing allResults traversal
+  test ("Ensure allResults returns all Results with main at the head of the list" ) {
+
+    assertAllResultsCorrect( validatorCode_Header.validate(request("PUT","/a/b","application/xml", goodXML_XSD2, false),
+                                                           response,
+                                                           chain ),
+                             4 )
+  }
+
+
+  // verifies that header error supersedes media type errors
+  test ( "POST on /a/b with application/JSON and no header should fail") {
+    assertResultFailed( validator_Header.validate( request( "POST", "/a/b", "application/json", goodJSON,
+    false, Map[String, List[String]]()), response, chain),
+                        400 )
+  }
+
   test ("PUT on /a/b with application/xml should succeed on validator_Header with valid XML1") {
     validator_Header.validate(request("PUT","/a/b","application/xml", goodXML_XSD2, false, Map("X-TEST"->List("foo"))),response,chain)
   }


### PR DESCRIPTION
Added a natural ordering for Result with Result.compare & the Ordered trait
so that the most salient ErrorResult can be selected from a MultiErrorResult.

Priority is dictated by ErrorResult type & then path length in the automaton.

Updated MultiErrorResult to pass all method calls to the most salient ErrorResult
in its PriorityQueue.  Added allResults method which returns a Traversable of
all Results in the MultiErrorResult.

Added test cases to verify priority dictated by ErrorResult and value of
Result.allResults.  Current tests already verify priority by path length.
