### PR TITLE
NULL Schema when testing against standard XSD types with no grammar

### DIFF
--- a/core/src/test/scala/validator-wadl-tests.scala
+++ b/core/src/test/scala/validator-wadl-tests.scala
@@ -269,6 +269,87 @@ class ValidatorWADLSuite extends BaseValidatorSuite {
 
 
   //
+  // validator_INT allows a GET on /a/<someint>/c. That is, the 2nd URI
+  // component can be any integer. The validator is used in the
+  // following tests.
+  //
+  val validator_INT = Validator(
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="a/{int}/c">
+                   <param name="int" style="template" type="xsd:integer"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+    </application>
+    , assertConfig)
+
+  test ("GET on /a/7/c should succeed on validator_INT") {
+    validator_INT.validate(request("GET","/a/7/c"),response,chain)
+  }
+
+  test ("GET on /a/-7/c should succeed on validator_INT") {
+    validator_INT.validate(request("GET","/a/-7/c"),response,chain)
+  }
+
+  test ("GET on /a/<randomLong>/c should succeed on validator_INT") {
+    val rl = new Random(new Date().getTime()).nextLong()
+    validator_INT.validate(request("GET","/a/"+rl+"/c"),response,chain)
+  }
+
+  test ("GET on /a/<bigInt>/c should succeed on validator_INT") {
+    val bi = new BigInteger(1024, new Random(new Date().getTime()).self)
+    validator_INT.validate(request("GET","/a/"+bi+"/c"),response,chain)
+  }
+
+  test ("GET on /a/<randomDouble>/c should fail validator_INT") {
+    val rf = new Random(new Date().getTime()).nextDouble()
+    assertResultFailed(validator_INT.validate(request("GET","/a/"+rf+"/c"),response,chain), 404)
+  }
+
+  test ("GET on /a/<uuid>/c should fail validator_INT") {
+    val uuid = UUID.randomUUID().toString()
+    assertResultFailed(validator_INT.validate(request("GET","/a/"+uuid+"/c"),response,chain), 404)
+  }
+
+  test ("GET on /a/<katakana>/c should fail validator_INT") {
+    assertResultFailed(validator_INT.validate(request("GET","/a/%E3%83%84%E3%83%85%E3%83%8C%E3%82%A4/c"),response,chain), 404)
+  }
+
+  //
+  //  Ignoring for now, this should fail, but it doesn't may be an
+  //  issue with XSD test.
+  //
+  ignore ("GET on /a/ 7/c should fail validator_INT") {
+    assertResultFailed(validator_INT.validate(request("GET","/a/ 7/c"),response,chain), 404)
+  }
+
+  test ("GET on /a/+7/c should succeed validator_INT") {
+    validator_INT.validate(request("GET","/a/%2B7/c"),response,chain)
+  }
+
+  test ("GET on /a/    /c should fail validator_INT") {
+    assertResultFailed(validator_INT.validate(request("GET","/a/++++/c"),response,chain), 404)
+  }
+
+  test ("GET on /a//c should fail validator_INT") {
+    assertResultFailed(validator_INT.validate(request("GET","/a//c"),response,chain), 404)
+  }
+
+  test ("GET on /a should fail validator_INT") {
+    assertResultFailed(validator_INT.validate(request("GET","/a"),response,chain), 405, Map("Allow"->""))
+  }
+
+  test ("GET on /a/7/d should fail validator_INT") {
+    assertResultFailed(validator_INT.validate(request("GET","/a/7/d"),response,chain), 404)
+  }
+
+  //
   // validator_RT allows:
   //
   // PUT /a/b with json and xml support


### PR DESCRIPTION
If the WADL does not have a  <grammar>  section and a standard xsd type is used:

xsd:string, xsd:int, xsd:long ...etc.

Then a null pointer exception will occur.   Somewhere around the line this used to work, but looks like there's been a regression.  Need tests!
