### PR TITLE
D-12702: upgrade scalatest to 2.9.3-1.9.1 to make standard-usage-schemas happy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.9.0</artifactId>
+            <artifactId>scalatest_2.9.3</artifactId>
             <version>${scala.test.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
After I changed standard-usage-schemas to use api-checker 1.0.8 (from 1.0.6), I got this exception (see below) when building it. So I changed standard-usage-schemas to use Scala 2.9.3 everywhere, including the scalatest_2.9.3-1.91. 

After that, it's still complaining of NoClassDefFoundError and someone is bringing in `org.scalatest:scalatest_2.9.0:1.6.1 requires scala version: 2.9.0` 

Running mvn dependency:tree showed that api-checker-1.0.8 test-jar does it. 

I did a local build of api-checker-1.0.9-SNAPSHOT with the above changes. Now, everyone is happy.

```
[INFO] --- maven-scala-plugin:2.15.2:testCompile (default) @ usage-schema ---
[INFO] Checking for multiple versions of scala
[WARNING]  Expected all dependencies to require Scala version: 2.9.1
[WARNING]  com.rackspace.usage:usage-schema:1.18.0-SNAPSHOT requires scala version: 2.9.1
[WARNING]  org.scalatest:scalatest_2.9.0:1.6.1 requires scala version: 2.9.0
[WARNING] Multiple versions of scala libraries detected!
….
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
org.apache.maven.surefire.util.SurefireReflectionException: java.lang.reflect.InvocationTargetException; nested exception is java.lang.reflect.InvocationTargetException: null
java.lang.reflect.InvocationTargetException
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
at java.lang.reflect.Method.invoke(Method.java:597)
at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcessWhenForked(SurefireStarter.java:107)
at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:68)
Caused by: java.lang.NoClassDefFoundError: org/scalatest/exceptions/TestFailedException
```
