### PR TITLE
Enable implicit conversions in core tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,6 +28,7 @@
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
                         <arg>-explaintypes</arg>
+                        <arg>-feature</arg>
                     </args>
                     <recompileMode>incremental</recompileMode>
                     <jvmArgs>

--- a/core/src/test/scala/validator-base.scala
+++ b/core/src/test/scala/validator-base.scala
@@ -40,6 +40,7 @@ import org.mockito.Matchers._
 import org.mockito.stubbing.Answer
 import org.mockito.invocation.InvocationOnMock
 
+import scala.language.implicitConversions
 import scala.collection.JavaConversions._
 
 import org.w3c.dom.Document


### PR DESCRIPTION
This removes warnings when compiling core tests.
