### PR TITLE
added an inStep method to the handlers that is used before the step is c...

### DIFF
--- a/core/src/main/scala/handler/MethodLabelHandler.scala
+++ b/core/src/main/scala/handler/MethodLabelHandler.scala
@@ -1,0 +1,61 @@
+/** *
+  * Copyright 2014 Rackspace US, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package com.rackspace.com.papi.components.checker.handler
+
+import javax.servlet.FilterChain
+
+import com.rackspace.com.papi.components.checker.Validator
+import com.rackspace.com.papi.components.checker.servlet.{CheckerServletRequest, CheckerServletResponse}
+import com.rackspace.com.papi.components.checker.step.{StepContext, Step, Result}
+import org.w3c.dom.{Document, NodeList}
+
+class MethodLabelHandler extends ResultHandler  {
+  val MethodLabelHeaderName: String = "X-METHOD-LABEL"
+
+  var methodMap : Map[String, String] = Map()
+
+  override def init(validator: Validator, checker: Option[Document]): Unit = {
+    checker.map { doc =>
+      val steps: NodeList = doc.getElementsByTagName("step")
+      for {
+        i <- 0 until steps.getLength
+        item <- Option(steps.item(i))
+        attributes <- Option(item.getAttributes)
+        attType <- Option(attributes.getNamedItem("type"))
+        id <- Option(attributes.getNamedItem("id")) if "METHOD".equalsIgnoreCase(attType.getTextContent)
+        label <- Option(attributes.getNamedItem("label")) if "METHOD".equalsIgnoreCase(attType.getTextContent)
+        idText <- Option(id.getTextContent)
+        labelText <- Option(label.getTextContent)
+      } yield {
+        methodMap = methodMap ++ Map(idText -> labelText)
+      }
+    }
+  }
+
+  override def handle(req: CheckerServletRequest, resp: CheckerServletResponse, chain: FilterChain, result: Result): Unit = {
+    for  {
+      id <- result.stepIDs if methodMap.contains(id)
+      m <- methodMap.get(id)
+    } yield {
+      req.addHeader(MethodLabelHeaderName, m)
+    }
+  }
+
+  override def inStep (currentStep: Step, req: CheckerServletRequest, resp : CheckerServletResponse, context: StepContext) : StepContext = {
+      methodMap.get(currentStep.id).map(context.requestHeaders.addHeader(MethodLabelHeaderName,_)).map(headers => context.copy(requestHeaders = headers)).getOrElse(context)
+  }
+}

--- a/core/src/main/scala/handler/dispatch-handler.scala
+++ b/core/src/main/scala/handler/dispatch-handler.scala
@@ -18,7 +18,7 @@ package com.rackspace.com.papi.components.checker.handler
 import scala.collection.immutable.List
 
 import com.rackspace.com.papi.components.checker.servlet._
-import com.rackspace.com.papi.components.checker.step.Result
+import com.rackspace.com.papi.components.checker.step.{StepContext, Step, Result}
 
 import javax.servlet.FilterChain
 
@@ -37,6 +37,9 @@ class DispatchResultHandler(private[this] var handlers : List[ResultHandler] = L
   }
   def handle (req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, result : Result)  : Unit = {
     handlers.foreach(h => h.handle(req,resp,chain,result))
+  }
+  override def inStep (currentStep: Step, req: CheckerServletRequest, resp : CheckerServletResponse, context: StepContext) : StepContext = {
+    handlers.foldLeft(context)((context : StepContext, handler : ResultHandler) => handler.inStep(currentStep, req, resp, context))
   }
   override def destroy : Unit = {
     handlers.foreach(h => h.destroy)

--- a/core/src/main/scala/handler/handler-base.scala
+++ b/core/src/main/scala/handler/handler-base.scala
@@ -15,7 +15,7 @@
  */
 package com.rackspace.com.papi.components.checker.handler
 
-import com.rackspace.com.papi.components.checker.step.Result
+import com.rackspace.com.papi.components.checker.step.{Step, StepContext, Result}
 import com.rackspace.com.papi.components.checker.servlet._
 
 import com.rackspace.com.papi.components.checker.Validator
