### PR TITLE
Explicitly using the class's classloader

### DIFF
--- a/core/src/main/scala/step/step-handler.scala
+++ b/core/src/main/scala/step/step-handler.scala
@@ -35,6 +35,7 @@ import javax.xml.validation.SchemaFactory
 import javax.xml.namespace.NamespaceContext
 import javax.xml.namespace.QName
 
+import com.saxonica.config.EnterpriseTransformerFactory
 import org.xml.sax.ContentHandler
 import org.xml.sax.Locator
 import org.xml.sax.Attributes
@@ -146,7 +147,22 @@ class StepHandler(var contentHandler : ContentHandler, val config : Config) exte
 
     config.xslEngine match  {
 
-      case "SaxonEE" => TransformerFactory.newInstance("com.saxonica.config.EnterpriseTransformerFactory", this.getClass.getClassLoader)
+      case "SaxonEE" => {
+        val factory = TransformerFactory.newInstance("com.saxonica.config.EnterpriseTransformerFactory", this.getClass.getClassLoader)
+       /*
+       * I found this through here: http://sourceforge.net/p/saxon/mailman/message/29737564/
+       * A bit of deduction and stuff let me to assume that all dynamic loading is done with the DynamicLoader
+       * object. The only way to get ahold of that is to typecast the TransformerFactory to the actual class, and
+       * then get the DynamicLoader out of it, and set it's classloader to the one where the saxonica classes
+       * are located.
+       */
+        //Now that we have a Saxon EE transformer factory, we need to configure it...
+        //We have to do casting to get the configuration object, to configure the DynamicLoader for our classloader
+        //This is only needed for saxon EE, because it generates bytecode.
+        val cast = factory.asInstanceOf[EnterpriseTransformerFactory]
+        cast.getConfiguration.getDynamicLoader.setClassLoader(this.getClass.getClassLoader)
+        factory
+      }
       case "SaxonHE" => TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", this.getClass.getClassLoader)
       // TODO:  if the wadl every explicitly calls out for  XSLT2 , we need to give them a SAXON transformer,
       // Xalan doesn't support 2

--- a/core/src/main/scala/step/step-handler.scala
+++ b/core/src/main/scala/step/step-handler.scala
@@ -123,7 +123,7 @@ class StepHandler(var contentHandler : ContentHandler, val config : Config) exte
       //  Enable CTA full XPath2.0 checking in XSD 1.1
       //
       case "Xerces"  => {
-        sf = SchemaFactory.newInstance("http://www.w3.org/XML/XMLSchema/v1.1")
+        sf = SchemaFactory.newInstance("http://www.w3.org/XML/XMLSchema/v1.1", "org.apache.xerces.jaxp.validation.XMLSchema11Factory", this.getClass.getClassLoader)
         sf.setFeature ("http://apache.org/xml/features/validation/cta-full-xpath-checking", true)
       }
 
@@ -146,11 +146,11 @@ class StepHandler(var contentHandler : ContentHandler, val config : Config) exte
 
     config.xslEngine match  {
 
-      case "SaxonEE" => TransformerFactory.newInstance("com.saxonica.config.EnterpriseTransformerFactory", null)
-      case "SaxonHE" => TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null)
+      case "SaxonEE" => TransformerFactory.newInstance("com.saxonica.config.EnterpriseTransformerFactory", this.getClass.getClassLoader)
+      case "SaxonHE" => TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", this.getClass.getClassLoader)
       // TODO:  if the wadl every explicitly calls out for  XSLT2 , we need to give them a SAXON transformer,
       // Xalan doesn't support 2
-      case _ =>  TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null)
+      case _ =>  TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", this.getClass.getClassLoader)
     }
   }
 
