### PR TITLE
Issue with method/URI errors with the same prioiry...

### DIFF
--- a/core/src/main/resources/xsl/priority-map.xml
+++ b/core/src/main/resources/xsl/priority-map.xml
@@ -15,8 +15,8 @@
     The actual priority of a step is set in priority.xsl.
 -->
 <priority-map xmlns="http://www.rackspace.com/repose/wadl/checker/priority">
-    <map type="URL_FAIL"      priority="10000" attributeMultipliers="notMatch notTypes" multValue="150"/>
-    <map type="METHOD_FAIL"   priority="20000" attributeMultipliers="notMatch" multValue="150"/>
+    <map type="URL_FAIL"      priority="10000" attributeMultipliers="notMatch notTypes" multValue="50"/>
+    <map type="METHOD_FAIL"   priority="20000" attributeMultipliers="notMatch" multValue="50"/>
     <map type="REQ_TYPE_FAIL" priority="30000"/>
     <map type="CONTENT_FAIL"  priority="40000"/>
     <map type="HEADER"        priority="41000"/>

--- a/core/src/main/resources/xsl/priority.xsl
+++ b/core/src/main/resources/xsl/priority.xsl
@@ -99,7 +99,9 @@
                     <xsl:for-each select="$mults">
                         <xsl:variable name="attr" as="xs:string" select="."/>
                         <xsl:if test="$step[@*[local-name() = $attr]]">
-                            <xsl:value-of select="xs:integer($map/@multValue)"/>
+                            <xsl:for-each select="chkp:matchList($step/@*[local-name() = $attr])">
+                                <xsl:value-of select="xs:integer($map/@multValue)"/>
+                            </xsl:for-each>
                         </xsl:if>
                     </xsl:for-each>
                 </xsl:when>
@@ -110,5 +112,14 @@
         </xsl:variable>
         <xsl:message>[DEBUG] ID=<xsl:value-of select="$step/@id"/> inPriority=<xsl:value-of select="$inPriority"/> offsets=<xsl:value-of select="$offsets"/> priority=<xsl:value-of select="$map/@priority"/> total: <xsl:value-of select="sum(($inPriority,$offsets,$map/@priority))"/></xsl:message>
         <xsl:value-of select="sum(($inPriority,$offsets,$map/@priority))"/>
+    </xsl:function>
+
+    <!--
+        Split matches by ' ' and '|' since this is how matches
+        are normally grouped.
+    -->
+    <xsl:function name="chkp:matchList" as="xs:string*">
+        <xsl:param as="xs:string" name="match"/>
+        <xsl:sequence select="for $t in tokenize($match,' ') return tokenize($t,'\|')"/>
     </xsl:function>
 </xsl:stylesheet>

