### PR TITLE
Bumped http-delegation library version to stay synced with Repose

### DIFF
--- a/core/src/main/scala/handler/DelegationHandler.scala
+++ b/core/src/main/scala/handler/DelegationHandler.scala
@@ -20,10 +20,10 @@ import javax.servlet.FilterChain
 import com.rackspace.com.papi.components.checker.Validator
 import com.rackspace.com.papi.components.checker.servlet.{CheckerServletRequest, CheckerServletResponse}
 import com.rackspace.com.papi.components.checker.step.{ErrorResult, Result}
-import com.rackspace.httpdelegation.impl.HttpDelegationManagerImpl.buildDelegationHeaders
+import com.rackspace.httpdelegation.HttpDelegationManager
 import org.w3c.dom.Document
 
-class DelegationHandler(delegationQuality: Double) extends ResultHandler {
+class DelegationHandler(delegationQuality: Double) extends ResultHandler with HttpDelegationManager {
 
   def init (validator : Validator, checker : Option[Document]) : Unit = {}
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <scala-logging.version>2.1.2</scala-logging.version>
         <slf4j.version>1.7.7</slf4j.version>
         <log4j.version>2.1</log4j.version>
-        <http.delegation.version>2.0.0</http.delegation.version>
+        <http.delegation.version>4.0.0</http.delegation.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
While it shouldn't matter, this may provide additional comfort to both projects. Additionally, it should not break any api-checker features or tests.