@@ -162,8 +162,8 @@ class StepHandler(var contentHandler : ContentHandler, val config : Config) exte
   private[this] val transformFactoryXSL1 : TransformerFactory = {
     config.xslEngine match  {
 
-      case "Xalan" => TransformerFactory.newInstance("org.apache.xalan.processor.TransformerFactoryImpl", null)
-      case "XalanC" => TransformerFactory.newInstance("org.apache.xalan.xsltc.trax.TransformerFactoryImpl", null)
+      case "Xalan" => TransformerFactory.newInstance("org.apache.xalan.processor.TransformerFactoryImpl", this.getClass.getClassLoader)
+      case "XalanC" => TransformerFactory.newInstance("org.apache.xalan.xsltc.trax.TransformerFactoryImpl", this.getClass.getClassLoader)
       case _ => transformFactoryXSL2
     }
   }
@@ -208,7 +208,7 @@ class StepHandler(var contentHandler : ContentHandler, val config : Config) exte
   //  used to capture inline schema and inline XSL.
   //
   private[this] val saxTransformerFactory : SAXTransformerFactory =
-    TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null).asInstanceOf[SAXTransformerFactory]
+    TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", this.getClass.getClassLoader).asInstanceOf[SAXTransformerFactory]
 
   private[this] var currentSchemaHandler : TransformerHandler = null
   private[this] var currentSchemaResult  : DOMResult = null

