### PR TITLE
Error states weren't correctly added to HEADER_ANY and HEADERXSD_ANY

### DIFF
--- a/core/src/main/resources/xsl/builder.xsl
+++ b/core/src/main/resources/xsl/builder.xsl
@@ -361,7 +361,7 @@
     </xsl:template>
 
     <!-- Only the following methods need error states added -->
-    <xsl:template match="check:step[@type=('URL','URLXSD','START','HEADER','HEADERXSD') and not(@inRequest)]" mode="addErrorStates">
+    <xsl:template match="check:step[@type=('URL','URLXSD','START','HEADER','HEADERXSD','HEADER_ANY','HEADERXSD_ANY') and not(@inRequest)]" mode="addErrorStates">
         <xsl:variable name="nexts" as="xsd:string*" select="tokenize(@next,' ')"/>
         <xsl:variable name="doConnect" as="xsd:boolean"
                       select="not((for $n in $nexts return


### PR DESCRIPTION
In practice this results in a bug where a Method error (405) will not
contain an appropriate Allow header. Test to validate are part of #244 