### PR TITLE
Reworked malformed URI fix so that the user always gets a 400.

### DIFF
--- a/core/src/main/scala/step/start-end.scala
+++ b/core/src/main/scala/step/start-end.scala
@@ -35,7 +35,22 @@ class Start(id : String, label : String, next : Array[Step]) extends ConnectedSt
                          resp : CheckerServletResponse,
                          chain : FilterChain,
                          uriLevel : Int ) : Int = uriLevel
-  override val mismatchMessage : String = "Bad Start Node?"
+
+  override def check(req : CheckerServletRequest,
+                     resp : CheckerServletResponse,
+                     chain : FilterChain,
+                     uriLevel : Int) : Option[Result] = {
+    //
+    // If we have a malformed URI, then we can't even start the
+    // machine, so return a 400 result.
+    //
+    req.parsedRequestURI match {
+      case (_, Some(e)) => Some(new ErrorResult(e.getMessage(), 400, uriLevel, id, Long.MaxValue))
+      case _ => super.check(req, resp, chain, uriLevel)
+    }
+  }
+
+  override val mismatchMessage : String = "Bad Request?"
 }
 
 //

--- a/core/src/main/scala/validator.scala
+++ b/core/src/main/scala/validator.scala
@@ -36,8 +36,6 @@ import java.io.ByteArrayOutputStream
 import java.io.Reader
 import java.io.StringWriter
 
-import java.net.URISyntaxException
-
 import scala.xml._
 
 import com.rackspace.com.papi.components.checker.wadl.StepBuilder
@@ -45,7 +43,6 @@ import com.rackspace.com.papi.components.checker.wadl.WADLDotBuilder
 
 import com.rackspace.com.papi.components.checker.step.Step
 import com.rackspace.com.papi.components.checker.step.Result
-import com.rackspace.com.papi.components.checker.step.ErrorResult
 
 import com.rackspace.com.papi.components.checker.handler.ResultHandler
 
@@ -62,8 +59,6 @@ import com.yammer.metrics.scala.Meter
 import com.yammer.metrics.scala.Timer
 import com.yammer.metrics.scala.MetricsGroup
 import com.yammer.metrics.util.PercentGauge
-
-import com.typesafe.scalalogging.slf4j.LazyLogging
 
 class ValidatorException(msg : String, cause : Throwable) extends Throwable(msg, cause) {}
 
@@ -128,8 +123,7 @@ trait ValidatorMBean {
   def getDotSHA1 : String
 }
 
-class Validator private (private val _name : String, val startStep : Step, val config : Config, val checker : Option[Document] = None) extends Instrumented 
-     with ValidatorMBean with LazyLogging {
+class Validator private (private val _name : String, val startStep : Step, val config : Config, val checker : Option[Document] = None) extends Instrumented  with ValidatorMBean {
 
   val name = _name match {
     case null => Integer.toHexString(hashCode())
@@ -223,10 +217,6 @@ class Validator private (private val _name : String, val startStep : Step, val c
       if (!result.valid) failMeter.mark()
       result
     } catch {
-      case u : URISyntaxException => val uri = req.getRequestURI()
-                                     logger.error(s"Could not parse URI {$uri} even after encoding it. Giving client 400. Handlers will be bypassed.", u)
-                                     res.sendError (400, u.getMessage())
-                                     new ErrorResult(u.getMessage(), 400, 0, "0", 1000000)
       case v : ValidatorException => throw v
       case e : Exception  => throw new ValidatorException("Error while validating request", e)
     } finally {

--- a/core/src/test/scala/validator-wadl-tests.scala
+++ b/core/src/test/scala/validator-wadl-tests.scala
@@ -119,7 +119,7 @@ class ValidatorWADLSuite extends BaseValidatorSuite {
   }
 
   test ("GET on /v1.0/ZZZZZZZZZ/foo/bar/c:\\boot.ini should fail on validator_AB") {
-    assertResultFailed(validator_AB.validate(request("GET","/v1.0/ZZZZZZZZZ/foo/bar/c:\\boot.ini"),response,chain), 404)
+    assertResultFailed(validator_AB.validate(request("GET","/v1.0/ZZZZZZZZZ/foo/bar/c:\\boot.ini"),response,chain), 400)
   }
 
   test ("GET on /v1.0/ZZZZZZZZZ/foo/bar/c:%5Cboot.ini should fail on validator_AB") {


### PR DESCRIPTION
This is a rework of #216 such that we always return a 400 in a malformed URL, we don't attempt a cleanup.