--- a/core/src/main/scala/util/transform-pool.scala
+++ b/core/src/main/scala/util/transform-pool.scala
@@ -38,7 +38,7 @@ object IdentityTransformPool extends Instrumented  {
   //  avoid licence check in SaxonEE, which for some reason is always
   //  trigged by id transform.
   //
-  private val tf = TransformerFactory.newInstance("org.apache.xalan.xsltc.trax.TransformerFactoryImpl", null)
+  private val tf = TransformerFactory.newInstance("org.apache.xalan.xsltc.trax.TransformerFactoryImpl", this.getClass.getClassLoader)
   private val pool = new SoftReferenceObjectPool[Transformer](new IdentityTransformerFactory(tf))
   private val activeGauge = metrics.gauge("Active")(numActive)
   private val idleGauge = metrics.gauge("Idle")(numIdle)

--- a/core/src/main/scala/util/xml-parser-pool.scala
+++ b/core/src/main/scala/util/xml-parser-pool.scala
@@ -36,7 +36,7 @@ object XMLParserPool extends Instrumented {
 }
 
 private class XMLParserFactory extends PoolableObjectFactory[DocumentBuilder] {
-  val builderFactory = DocumentBuilderFactory.newInstance ("org.apache.xerces.jaxp.DocumentBuilderFactoryImpl", null)
+  val builderFactory = DocumentBuilderFactory.newInstance ("org.apache.xerces.jaxp.DocumentBuilderFactoryImpl", this.getClass.getClassLoader)
 
   //
   //  Setup the builder factory so that it works within the security

--- a/core/src/main/scala/validator.scala
+++ b/core/src/main/scala/validator.scala
@@ -71,7 +71,7 @@ object Validator {
 
   def apply (name : String, in : Source, config : Config = new Config) : Validator = {
     val builder = new StepBuilder()
-    val transformerFactory = TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null)
+    val transformerFactory = TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", this.getClass.getClassLoader)
 
     if (!transformerFactory.getFeature(SAXTransformerFactory.FEATURE)) {
       throw new RuntimeException("Need a SAX-compatible TransformerFactory!")

--- a/core/src/main/scala/wadl/checker-builder.scala
+++ b/core/src/main/scala/wadl/checker-builder.scala
@@ -110,7 +110,7 @@ class WADLCheckerBuilder(protected[wadl] var wadl : WADLNormalizer) extends Lazy
   //  We purposly do the identity transform using xalan instead of
   //  Saxon, because of SaxonEE license issue.
   //
-  private val idTransform = TransformerFactory.newInstance("org.apache.xalan.processor.TransformerFactoryImpl",null).newTransformer()
+  private val idTransform = TransformerFactory.newInstance("org.apache.xalan.processor.TransformerFactoryImpl",this.getClass.getClassLoader).newTransformer()
   idTransform.setErrorListener (new LogErrorListener)
 
   private def buildFromWADL (in : Source, out: Result, config : Config) : Unit = {

--- a/core/src/test/scala/step/step-base-saxonee.scala
+++ b/core/src/test/scala/step/step-base-saxonee.scala
@@ -19,9 +19,7 @@ import javax.xml.validation._
 import javax.xml.transform.stream._
 
 class BaseStepSuiteSaxonEE extends BaseStepSuite {
-  System.setProperty ("javax.xml.validation.SchemaFactory:http://www.w3.org/2001/XMLSchema", "com.saxonica.jaxp.SchemaFactoryImpl")
-
-  private val schemaFactorySaxon = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema")
+  private val schemaFactorySaxon = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema", "com.saxonica.jaxp.SchemaFactoryImpl", this.getClass.getClassLoader)
 
   //
   //  Enable 1.1 support in saxon

--- a/core/src/test/scala/step/step-base.scala
+++ b/core/src/test/scala/step/step-base.scala
@@ -45,14 +45,14 @@ import javax.xml.namespace.QName
 import org.mockito.Mockito._
 
 class BaseStepSuite extends BaseValidatorSuite {
-  System.setProperty ("javax.xml.validation.SchemaFactory:http://www.w3.org/XML/XMLSchema/v1.1", "org.apache.xerces.jaxp.validation.XMLSchema11Factory")
-
-  private val schemaFactory = SchemaFactory.newInstance("http://www.w3.org/XML/XMLSchema/v1.1")
+  private val schemaFactory = SchemaFactory.newInstance("http://www.w3.org/XML/XMLSchema/v1.1",
+    "org.apache.xerces.jaxp.validation.XMLSchema11Factory",
+    this.getClass.getClassLoader)
 
   private val jsonSchemaFactory = JsonSchemaFactory.newBuilder.setReportProvider(new ListReportProvider(LogLevel.WARNING, LogLevel.ERROR)).freeze
 
-  val xsl1Factory = TransformerFactory.newInstance("org.apache.xalan.xsltc.trax.TransformerFactoryImpl", null)
-  val xsl2Factory = TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null)
+  val xsl1Factory = TransformerFactory.newInstance("org.apache.xalan.xsltc.trax.TransformerFactoryImpl", this.getClass.getClassLoader)
+  val xsl2Factory = TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", this.getClass.getClassLoader)
 
   val xsl1Templates = xsl1Factory.newTemplates (new StreamSource(getClass().getResourceAsStream("/xsl/testXSL1.xsl")))
   val xsl2Templates = xsl2Factory.newTemplates (new StreamSource(getClass().getResourceAsStream("/xsl/testXSL2.xsl")))

--- a/core/src/test/scala/util/transform-pool-tests.scala
+++ b/core/src/test/scala/util/transform-pool-tests.scala
@@ -27,7 +27,7 @@ import org.scalatest.FunSuite
 
 @RunWith(classOf[JUnitRunner])
 class TransformPoolSuite extends FunSuite {
-  val factory = TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", null)
+  val factory = TransformerFactory.newInstance("net.sf.saxon.TransformerFactoryImpl", this.getClass.getClassLoader)
   val templates1 = factory.newTemplates (new StreamSource(getClass().getResource("/xsl/builder.xsl").toString))
   val templates2 = factory.newTemplates (new StreamSource(getClass().getResource("/xsl/opt/removeDups.xsl").toString))
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <scala.test.version>2.0</scala.test.version>
         <scala.uri.version>0.4.2</scala.uri.version>
         <junit.version>4.10</junit.version>
-        <wadl-tools.version>1.0.28</wadl-tools.version>
+        <wadl-tools.version>1.0.29</wadl-tools.version>
         <xmlsec.version>1.4.6</xmlsec.version>
         <xerces.version>2.12.1-rax</xerces.version>
         <servlet.version>3.1</servlet.version>


### PR DESCRIPTION
This makes it far less complicated than trying to manipulate the
Thread Context ClassLoader, and should result in less errors.

This project, and wadl-tools, explicitly depend on saxon(ee) XML parsing
stuff, so we can just explicitly use the classloader that includes the
dependencies. Much less complicated.