### PR TITLE
this commit fixes issue #227

### DIFF
--- a/core/src/main/resources/xsd/checker.xsd
+++ b/core/src/main/resources/xsd/checker.xsd
@@ -147,7 +147,7 @@
         </annotation>
         <complexContent>
             <extension base="chk:ConnectedStep">
-                <attribute name="priority" type="xsd:unsignedInt" use="optional" default="1"/>
+                <attribute name="priority" type="xsd:unsignedInt" use="optional" default="0"/>
             </extension>
         </complexContent>
     </complexType>
@@ -432,7 +432,7 @@
         </annotation>
         <complexContent>
             <extension base="chk:Step">
-                <attribute name="priority" type="xsd:unsignedInt" use="optional" default="1"/>
+                <attribute name="priority" type="xsd:unsignedInt" use="optional" default="0"/>
             </extension>
         </complexContent>
     </complexType>

--- a/core/src/main/resources/xsl/priority.xsl
+++ b/core/src/main/resources/xsl/priority.xsl
@@ -106,26 +106,33 @@
         <xsl:if test="not($map)">
             <xsl:message  terminate="yes">[ERROR] Cannot find priority information for step type <xsl:value-of select="$step/@type"/> that's very strange</xsl:message>
         </xsl:if>
-        <xsl:variable name="offsets" as="xs:integer*">
-            <xsl:choose>
-                <xsl:when test="$map/@attributeMultipliers and $map/@multValue">
-                    <xsl:variable name="mults" as="xs:string*" select="tokenize($map/@attributeMultipliers,' ')"/>
-                    <xsl:for-each select="$mults">
-                        <xsl:variable name="attr" as="xs:string" select="."/>
-                        <xsl:if test="$step[@*[local-name() = $attr]]">
-                            <xsl:for-each select="chkp:matchList($step/@*[local-name() = $attr])">
-                                <xsl:value-of select="xs:integer($map/@multValue)"/>
+        <xsl:choose>
+            <xsl:when test="$step/@priority and not($step/@priority = 0)">
+                <xsl:value-of select="$step/@priority"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:variable name="offsets" as="xs:integer*">
+                    <xsl:choose>
+                        <xsl:when test="$map/@attributeMultipliers and $map/@multValue">
+                            <xsl:variable name="mults" as="xs:string*" select="tokenize($map/@attributeMultipliers,' ')"/>
+                            <xsl:for-each select="$mults">
+                                <xsl:variable name="attr" as="xs:string" select="."/>
+                                <xsl:if test="$step[@*[local-name() = $attr]]">
+                                    <xsl:for-each select="chkp:matchList($step/@*[local-name() = $attr])">
+                                        <xsl:value-of select="xs:integer($map/@multValue)"/>
+                                    </xsl:for-each>
+                                </xsl:if>
                             </xsl:for-each>
-                        </xsl:if>
-                    </xsl:for-each>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="0"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-        <xsl:message>[DEBUG] ID=<xsl:value-of select="$step/@id"/> inPriority=<xsl:value-of select="$inPriority"/> offsets=<xsl:value-of select="$offsets"/> priority=<xsl:value-of select="$map/@priority"/> total: <xsl:value-of select="sum(($inPriority,$offsets,$map/@priority))"/></xsl:message>
-        <xsl:value-of select="sum(($inPriority,$offsets,$map/@priority))"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="0"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <xsl:message>[DEBUG] ID=<xsl:value-of select="$step/@id"/> inPriority=<xsl:value-of select="$inPriority"/> offsets=<xsl:value-of select="$offsets"/> priority=<xsl:value-of select="$map/@priority"/> total: <xsl:value-of select="sum(($inPriority,$offsets,$map/@priority))"/></xsl:message>
+                <xsl:value-of select="sum(($inPriority,$offsets,$map/@priority))"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:function>
 
     <!--


### PR DESCRIPTION
Changes include: 
Updating checker.xsd to a lower priority to that it can be used to find if a priority was set.
If a priority was set to use it by default otherwise calculate.
Any place that we copy a path for rax roles when masking, we also take into account that headers are a good state just like url and method.
No changes were made to the header tests because they tested all the conditions correctly. It was just masking that had problems.  Tests were added for the different ways you could use a header with masking though.