--- a/core/src/test/scala/validator-wadl-priority-tests.scala
+++ b/core/src/test/scala/validator-wadl-priority-tests.scala
@@ -19,30 +19,30 @@ import org.w3c.dom.Document
 @RunWith(classOf[JUnitRunner])
 class ValidatorWADLPrioritySuite extends BaseValidatorSuite {
 
-  //
-  // validator_XSDElementContentManyPlain allows:
-  //
-  //
-  // POST /a/b with xml support
-  // POST /a/c with xml support
-  //
-  //
-  // The validator checks for wellformness in XML and grammar checks
-  // XSD requests.  It also checks the element type, and it checks
-  // constraints against required plain params.  One path contains
-  // many plain parameters, another does not. We want to make sure
-  // that when things fail, the XSD errors win out, thus adhereing to
-  // the the proper error priorites.
-  //
-  // The validator is used in the following tests.
-  //
-
-  val configs = Map[String, Config]("Config without ops " -> TestConfig(false, false, true, true, true, 2, true, false, false, "SaxonHE", false),
+  val configs1 = Map[String, Config]("Config without ops " -> TestConfig(false, false, true, true, true, 2, true, false, false, "SaxonHE", false),
                                     "Config with removeDups" -> TestConfig(true, false, true, true, true, 2, true, false, false, "SaxonHE", false),
                                     "Config with joinXPathChecks" -> TestConfig(false, false, true, true, true, 2, true, false, false, "SaxonHE", true),
                                     "Config with removeDups and joinXPathChecks" -> TestConfig(true, false, true, true, true, 2, true, false, false, "SaxonHE", true))
 
-  for ((description, config) <- configs) {
+  for ((description, config) <- configs1) {
+
+    //
+    // validator_XSDElementContentManyPlain allows:
+    //
+    //
+    // POST /a/b with xml support
+    // POST /a/c with xml support
+    //
+    //
+    // The validator checks for wellformness in XML and grammar checks
+    // XSD requests.  It also checks the element type, and it checks
+    // constraints against required plain params.  One path contains
+    // many plain parameters, another does not. We want to make sure
+    // that when things fail, the XSD errors win out, thus adhereing to
+    // the the proper error priorites.
+    //
+    // The validator is used in the following tests.
+    //
 
     val validator_XSDElementContentManyPlain = Validator((localWADLURI,
       <application xmlns="http://wadl.dev.java.net/2009/02"
@@ -81,4 +81,105 @@ class ValidatorWADLPrioritySuite extends BaseValidatorSuite {
                          List("declaration","'bad'"))
     }
   }
+
+  val configs2 = Map[String, Config]("Config without ops " -> TestConfig(false, false, true, true, true, 2, true, false, false, "SaxonHE", false,
+                                                                         false, false, false, false, false, true, false, true),
+                                     "Config with removeDups" -> TestConfig(true, false, true, true, true, 2, true, false, false, "SaxonHE", false,
+                                                                           false, false, false, false, false, true, false, true))
+
+  for ((description, config) <- configs2) {
+
+    // validator_getRoles allows:
+    //
+    // GET    /a for roles a:observer and a:admin
+    // POST   /a for role a:admin
+    // DELETE /a for role a:admin
+    //
+    // This raxrole-mask validiator is testing to make sure prioritis
+    // are properly set for method errors.  If the role is a:observer
+    // on a PUT the allow header should be GET. If the role is a:admin
+    // in combination with any other role (including a:observer) then
+    // the allow header should be DELETE, GET, and POST.
+    //
+
+    val validator_getRoles = Validator((localWADLURI,
+     <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api">
+      <resources base="http://localhost:${targetPort}">
+        <resource path="/a">
+            <method name="GET" rax:roles="a:observer a:admin"/>
+            <method name="POST" rax:roles="a:admin"/>
+            <method name="DELETE" rax:roles="a:admin"/>
+        </resource>
+      </resources>
+    </application>)
+    , config)
+
+    test ("GET on /a should succeed with role a:observer and a:admin "+description) {
+      validator_getRoles.validate(request("GET", "/a", "application/xml", "<foo />", false, Map("X-ROLES" ->List("a:observer", "a:admin"))), response, chain)
+    }
+
+    test ("PUT on /a with role of a:admin should fail with 405 and Allow = DELETE, GET, POST "+ description) {
+      assertResultFailed(validator_getRoles.validate(request("PUT", "/a", "application/xml", "<foo />", false, Map("X-ROLES"->List("a:admin"))),
+                                                     response, chain), 405, Map("Allow"->"DELETE, GET, POST"))
+    }
+
+    test ("PUT on /a with role of a:observer should fail with 405 and Allow = GET "+ description) {
+      assertResultFailed(validator_getRoles.validate(request("PUT", "/a", "application/xml", "<foo />", false, Map("X-ROLES"->List("a:observer"))),
+                                                     response, chain), 405, Map("Allow"->"GET"))
+    }
+
+    test ("PUT on /a with role of a:observer and a:admin should fail with 405 and Allow = DELETE, GET, POST "+ description) {
+      assertResultFailed(validator_getRoles.validate(request("PUT", "/a", "application/xml", "<foo />", false, Map("X-ROLES"->List("a:observer", "a:admin"))),
+                                                     response, chain), 405, Map("Allow"->"DELETE, GET, POST"))
+    }
+
+    test ("PUT on /a with role of a:admin and a:observer  should fail with 405 and Allow = DELETE, GET, POST "+ description) {
+      assertResultFailed(validator_getRoles.validate(request("PUT", "/a", "application/xml", "<foo />", false, Map("X-ROLES"->List("a:admin", "a:observer"))),
+                                                     response, chain), 405, Map("Allow"->"DELETE, GET, POST"))
+    }
+  }
+
+  for ((description, config) <- configs2) {
+
+    //
+    // validator_getRoles2 is like validatior_getRoles above but
+    // defines methods in a slightly different order.
+    //
+    val validator_getRoles2 = Validator((localWADLURI,
+     <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api">
+      <resources base="http://localhost:${targetPort}">
+        <resource path="/a">
+            <method name="POST" rax:roles="a:admin"/>
+            <method name="DELETE" rax:roles="a:admin"/>
+            <method name="GET" rax:roles="a:observer a:admin"/>
+        </resource>
+      </resources>
+    </application>)
+    , config)
+
+    test ("GET on /a in roles 2, should succeed with role a:observer and a:admin "+description) {
+      validator_getRoles2.validate(request("GET", "/a", "application/xml", "<foo />", false, Map("X-ROLES" ->List("a:observer", "a:admin"))), response, chain)
+    }
+
+    test ("PUT on /a in roles 2, with role of a:admin should fail with 405 and Allow = DELETE, GET, POST "+ description) {
+      assertResultFailed(validator_getRoles2.validate(request("PUT", "/a", "application/xml", "<foo />", false, Map("X-ROLES"->List("a:admin"))),
+                                                     response, chain), 405, Map("Allow"->"DELETE, GET, POST"))
+    }
+
+    test ("PUT on /a in roles 2, with role of a:observer should fail with 405 and Allow = GET "+ description) {
+      assertResultFailed(validator_getRoles2.validate(request("PUT", "/a", "application/xml", "<foo />", false, Map("X-ROLES"->List("a:observer"))),
+                                                     response, chain), 405, Map("Allow"->"GET"))
+    }
+
+    test ("PUT on /a in roles 2, with role of a:observer and a:admin should fail with 405 and Allow = DELETE, GET, POST "+ description) {
+      assertResultFailed(validator_getRoles2.validate(request("PUT", "/a", "application/xml", "<foo />", false, Map("X-ROLES"->List("a:observer", "a:admin"))),
+                                                     response, chain), 405, Map("Allow"->"DELETE, GET, POST"))
+    }
+
+    test ("PUT on /a in roles 2, with role of a:admin and a:observer  should fail with 405 and Allow = DELETE, GET, POST "+ description) {
+      assertResultFailed(validator_getRoles2.validate(request("PUT", "/a", "application/xml", "<foo />", false, Map("X-ROLES"->List("a:admin", "a:observer"))),
+                                                     response, chain), 405, Map("Allow"->"DELETE, GET, POST"))
+    }
+  }
+
 }


### PR DESCRIPTION
See the following example:

``` xml
<application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api">
    <resources base="http://localhost:${targetPort}">
        <resource path="/a">
            <method name="GET" rax:roles="a:observer a:admin"/>
            <method name="POST" rax:roles="a:admin"/>
            <method name="DELETE" rax:roles="a:admin"/>
        </resource>
    </resources>
</application>
```

![test](https://cloud.githubusercontent.com/assets/348314/3109570/ecd80f10-e69a-11e3-9e6a-fafaabd4be89.png)

Notice that the method fail on a both `!(GET)` and `!(DELETE|GET|POST)` have the same priority (20153).  That means it's a crap-shoot which error will hit. The error with the most misses should have a higher priority.
