### PR TITLE
A representation with no mediatype should be ignored when processing plain parameters

### DIFF
--- a/core/src/main/resources/xsl/builder.xsl
+++ b/core/src/main/resources/xsl/builder.xsl
@@ -246,7 +246,7 @@
         <xsl:apply-templates mode="ns"/>
     </xsl:template>
 
-    <xsl:template match="wadl:representation[check:isXML(@mediaType)]/wadl:param[(@style = 'plain') and @path]" priority="2" mode="ns">
+    <xsl:template match="wadl:representation[@mediaType and check:isXML(@mediaType)]/wadl:param[(@style = 'plain') and @path]" priority="2" mode="ns">
         <!--
             If we have an XPath param in an XML representation, then
             copy all namespace nodes in that param. And enure that we

--- a/core/src/test/scala/wadl/checker-tests.scala
+++ b/core/src/test/scala/wadl/checker-tests.scala
@@ -4378,6 +4378,37 @@ class WADLCheckerSpec extends BaseCheckerSpec {
             XPath("/tst:a/@id"), XPath("/tst:a/@stepType"), ContentFail)
   }
 
+  scenario("The WADL contains a POST  operation with plain params but a missing mediaType, should validaate but not create XPaths") {
+    Given ("a WADL that contains a POST operation with XML that must validate against an XSD with elemenst specified and multiple plain params")
+    val inWADL =
+      <application xmlns="http://wadl.dev.java.net/2009/02"
+                   xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
+        <grammars>
+            <include href="src/test/resources/xsd/test-urlxsd.xsd"/>
+        </grammars>
+        <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                      <representation element="tst:a">
+                         <param name="id" style="plain" path="/tst:a/@id" required="true"/>
+                         <param name="stepType" style="plain" path="/tst:a/@stepType" required="true"/>
+                      </representation>
+                  </request>
+               </method>
+           </resource>
+        </resources>
+    </application>
+    register("test://app/src/test/resources/xsd/test-urlxsd.xsd",
+             XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
+    val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1, true))
+    assert(checker, "count(/chk:checker/chk:step[@type='XPATH']) = 0")
+    assert(checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/tst:a']) = 0")
+    assert(checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/tst:a/@id']) = 0")
+    assert(checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/tst:a/@stepType']) = 0")
+    assert (checker, Start, URL("a"), URL("b"), Method("POST"),  Accept)
+  }
+
   scenario("The WADL contains a POST  operation accepting xml which must validate against an XSD with elements specified and multiple required plain params (rax:code extension)") {
     Given ("a WADL that contains a POST operation with XML that must validate against an XSD with elemenst specified and multiple plain params")
     val inWADL =


### PR DESCRIPTION
Only representations with XML mediatypes should work.

Currently all representations with plain params are checked (even if they are not XML).  This produces a recoverable non-fatal error, but should still be corrected so that we only check the plain params we support.
