### PR TITLE
Not tracking paths to error conditions

### DIFF
--- a/core/src/main/scala/step/step-base.scala
+++ b/core/src/main/scala/step/step-base.scala
@@ -79,7 +79,7 @@ abstract class ConnectedStep(id : String, label : String, val next : Array[Step]
         results(0).addStepId(id)
         result = Some(results(0))
       } else {
-        result = Some(new MultiFailResult (results))
+        result = Some(new MultiFailResult (results, id))
       }
 
     } else {

--- a/core/src/main/scala/step/urixsd.scala
+++ b/core/src/main/scala/step/urixsd.scala
@@ -30,7 +30,7 @@ class URIXSD(id : String, label : String, simpleType : QName, schema : Schema, n
                results(0).addStepId(id)
                result = Some(results(0))
              case _ =>
-               result = Some(new MultiFailResult (results))
+               result = Some(new MultiFailResult (results, id))
            }
          }
        } else {

--- a/core/src/test/scala/step/result-tests.scala
+++ b/core/src/test/scala/step/result-tests.scala
@@ -1,0 +1,79 @@
+package com.rackspace.com.papi.components.checker.step
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[JUnitRunner])
+class ResultSuite extends BaseStepSuite {
+  val e12 = new MismatchResult("Mismatch", -1, "12", 8)
+  val e13 = new MismatchResult("Mismatch", -1, "13", 8)
+  val e14 = new BadMediaTypeResult("Bad Media Type", -1, "14", 8)
+  val e15 = new MethodFailResult("Bad Method", -1, "15", 8, Map("Foo"->"Bar"))
+  val e16 = new BadMediaTypeResult("Bad MT", -1, "16", 9)
+
+  val e10 = new MultiFailResult(Array(e12, e13, e14, e15), "10")
+
+  e10.addStepId("9")
+  e10.addStepId("8")
+
+  val e7 = new MethodFailResult("Bad Method", -1, "7", 8, Map("Foo"->"Bar"))
+
+  e7.addStepId("6")
+  e7.addStepId("5")
+
+  val e3 = new MultiFailResult(Array(e10, e7), "3")
+
+  e3.addStepId("2")
+  e3.addStepId("1")
+  e3.addStepId("S")
+
+  val e11 = new MultiFailResult(Array(e3, e16), "0")
+
+  test("Given e3, the result should be bad media type.") {
+    assert (e3.code == 415, "The error code should match bad media type")
+    assert (e3.message == "Bad Media Type", "The message should match bad media type")
+  }
+
+  test("Given e11, the result should be a *different* bad media type.") {
+    assert (e11.code == 415, "The error should match bad media type")
+    assert (e11.message == "Bad MT", "The message should match bad mt")
+  }
+
+  test("Confirm path for e12") {
+    assert (e12.path == "(12)")
+  }
+
+  test("Confirm path for e13") {
+    assert (e13.path == "(13)")
+  }
+
+  test("Confirm path for e14") {
+    assert (e14.path == "[14]")
+  }
+
+  test("Confirm path for e15") {
+    assert (e15.path == "[15]")
+  }
+
+  test("Confirm path for e16") {
+    assert (e16.path == "[16]")
+  }
+
+  test("Confirm path for e7") {
+    assert (e7.path == "[5 6 7]")
+  }
+
+  test ("Confirm path for e10") {
+    assert (e10.path == "{8 9 10 (12) (13) [14] [15]}*14*")
+  }
+
+  test("Confirm path for e3") {
+    assert (e3.path == "{S 1 2 3 {8 9 10 (12) (13) [14] [15]}*14* [5 6 7]}*14*")
+  }
+
+  test ("Confirm path for e11") {
+    assert (e11.path == "{0 {S 1 2 3 {8 9 10 (12) (13) [14] [15]}*14* [5 6 7]}*14* [16]}*16*")
+  }
+}

--- a/core/src/test/scala/validator-base.scala
+++ b/core/src/test/scala/validator-base.scala
@@ -540,18 +540,10 @@ class BaseValidatorSuite extends FunSuite {
       case e : ErrorResult => e
     }
 
-    if ( list.size != size ) {
-      throw new TestFailedException(Some("Expect list of 4 but got " + list.size ), None, 4)
-    }
-
-    if( result.code != head.code
-        || result.message != head.message
-        || result.uriLevel != head.uriLevel
-        || result.stepIDs != head.stepIDs ) {
-      throw new TestFailedException(Some("First item in allResults list did not match main Result" ), None, 4)
-    }
-
-
+    assert(list.size == size, "Bad list size")
+    assert(result.code == head.code, "First item in allResults list did not match main Result" )
+    assert(result.message == head.message, "First item in allResults list did not match main Result" )
+    assert(result.uriLevel == head.uriLevel, "First item in allResults list did not match main Result" )
   }
 
   def assertResultFailed(f : => Any, code : Int) : Unit = {


### PR DESCRIPTION
There seems to be a bug where we are not tracking paths to error conditions. With the console logger we are getting output like this:

```
[NOPE] PUT /a/b [d33e9 d33e17WF] 400 : Bad Content: object has missing required properties (["firstName","lastName"])
```

Notice that we are not seeing path from the start node.
