### PR TITLE
Ensure generated Step IDs are always valid...

### DIFF
--- a/core/src/main/resources/xsl/raxRolesMask.xsl
+++ b/core/src/main/resources/xsl/raxRolesMask.xsl
@@ -238,6 +238,6 @@
     <xsl:function as="xs:string" name="rol:id">
         <xsl:param name="oldId" as="xs:string"/>
         <xsl:param name="role" as="xs:string"/>
-        <xsl:value-of select="replace(concat($oldId,'_',$role),':','_')"/>
+        <xsl:value-of select="chk:string-to-id(replace(concat($oldId,'_',$role),':','_'))"/>
     </xsl:function>
 </xsl:stylesheet>

--- a/core/src/main/resources/xsl/util/funs.xsl
+++ b/core/src/main/resources/xsl/util/funs.xsl
@@ -56,5 +56,67 @@
         <xsl:sequence select="tokenize($step/@next, ' ')"/>
     </xsl:function>
 
+    <!--
+        Given a string, convert it to a valid ID.
+    -->
+    <xsl:function as="xs:string" name="chk:string-to-id">
+        <xsl:param name="in" as="xs:string"/>
+        <xsl:choose>
+            <xsl:when test="chk:is-valid-id($in)" >
+                <!-- If the value is castable as an ID don't mess with it -->
+                <xsl:sequence select="$in"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="concat('_',chk:string-to-hex($in))"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!--
+       Returns true if the string is a valid ID
+    -->
+    <xsl:function as="xs:boolean" name="chk:is-valid-id">
+        <xsl:param name="in" as="xs:string"/>
+        <xsl:choose>
+            <xsl:when test="matches($in,'^[\i-[:]][\c-[:]]*$')" use-when="system-property('xsl:is-schema-aware') eq 'no'">
+                <xsl:sequence select="true()"/>
+            </xsl:when>
+            <xsl:when test="$in castable as xs:ID" use-when="system-property('xsl:is-schema-aware') eq 'yes'">
+                <xsl:sequence select="true()"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="false()"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!--
+       Hexadecimal encode a string.
+    -->
+    <xsl:function as="xs:string" name="chk:string-to-hex">
+        <xsl:param name="in" as="xs:string"/>
+        <xsl:sequence select="string-join(for $i in string-to-codepoints($in)
+                                          return chk:int-to-hex($i), '')"/>
+    </xsl:function>
+
+    <!--
+      Converts an integer to a hex string.
+
+      This clever function was borrowed from Yves Forkl and Michael
+      Kay:
+      http://www.oxygenxml.com/archives/xsl-list/200902/msg00215.html
+    -->
+    <xsl:function name="chk:int-to-hex" as="xs:string">
+        <xsl:param name="in" as="xs:integer"/>
+        <xsl:sequence
+        select="if ($in eq 0)
+                then '0'
+                else
+                concat(if ($in gt 16)
+                then chk:int-to-hex($in idiv 16)
+                else '',
+                substring('0123456789ABCDEF',
+                ($in mod 16) + 1, 1))"/>
+    </xsl:function>
 
 </xsl:stylesheet>

--- a/core/src/test/scala/validator-wadl-rax-extension-tests.scala
+++ b/core/src/test/scala/validator-wadl-rax-extension-tests.scala
@@ -973,6 +973,107 @@ class GivenAWadlWithNestedResourcesAndMethodReferences extends FlatSpec with Rax
   }
 }
 
