### PR TITLE
Updating versions of json and jackson libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <codec.version>1.7</codec.version>
         <xalan.version>2.7.1</xalan.version>
         <metrics-scala.version>2.2.0</metrics-scala.version>
-        <jackson-databind.version>2.1.5</jackson-databind.version>
-        <json-schema-validator.version>2.1.6</json-schema-validator.version>
+        <jackson-databind.version>2.2.3</jackson-databind.version>
+        <json-schema-validator.version>2.1.7</json-schema-validator.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Updating libraries (all unit tests are passing)

jackson-databind (2.1.5  ->  2.2.3)

json-schema-validator (2.1.6  ->  2.1.7)

Full release notes can be found:
https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION
https://github.com/fge/json-schema-validator/blob/master/RELEASE-NOTES.md
