### PR TITLE
Updated WADL-Tools to 1.0.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <saxon-ee.version>9.4.0.6</saxon-ee.version>
         <scala.test.version>2.0</scala.test.version>
         <junit.version>4.10</junit.version>
-        <wadl-tools.version>1.0.20</wadl-tools.version>
+        <wadl-tools.version>1.0.21</wadl-tools.version>
         <xmlsec.version>1.4.6</xmlsec.version>
         <xerces.version>2.12.1-rax</xerces.version>
         <servlet.version>3.1</servlet.version>


### PR DESCRIPTION
This addresses an issue where extension attributes like rax:roles are
not handled correctly when the attributes are in an element with an
href.
