### PR TITLE
Fixed bug where an improperly encoded URI will cause a 500.

### DIFF
--- a/core/src/test/scala/validator-wadl-tests.scala
+++ b/core/src/test/scala/validator-wadl-tests.scala
@@ -118,6 +118,14 @@ class ValidatorWADLSuite extends BaseValidatorSuite {
     assertResultFailed(validator_AB.validate(request("GET","/index.html"),response,chain), 404)
   }
 
+  test ("GET on /v1.0/ZZZZZZZZZ/foo/bar/c:\\boot.ini should fail on validator_AB") {
+    assertResultFailed(validator_AB.validate(request("GET","/v1.0/ZZZZZZZZZ/foo/bar/c:\\boot.ini"),response,chain), 404)
+  }
+
+  test ("GET on /v1.0/ZZZZZZZZZ/foo/bar/c:%5Cboot.ini should fail on validator_AB") {
+    assertResultFailed(validator_AB.validate(request("GET","/v1.0/ZZZZZZZZZ/foo/bar/c:%5Cboot.ini"),response,chain), 404)
+  }
+
 
   //
   // validator_ABAC allows a GET on /a/b and /a/c. The validator is used in the

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <scala.dep.version>2.10</scala.dep.version>
         <saxon-ee.version>9.4.0.6</saxon-ee.version>
         <scala.test.version>2.0</scala.test.version>
+        <scala.uri.version>0.4.2</scala.uri.version>
         <junit.version>4.10</junit.version>
         <wadl-tools.version>1.0.25</wadl-tools.version>
         <xmlsec.version>1.4.6</xmlsec.version>
@@ -106,6 +107,11 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.10</artifactId>
             <version>${scala.test.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.netaporter</groupId>
+            <artifactId>scala-uri_2.10</artifactId>
+            <version>${scala.uri.version}</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.cloud.api</groupId>


### PR DESCRIPTION
The strategy is to handle the URI syntax error, by attempting to
encode the URL. If that fails then we return a 400 to the client.
