### PR TITLE
return empty iterator of string List to avoid NPE

### DIFF
--- a/core/src/main/scala/util/header.scala
+++ b/core/src/main/scala/util/header.scala
@@ -17,7 +17,7 @@ object HeaderUtil {
   def getHeaders (request : HttpServletRequest, name : String) : Enumeration[String] = {
     val headers = request.getHeaders(name)
     headers match {
-      case null => null
+      case null => List[String]().iterator
       case _ => var list : List[String] = List()
         headers.foreach(i => list = list ++ i.split(",").map(j => j.trim))
         list.iterator


### PR DESCRIPTION
If I have a WADL with &lt;param style=header .. &gt; and I have a request using validator-base.scala's mock HttpRequest object without any request header, I would get an NPE:
https://gist.github.com/shintasmith/7018179d79b89ed4bdd0

This PR fixes that NPE.