+
+@RunWith(classOf[JUnitRunner])
+class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames extends FlatSpec with RaxRolesBehaviors {
+
+  val configs = Map[String, Config]("Config With Roles Enabled" -> configWithRolesEnabled,
+    "Config With Roles Enabled and Messsage Extensions Disabled" -> configWithRolesEnabledMessageExtDisabled,
+    "Config With Roles Enabled and Duplications Removed" -> configWithRolesEnabledDupsRemoved,
+    "Config With Roles Enabled and Header Checks Disabled" -> configWithRolesEnabledHeaderCheckDisabled)
+
+  for ((description, configuration) <- configs) {
+
+    val validator = Validator((localWADLURI,
+      <application xmlns="http://wadl.dev.java.net/2009/02"
+                   xmlns:rax="http://docs.rackspace.com/api"
+                   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:tst="test://schema/a">
+        <grammars>
+           <schema elementFormDefault="qualified"
+                   attributeFormDefault="unqualified"
+                   xmlns="http://www.w3.org/2001/XMLSchema"
+                   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   targetNamespace="test://schema/a">
+              <simpleType name="yesno">
+                 <restriction base="xsd:string">
+                     <enumeration value="yes"/>
+                     <enumeration value="no"/>
+                 </restriction>
+             </simpleType>
+           </schema>
+        </grammars>
+        <resources base="https://test.api.openstack.com">
+          <resource path="/a" rax:roles="a:admin-foo">
+            <method href="#putOnA" rax:roles="a:observer%"/>
+            <resource path="/b" rax:roles="b:creator">
+              <method href="#postOnB"/>
+              <method href="#putOnB"/>
+              <method href="#deleteOnB" rax:roles="AR-Payments-Billing-Support b:admin"/>
+            </resource>
+            <resource path="{yn}" rax:roles="a:admin-foo">
+              <param name="yn" style="template" type="tst:yesno"/>
+              <method href="#yn"/>
+            </resource>
+          </resource>
+        </resources>
+        <method id="putOnA" name="PUT"/>
+        <method id="postOnB" name="POST"/>
+        <method id="putOnB" name="PUT" rax:roles="AR-Payments-Billing-Support"/>
+        <method id="deleteOnB" name="DELETE" rax:roles="b:foo"/>
+        <method id="yn" name="GET" />
+      </application>)
+      , configuration)
+
+    // PUT /a has resource level a:admin-foo, method level a:observer%
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer%"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer%", "a:admin-foo"), description)
+    it should behave like accessIsForbidden(validator, "PUT", "/a", List("AR-Payments-Billing-Support"), description)
+    it should behave like accessIsForbiddenWhenNoXRoles(validator, "PUT", "/a", description)
+
+    // DELETE /a has resource level a:admin-foo, method is not defined
+    it should behave like methodNotAllowed(validator, "DELETE", "/a", List("a:admin-foo"), description)
+    it should behave like methodNotAllowed(validator, "DELETE", "/a", List(), description)
+
+    // POST /a/b has parent resource level a:admin-foo, resource level b:creator
+    it should behave like accessIsAllowed(validator, "POST", "/a/b", List("a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "POST", "/a/b", List("b:creator"), description)
+    it should behave like accessIsForbidden(validator, "POST", "/a/b", List("a:observer%"), description)
+    it should behave like accessIsForbiddenWhenNoXRoles(validator, "POST", "/a/b", description)
+
+    // PUT /a/b has parent resource level a:admin-foo, resource level b:creator, method level AR-Payments-Billing-Support
+    it should behave like accessIsAllowed(validator, "PUT", "/a/b", List("a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/b", List("b:creator"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/b", List("AR-Payments-Billing-Support", "a:foo"), description)
+    it should behave like accessIsForbidden(validator, "PUT", "/a/b", List("a:creator"), description)
+    it should behave like accessIsForbidden(validator, "PUT", "/a/b", List(), description)
+    it should behave like accessIsForbidden(validator, "PUT", "/a/b", List("observer"), description)
+    it should behave like accessIsForbiddenWhenNoXRoles(validator, "PUT", "/a/b", description)
+
+    // DELETE /a/b has parent resource level a:admin-foo, resource level b:creator, method level b:admin, AR-Payments-Billing-Support
+    it should behave like accessIsAllowed(validator, "DELETE", "/a/b", List("a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "DELETE", "/a/b", List("b:creator"), description)
+    it should behave like accessIsAllowed(validator, "DELETE", "/a/b", List("AR-Payments-Billing-Support", "a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "DELETE", "/a/b", List("b:admin"), description)
+    it should behave like accessIsForbidden(validator, "DELETE", "/a/b", List(), description)
+    it should behave like accessIsForbidden(validator, "DELETE", "/a/b", List("a:observer%"), description)
+    it should behave like accessIsForbidden(validator, "DELETE", "/a/b", List("b:foo"), description)
+    it should behave like accessIsForbiddenWhenNoXRoles(validator, "DELETE", "/a/b", description)
+
+    // GET on /a/yes, /a/no, /a/foo
+    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo"), description)
+    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo"), description, List("'b'","yes","no"))
+    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer%"), description)
+    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo", "a:observer%"), description)
+    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer%"), description, List("'b'","yes","no"))
+    it should behave like accessIsForbidden(validator, "GET", "/a/yes", List("a:observer%"), description)
+    it should behave like accessIsForbidden(validator, "GET", "/a/no", List("a:observer%"), description)
+    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:observer%"), description, List("'b'","yes","no"))
+  }
+}
+
 @RunWith(classOf[JUnitRunner])
 class GivenAWadlWithNestedResourcesAndMethodReferencesMasked extends FlatSpec with RaxRolesBehaviors {
 
@@ -1076,3 +1177,105 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesMasked extends FlatSpec wi
   }
 }
 
+@RunWith(classOf[JUnitRunner])
+class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNamesMasked extends FlatSpec with RaxRolesBehaviors {
+
+  val configs = Map[String, Config]("Config With Roles Enabled" -> configWithRolesMaskedEnabled,
+    "Config With Roles Enabled and Messsage Extensions Disabled" -> configWithRolesMaskedEnabledMessageExtDisabled,
+    "Config With Roles Enabled and Duplications Removed" -> configWithRolesMaskedEnabledDupsRemoved,
+    "Config With Roles Enabled and Header Checks Disabled" -> configWithRolesMaskedEnabledHeaderCheckDisabled)
+
+  for ((description, configuration) <- configs) {
+
+    val validator = Validator((localWADLURI,
+      <application xmlns="http://wadl.dev.java.net/2009/02"
+                   xmlns:rax="http://docs.rackspace.com/api"
+                   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:tst="test://schema/a">
+        <grammars>
+           <schema elementFormDefault="qualified"
+                   attributeFormDefault="unqualified"
+                   xmlns="http://www.w3.org/2001/XMLSchema"
+                   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   targetNamespace="test://schema/a">
+              <simpleType name="yesno">
+                 <restriction base="xsd:string">
+                     <enumeration value="yes"/>
+                     <enumeration value="no"/>
+                 </restriction>
+             </simpleType>
+           </schema>
+        </grammars>
+        <resources base="https://test.api.openstack.com">
+          <resource path="/a" rax:roles="a:admin-foo">
+            <method href="#putOnA" rax:roles="a:observer%"/>
+            <resource path="/b" rax:roles="b:creator">
+              <method href="#postOnB"/>
+              <method href="#putOnB"/>
+              <method href="#deleteOnB" rax:roles="AR-Payments-Billing-Support b:admin"/>
+            </resource>
+            <resource path="{yn}" rax:roles="a:admin-foo">
+              <param name="yn" style="template" type="tst:yesno"/>
+              <method href="#yn"/>
+            </resource>
+          </resource>
+        </resources>
+        <method id="putOnA" name="PUT"/>
+        <method id="postOnB" name="POST"/>
+        <method id="putOnB" name="PUT" rax:roles="AR-Payments-Billing-Support"/>
+        <method id="deleteOnB" name="DELETE" rax:roles="b:foo"/>
+        <method id="yn" name="GET" />
+      </application>)
+      , configuration)
+
+    // PUT /a has resource level a:admin-foo, method level a:observer%
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer%"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer%", "a:admin-foo"), description)
+    it should behave like methodNotAllowed(validator, "PUT", "/a", List("AR-Payments-Billing-Support"), description)
+    it should behave like resourceNotFoundWhenNoXRoles(validator, "PUT", "/a", description)
+
+    // DELETE /a has resource level a:admin-foo, method is not defined
+    it should behave like methodNotAllowed(validator, "DELETE", "/a", List("a:admin-foo"), description, List("does not match","'PUT'"))
+    it should behave like methodNotAllowed(validator, "DELETE", "/a", List("a:observer%"), description, List("does not match","'PUT'"))
+    it should behave like resourceNotFound(validator, "DELETE", "/a", List(), description)
+
+    // POST /a/b has parent resource level a:admin-foo, resource level b:creator
+    it should behave like accessIsAllowed(validator, "POST", "/a/b", List("a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "POST", "/a/b", List("b:creator"), description)
+    it should behave like resourceNotFound(validator, "POST", "/a/b", List("a:observer%"), description)
+    it should behave like methodNotAllowed(validator, "POST", "/a/b", List("AR-Payments-Billing-Support"), description, List("does not match","'DELETE|PUT'"))
+    it should behave like resourceNotFoundWhenNoXRoles(validator, "POST", "/a/b", description)
+
+    // PUT /a/b has parent resource level a:admin-foo, resource level b:creator, method level AR-Payments-Billing-Support
+    it should behave like accessIsAllowed(validator, "PUT", "/a/b", List("a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/b", List("b:creator"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/b", List("AR-Payments-Billing-Support", "a:foo"), description)
+    it should behave like resourceNotFound(validator, "PUT", "/a/b", List("a:creator"), description)
+    it should behave like resourceNotFound(validator, "PUT", "/a/b", List(), description)
+    it should behave like resourceNotFound(validator, "PUT", "/a/b", List("observer"), description)
+    it should behave like methodNotAllowed(validator, "PUT", "/a/b", List("b:admin"), description, List("does not match","'DELETE'"))
+    it should behave like resourceNotFoundWhenNoXRoles(validator, "PUT", "/a/b", description)
+
+    // DELETE /a/b has parent resource level a:admin-foo, resource level b:creator, method level b:admin, AR-Payments-Billing-Support
+    it should behave like accessIsAllowed(validator, "DELETE", "/a/b", List("a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "DELETE", "/a/b", List("b:creator"), description)
+    it should behave like accessIsAllowed(validator, "DELETE", "/a/b", List("AR-Payments-Billing-Support", "a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "DELETE", "/a/b", List("b:admin"), description)
+    it should behave like resourceNotFound(validator, "DELETE", "/a/b", List(), description)
+    it should behave like resourceNotFound(validator, "DELETE", "/a/b", List("a:observer%"), description)
+    it should behave like resourceNotFound(validator, "DELETE", "/a/b", List("b:foo"), description)
+    it should behave like resourceNotFoundWhenNoXRoles(validator, "DELETE", "/a/b", description)
+
+    // GET on /a/yes, /a/no, /a/foo
+    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo"), description)
+    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo"), description, List("'b'","yes","no"))
+    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer%"), description)
+    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo", "a:observer%"), description)
+    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer%"), description, List("'b'","yes","no"))
+    it should behave like resourceNotFound(validator, "GET", "/a/yes", List("a:observer%"), description, List("{yes}"))
+    it should behave like resourceNotFound(validator, "GET", "/a/no", List("a:observer%"), description, List("{no}"))
+    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:observer%"), description, List("{foo}"))
+  }
+}


### PR DESCRIPTION
It is possible to generate an invalid ID for a header step when rax:roles Mask is enabled, because the role name is used to construct the id.

The problem is in this function:
https://github.com/rackerlabs/api-checker/blob/api-checker-1.0.17/core/src/main/resources/xsl/raxRolesMask.xsl#L224
