### PR TITLE
change assertResultFailed(f : =>, code: Int) to return ErrorResult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+*.iml

--- a/core/src/test/scala/validator-base.scala
+++ b/core/src/test/scala/validator-base.scala
@@ -494,7 +494,7 @@ class BaseValidatorSuite extends FunSuite {
     return result
   }
 
-  def assertResultFailed(f : => Any, code : Int, message : String) : Unit = {
+  def assertResultFailed(f : => Any, code : Int, message : String) : ErrorResult = {
     var result : ErrorResult = null
     assertResultFailed(f).get.result match {
       case other : ErrorResult =>
@@ -507,9 +507,10 @@ class BaseValidatorSuite extends FunSuite {
     if (result.message != message) {
       throw new TestFailedException(Some("Expected error message '"+message+"' but got '"+result.message+"'"), None, 4)
     }
+    return result
   }
 
-  def assertResultFailed(f : => Any, code : Int, message : List[String]) : Unit = {
+  def assertResultFailed(f : => Any, code : Int, message : List[String]) : ErrorResult = {
     var result : ErrorResult = null
     assertResultFailed(f).get.result match {
       case other : ErrorResult =>
@@ -524,9 +525,10 @@ class BaseValidatorSuite extends FunSuite {
         throw new TestFailedException(Some("Expected error string '"+m+"' in the result message, but it didn't have one. Actual result message: '"+result.message+"'"), None, 4)
       }
     })
+    return result
   }
 
-  def assertResultFailed(f : => Any, code : Int, headers : Map[String, String]) : Unit = {
+  def assertResultFailed(f : => Any, code : Int, headers : Map[String, String]) : ErrorResult = {
     var result : ErrorResult = null
     assertResultFailed(f).get.result match {
       case other : ErrorResult =>
@@ -545,5 +547,6 @@ class BaseValidatorSuite extends FunSuite {
         throw new TestFailedException(Some("Expected result header "+k+" to match value '"+v+"' but instead got '"+result.headers.get(k)+"'"), None, 4)
       }
     })
+    return result
   }
 }

--- a/core/src/test/scala/validator-base.scala
+++ b/core/src/test/scala/validator-base.scala
@@ -481,7 +481,7 @@ class BaseValidatorSuite extends FunSuite {
 
   }
 
-  def assertResultFailed(f : => Any, code : Int) : Unit = {
+  def assertResultFailed(f : => Any, code : Int) : ErrorResult = {
     var result : ErrorResult = null
     assertResultFailed(f).get.result match {
       case other : ErrorResult =>
@@ -491,6 +491,7 @@ class BaseValidatorSuite extends FunSuite {
     if (result.code != code) {
       throw new TestFailedException(Some("Expected error code "+code+" but got "+result.code), None, 4)
     }
+    return result
   }
 
   def assertResultFailed(f : => Any, code : Int, message : String) : Unit = {

--- a/core/src/test/scala/validator-tests.scala
+++ b/core/src/test/scala/validator-tests.scala
@@ -30,7 +30,9 @@ class ValidatorSuite extends BaseValidatorSuite {
   }, assertConfig)
 
   test ("GET on / should fail on validator_EMPTY") {
-    assertResultFailed(validator_EMPTY.validate(request("GET","/"),response,chain), 405, Map("Allow"->""))
+    val result = assertResultFailed(validator_EMPTY.validate(request("GET","/"),response,chain), 405, Map("Allow"->""))
+    // this is just a check to make sure the returned result has the same error code
+    assert(result.code == 405)
   }
 
   test ("an empty GET should fail on validator_EMPTY") {


### PR DESCRIPTION
In standard-usage-schema, I would like to be able to check substring for the 400 message. The reason is, the exact error messages for error 400 returned by Xerces and Saxon are different. I don't want to have to conditionally code this in the standard-usage-schema tests. Instead, I want to be able to check for substring like this:

```
  test("Slice Action without serviceCode should generate 400 with the appropriate response message") {
    val req = request("POST", "/servers/events", "application/atom+xml", sliceActionWithoutServiceCode)
    val validatorResult = this.assertResultFailed(atomValidator.validate(req, response, chain), 400)
    assert(validatorResult.message.contains("serviceCode"))
    //assertResultFailed(atomValidator.validate(req, response, chain), 400, "Bad Content: Required attribute @serviceCode is missing")
  }
```