@@ -27,6 +27,7 @@ import org.w3c.dom.Document
 abstract class ResultHandler {
   def init(validator : Validator, checker : Option[Document]) : Unit
   def handle (req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, result : Result) : Unit
+  def inStep (currentStep: Step, req: CheckerServletRequest, resp : CheckerServletResponse, context: StepContext) : StepContext = { context }
   def destroy : Unit = {}
 }
 

--- a/core/src/main/scala/servlet/request-response.scala
+++ b/core/src/main/scala/servlet/request-response.scala
@@ -149,27 +149,19 @@ class CheckerServletRequest(val request : HttpServletRequest) extends HttpServle
   }
 
   override def getHeaders(name: String): util.Enumeration[String] = {
-    auxiliaryHeaders.get(name) match {
-      case Some(auxiliaryHeaderValues) =>
-        Option(super.getHeaders(name)) match {
-          case Some(primaryHeaderValues) =>
-            // Note: We store a Scala set to prevent inconsistent unions (probably due to primaryHeaderNames
-            // being a Java Enumeration).
-            val headerValuesSet = primaryHeaderValues.asScala.toList
-            (auxiliaryHeaderValues ++ headerValuesSet).toIterator.asJavaEnumeration
-          case None => null
-        }
-      case None => super.getHeaders(name)
+    // Note: We store a Scala set to prevent inconsistent unions (probably due to primaryHeaderNames
+    // being a Java Enumeration).
+    Option(super.getHeaders(name)) match {
+      case Some(originalHeaders) => (auxiliaryHeaders.get(name).getOrElse(List()) ++ originalHeaders.asScala.toList).toIterator.asJavaEnumeration
+      case None => null
     }
   }
 
   override def getHeaderNames: util.Enumeration[String] = {
+//    Note: We store a Scala set to prevent inconsistent unions (probably due to primaryHeaderNames
+//            being a Java Enumeration).
     Option(super.getHeaderNames) match {
-      case Some(primaryHeaderNames) =>
-        // Note: We store a Scala set to prevent inconsistent unions (probably due to primaryHeaderNames
-        // being a Java Enumeration).
-        val headerNamesSet = primaryHeaderNames.asScala.toList
-        (auxiliaryHeaders.keySet ++ headerNamesSet).toIterator.asJavaEnumeration
+      case Some(originalHeaderNames) => (auxiliaryHeaders.keySet ++ originalHeaderNames.asScala.toList).toIterator.asJavaEnumeration
       case None => null
     }
   }

--- a/core/src/main/scala/step/method.scala
+++ b/core/src/main/scala/step/method.scala
@@ -21,16 +21,12 @@ import com.rackspace.com.papi.components.checker.servlet._
 import javax.servlet.FilterChain
 
 class Method(id : String, label : String, val method : Regex, next : Array[Step]) extends ConnectedStep(id, label, next) {
-  override val mismatchMessage : String = method.toString;
+  override val mismatchMessage : String = method.toString
 
   override def checkStep(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, context : StepContext) : Option[StepContext] = {
-    var ret : Option[StepContext] = None
-    if (context.uriLevel >= req.URISegment.size) {
-      req.getMethod() match {
-        case method() => ret= Some(context)
-        case _ => ret= None
-      }
+    req.getMethod match {
+      case method() if context.uriLevel >= req.URISegment.size => Some(context)
+      case _ => None
     }
-    ret
   }
 }

--- a/core/src/main/scala/step/reqtype.scala
+++ b/core/src/main/scala/step/reqtype.scala
@@ -21,14 +21,12 @@ import com.rackspace.com.papi.components.checker.servlet._
 import javax.servlet.FilterChain
 
 class ReqType(id : String, label : String, val rtype : Regex, next : Array[Step]) extends ConnectedStep(id, label, next) {
-  override val mismatchMessage : String = rtype.toString
+  override val mismatchMessage : String = rtype.toString()
 
   override def checkStep(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, context : StepContext) : Option[StepContext] = {
-    var ret : Option[StepContext] = None
-    req.getContentType() match {
-      case rtype(_,_) => ret = Some(context)
-      case _ => ret= None
+    req.getContentType match {
+      case rtype(_,_) => Some(context)
+      case _ => None
     }
-    ret
   }
 }

--- a/core/src/main/scala/step/step-base.scala
+++ b/core/src/main/scala/step/step-base.scala
@@ -15,6 +15,8 @@
  */
 package com.rackspace.com.papi.components.checker.step
 
+import com.rackspace.com.papi.components.checker.handler.ResultHandler
+
 import scala.collection.mutable.ListBuffer
 
 import com.rackspace.com.papi.components.checker.servlet._
@@ -24,7 +26,7 @@ import javax.servlet.FilterChain
 //
 //  Used to keep context about the current request
 //
-case class StepContext(uriLevel : Int = 0, requestHeaders : HeaderMap = new HeaderMap)
+case class StepContext(uriLevel : Int = 0, requestHeaders : HeaderMap = new HeaderMap, handler: Option[ResultHandler] = None)
 
 
 //
@@ -119,7 +121,8 @@ abstract class ConnectedStep(id : String, label : String, val next : Array[Step]
     val nextContext = checkStep(req, resp, chain, context)
 
     if (nextContext != None) {
-      val results : Array[Result] = nextStep (req, resp, chain, nextContext.get)
+      val results : Array[Result] =
+          nextStep (req, resp, chain, nextContext.get.handler.map{ handler => handler.inStep(this, req, resp, nextContext.get) }.getOrElse(nextContext.get))
       if (results.size == 1) {
         results(0).addStepId(id)
         result = Some(results(0))

--- a/core/src/main/scala/validator.scala
+++ b/core/src/main/scala/validator.scala
@@ -213,7 +213,7 @@ class Validator private (private val _name : String, val startStep : Step, val c
     try {
       val creq = new CheckerServletRequest (req)
       val cres = new CheckerServletResponse(res)
-      val result = startStep.check (creq, cres, chain, StepContext()).get
+      val result = startStep.check (creq, cres, chain, StepContext(handler = Option(resultHandler))).get
       resultHandler.handle(creq, cres, chain, result)
       if (!result.valid) failMeter.mark()
       result

--- a/core/src/test/scala/handler/MethodLabelHandlerTest.scala
+++ b/core/src/test/scala/handler/MethodLabelHandlerTest.scala
@@ -1,0 +1,213 @@
+/** *
+  * Copyright 2014 Rackspace US, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package com.rackspace.com.papi.components.checker.handler
+
+import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletRequest
+import javax.xml.transform.Transformer
+import javax.xml.transform.sax.SAXResult
+import javax.xml.transform.stream.StreamSource
+
+import com.rackspace.com.papi.components.checker.Converters._
+import com.rackspace.com.papi.components.checker.servlet.{CheckerServletRequest, CheckerServletResponse}
+import com.rackspace.com.papi.components.checker.step._
+import com.rackspace.com.papi.components.checker.util.{IdentityTransformPool, HeaderMap}
+import com.rackspace.com.papi.components.checker.{AssertResultHandler, TestConfig, BaseValidatorSuite, Validator}
+import org.junit.runner.RunWith
+import org.mockito.Matchers.anyString
+import org.mockito.{Matchers, ArgumentCaptor, Mockito}
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfter
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.mock.MockitoSugar
+import com.rackspace.cloud.api.wadl.Converters._
+import scala.collection.JavaConverters._
+
+
+@RunWith(classOf[JUnitRunner])
+class MethodLabelHandlerTest extends BaseValidatorSuite with BeforeAndAfter with MockitoSugar {
+  val methodNameLoggerHandler = new MethodLabelHandler
+
+  val handlerConfig = {
+    val cnfg = TestConfig()
+    val handler = new DispatchResultHandler(List[ResultHandler](new ConsoleResultHandler(),
+      methodNameLoggerHandler,
+      new AssertResultHandler(),
+      new ServletResultHandler()))
+    cnfg.resultHandler = handler
+    cnfg
+  }
+
+  val xmlChecker =
+    <checker xmlns="http://www.rackspace.com/repose/wadl/checker">
+      <step id="S0" type="START" next="a badAURL badMethod"/>
+      <step id="a" type="URL" match="a" next="GET PUT DELETE POST-XML POST-JSON badMethodNotGetOrPostorPut badURL"/>
+      <step id="GET" type="METHOD" match="GET" next="Accept" label="some-specific-method"/>
+      <step id="PUT" type="METHOD" match="PUT" next="Header badHeader" label="put-specific-method"/>
+      <step id="POST-XML" type="METHOD" match="POST" next="REQ_TYPE_XML REQ_TYPE_XML_FAIL" label="post-xml-method"/>
+      <step id="POST-JSON" type="METHOD" match="POST" next="REQ_TYPE_JSON REQ_TYPE_JSON_FAIL" label="post-json-method"/>
+      <step id="DELETE" type="METHOD" match="DELETE" next="Accept"/>
+      <step id="REQ_TYPE_XML" type="REQ_TYPE" next="Accept" match="(?i)(application/xml)(;.*)?"/>
+      <step id="REQ_TYPE_JSON" type="REQ_TYPE" next="Accept" match="(?i)(application/json)(;.*)?"/>
+      <step id="REQ_TYPE_XML_FAIL" type="REQ_TYPE_FAIL" notMatch="(?i)(application/xml)(;.*)?"/>
+      <step id="REQ_TYPE_JSON_FAIL" type="REQ_TYPE_FAIL" notMatch="(?i)(application/json)(;.*)?"/>
+      <step id="Header" type="HEADER_ANY" name="foo" match="bar" next="Accept"/>
+      <step id="Accept" type="ACCEPT" priority="100000"/>
+      <step id="badAURL" type="URL_FAIL" notMatch="a" priority="1000"/>
+      <step id="badMethodNotGetOrPostorPut" type="METHOD_FAIL" notMatch="GET|POST|PUT|DELETE" priority="2000"/>
+      <step id="badMethod" type="METHOD_FAIL" priority="2000"/>
+      <step id="badURL" type="URL_FAIL" priority="1000"/>
+      <step id="badHeader" type="CONTENT_FAIL" priority="1000"/>
+    </checker>
+
+  val headers: HeaderMap = new HeaderMap().addHeaders("foo", List("bar", "baz"))
+
+  val steps = {
+    var transf: Transformer = null
+    val stepHandler = new StepHandler(null, handlerConfig)
+    try {
+      transf = IdentityTransformPool.borrowTransformer
+      transf.transform(new StreamSource(xmlChecker), new SAXResult(stepHandler))
+      stepHandler.step
+    } finally {
+      if (transf != null) IdentityTransformPool.returnTransformer(transf)
+    }
+  }
+
+  val validator = Validator("MyInstTestValidator", steps, handlerConfig)
+
+  //
+  //  Reinitialize the handlers so that we can connect the state
+  //  machine with the checker format manually.
+  //
+
+  handlerConfig.resultHandler.destroy
+  handlerConfig.resultHandler.init(validator, Some(xmlChecker))
+
+  val req = Mockito.mock(classOf[CheckerServletRequest])
+  val resp = Mockito.mock(classOf[CheckerServletResponse])
+  val chn = Mockito.mock(classOf[FilterChain])
+  val res = Mockito.mock(classOf[Result])
+
+  before {
+    reset(req, resp, chn, res)
+  }
+
+  //INSTEP METHOD
+  test("when the validator finds a method with a label on /a should add the label header to the context") {
+    val request = Mockito.mock(classOf[CheckerServletRequest])
+    when(request.getMethod).thenReturn("POST")
+    when(request.getRequestURI).thenReturn("/a")
+    when(request.getContentType).thenReturn("application/xml")
+    when(request.getHeaders("X-METHOD-LABEL")).thenReturn(List[String]().toIterator.asJavaEnumeration)
+
+    validator.validate(request, resp, chn)
+
+    val newRequest: ArgumentCaptor[CheckerServletRequest] = ArgumentCaptor.forClass(classOf[CheckerServletRequest])
+    verify(chn).doFilter(newRequest.capture(), Matchers.any(classOf[CheckerServletResponse]))
+    assert(newRequest.getValue.getHeaders("X-METHOD-LABEL").nextElement() == "post-xml-method")
+  }
+
+  test("when a validator finds a method without a label on /a should not add the label header to the context2") {
+    val request = Mockito.mock(classOf[CheckerServletRequest])
+    when(request.getMethod).thenReturn("DELETE")
+    when(request.getRequestURI).thenReturn("/a")
+    when(request.getContentType).thenReturn("application/xml")
+    when(request.getHeaders("X-METHOD-LABEL")).thenReturn(List[String]().toIterator.asJavaEnumeration)
+
+    validator.validate(request, resp, chn)
+
+    val newRequest: ArgumentCaptor[CheckerServletRequest] = ArgumentCaptor.forClass(classOf[CheckerServletRequest])
+    verify(chn).doFilter(newRequest.capture(), Matchers.any(classOf[CheckerServletResponse]))
+    assert(!newRequest.getValue.getHeaders("X-METHOD-LABEL").hasMoreElements)
+  }
+
+  test("a method with a label on /a should add the label header to the context") {
+    val getStep = new Method("GET", "label", "GET".r, Array())
+    val putStep = new Method("PUT", "label", "PUT".r, Array())
+
+    val newCtx = methodNameLoggerHandler.inStep(putStep, req, resp, methodNameLoggerHandler.inStep(getStep, req, resp, StepContext(requestHeaders = headers)))
+
+    assert(newCtx.requestHeaders.get("foo").get == headers.get("foo").get)
+    assert(newCtx.requestHeaders.get("X-METHOD-LABEL").get == List("some-specific-method", "put-specific-method"))
+  }
+
+  test("a method without a label on /a should not add the label header to the context") {
+    val step = new Method("POST", "label", "POST".r, Array())
+
+    val newCtx = methodNameLoggerHandler.inStep(step, req, resp, StepContext(requestHeaders = headers))
+
+    assert(newCtx.requestHeaders.get("foo").get == headers.get("foo").get)
+    assert(newCtx.requestHeaders.get("X-METHOD-LABEL").isEmpty)
+  }
+
+  test("a step not in the map should not add the label header to the context") {
+    val step = new Accept("foo", "label", 1)
+
+    val newCtx = methodNameLoggerHandler.inStep(step, req, resp, StepContext(requestHeaders = headers))
+
+    assert(newCtx.requestHeaders.get("foo").get == headers.get("foo").get)
+    assert(newCtx.requestHeaders.get("X-METHOD-LABEL").isEmpty)
+  }
+
+  test("a checker which has failed to be created results in no label header to the context") {
+    val methodNameLoggerHandler = new MethodLabelHandler
+    methodNameLoggerHandler.init(Mockito.mock(classOf[Validator]), None)
+    val step = new Method("POST", "label", "POST".r, Array())
+
+    val newCtx = methodNameLoggerHandler.inStep(step, req, resp, StepContext(requestHeaders = headers))
+
+    assert(newCtx.requestHeaders.get("foo").get == headers.get("foo").get)
+    assert(newCtx.requestHeaders.get("X-METHOD-LABEL").isEmpty)
+  }
+
+  //HANDLE METHOD
+
+  test("a method with a label on /a should set a header on the request") {
+    when(res.stepIDs).thenReturn(List("S0", "a", "PUT", "badHeader"))
+
+    methodNameLoggerHandler.handle(req, resp, chn, res)
+
+    verify(req).addHeader("X-METHOD-LABEL", "put-specific-method")
+  }
+
+  test("a method without a label on /a should not set a label on the request") {
+    when(res.stepIDs).thenReturn(List("S0", "a", "POST", "Accept"))
+
+    methodNameLoggerHandler.handle(req, resp, chn, res)
+
+    verify(req, never()).addHeader(anyString(), anyString())
+  }
+
+  test("a failed result before getting to a method should not add a header to the request") {
+    when(res.stepIDs).thenReturn(List("S0", "badAURL"))
+
+    methodNameLoggerHandler.handle(req, resp, chn, res)
+
+    verify(req, never()).addHeader(anyString(), anyString())
+  }
+
+  test("a checker which has failed to be created results in no header set on the request") {
+    val methodNameLoggerHandler = new MethodLabelHandler
+    methodNameLoggerHandler.init(Mockito.mock(classOf[Validator]), None)
+    when(res.stepIDs).thenReturn(List())
+
+    methodNameLoggerHandler.handle(req, resp, chn, res)
+
+    verify(req, never()).addHeader(anyString(), anyString())
+  }
+}

--- a/core/src/test/scala/servlet/request-response.scala
+++ b/core/src/test/scala/servlet/request-response.scala
@@ -15,11 +15,15 @@
  */
 package com.rackspace.com.papi.components.checker
 
+import org.junit.runner.RunWith
 import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest
 import org.mockito.Mockito.when
 
 import scala.collection.JavaConverters._
 
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
 class RequestResponseSuite extends BaseValidatorSuite {
 
   test ("Ensure wrapper does not parse commas on getHeader") {
@@ -100,5 +104,47 @@ class RequestResponseSuite extends BaseValidatorSuite {
     intercept[IllegalArgumentException] {
       wrap.getDateHeader("Last-Modified")
     }
+  }
+
+  test("Ensure getHeaders retrieves the new headers if the original request does not have any") {
+    val emptyMap: Map[String, List[String]] = Map()
+    val req = request("GET","/foo","application/XML","",false,emptyMap)
+    val wrapper = new CheckerServletRequest(req)
+    wrapper.addHeader("Foo", "Bar")
+    wrapper.addHeader("Foo", "Baz")
+    val headers = wrapper.getHeaders("Foo")
+    assert(headers.nextElement() == "Bar")
+    assert(headers.nextElement() == "Baz")
+  }
+
+  test("Ensure getHeaders continues to send null if the original request sends null because of security") {
+    val req = request("GET","/foo")
+    val wrapper = new CheckerServletRequest(req)
+    wrapper.addHeader("Foo", "Bar")
+    wrapper.addHeader("Foo", "Baz")
+    val headers = wrapper.getHeaders("Foo")
+    assert(headers == null)
+  }
+
+  test("Ensure getHeaderNames retrieves the header names if the original request does not have any") {
+    val emptyMap: Map[String, List[String]] = Map()
+    val req = request("GET","/foo","application/XML","",false,emptyMap)
+    val wrapper = new CheckerServletRequest(req)
+    wrapper.addHeader("Foo", "Bar")
+    wrapper.addHeader("Foo", "Baz")
+    wrapper.addHeader("Moo", "Baz")
+    val headers = wrapper.getHeaderNames()
+    assert(headers.nextElement() == "Foo")
+    assert(headers.nextElement() == "Moo")
+  }
+
+  test("Ensure getHeaderNames continues to send null if the original request sends null because of security") {
+    val req = request("GET","/foo")
+    val wrapper = new CheckerServletRequest(req)
+    wrapper.addHeader("Foo", "Bar")
+    wrapper.addHeader("Foo", "Baz")
+    wrapper.addHeader("Moo", "Baz")
+    val headers = wrapper.getHeaderNames()
+    assert(headers == null)
   }
 }

--- a/core/src/test/scala/validator-base.scala
+++ b/core/src/test/scala/validator-base.scala
@@ -557,6 +557,12 @@ class BaseValidatorSuite extends FunSuite {
       }
     })
 
+    when(req.getHeaderNames).thenAnswer(new Answer[Enumeration[String]] {
+      override def answer(invocation : InvocationOnMock) : Enumeration[String] = {
+        caseInSensitiveHeaders.keySet.iterator
+      }
+    })
+
     return req
   }
 


### PR DESCRIPTION
This closes #242 

A number of changes from the original PR

0. Rebased to Master
1. Lots of whitespaces differences in step-tests removed
2. Some of the XML step tests were (inadvertently?) changed.  Reverted these
3. There was an unessesary non-functional import statement in request test for java.util
4. Request-response  tests were not really being run (Not your fault tyler apparently these were never run, I blame Lisa Clark :-) )
5. Checker XML in handler test was technically incorrect so fixed it