### PR TITLE
Moving to wadl-tools 1.0.15-SNAPSHOT.  Required for atom-hopper.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <saxon-ee.version>9.4.0.6</saxon-ee.version>
         <scala.test.version>1.9.1</scala.test.version>
         <junit.version>4.10</junit.version>
-        <wadl-tools.version>1.0.14</wadl-tools.version>
+        <wadl-tools.version>1.0.15-SNAPSHOT</wadl-tools.version>
         <xmlsec.version>1.4.6</xmlsec.version>
         <xerces.version>2.12.1-rax</xerces.version>
         <servlet.version>3.1</servlet.version>


### PR DESCRIPTION
- Points to wadl-tools 1.0.15-SNAPSHOT which has a fix to no longer strip
  xmlns attributes within the wadl param element during normalization.
- atom-hopper requires this for B-50883
