### PR TITLE
Udpated the DelegationHandler for better customization.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Releases #
 
+## Release 1.1.2 (2015-07-20) ##
+1. Added the ability for the DelegationHandler to have the default component name of ```api-checker``` overridden.
+This will allow multiple API-Checker instances to be utilized in a single application and have them be differentiated in the logs.
+
 ## Release 1.1.1 (2015-05-22) ##
 1. Added the new ApiCoverageHandler to log the path taken by a request to a logger named ```api-coverage-logger```.
 1. Fixed a bug where the Wadl2Checker and Wadl2Dot CLI utilities were accidentally placed in the test source tree. 

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/handler/DelegationHandler.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/handler/DelegationHandler.scala
@@ -23,7 +23,8 @@ import com.rackspace.com.papi.components.checker.step.results.{ErrorResult, Resu
 import com.rackspace.httpdelegation.HttpDelegationManager
 import org.w3c.dom.Document
 
-class DelegationHandler(delegationQuality: Double) extends ResultHandler with HttpDelegationManager {
+class DelegationHandler(delegationQuality: Double, component: String) extends ResultHandler with HttpDelegationManager {
+  def this(delegationQuality: Double) = this(delegationQuality, "api-checker")
 
   def init (validator : Validator, checker : Option[Document]) : Unit = {}
 
@@ -32,7 +33,7 @@ class DelegationHandler(delegationQuality: Double) extends ResultHandler with Ht
       result match {
         case errorResult : ErrorResult =>
           val delegationHeaders = buildDelegationHeaders(
-            errorResult.code, "api-checker", errorResult.message, delegationQuality
+            errorResult.code, component, errorResult.message, delegationQuality
           )
 
           delegationHeaders.foreach { case (headerName, headerValues) =>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/handler/DelegationHandlerTest.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/handler/DelegationHandlerTest.scala
@@ -64,4 +64,16 @@ class DelegationHandlerTest extends BaseValidatorSuite {
 
     verify(chn, never()).doFilter(req, resp)
   }
+
+  test("Delegation header should contain the provided component name") {
+    val delegationHandler = new DelegationHandler(.7, "component-test")
+    val res = new ErrorResult("I'm A Teapot", 418, StepContext(-1), "-1", -1)
+
+    val req = mock(classOf[CheckerServletRequest])
+    val resp = mock(classOf[CheckerServletResponse])
+
+    delegationHandler.handle(req, resp, chain, res)
+
+    verify(req).addHeader("X-Delegated", "status_code=418`component=component-test`message=I'm A Teapot;q=0.7")
+  }
 }


### PR DESCRIPTION
The new constructor adds a component name so that multiple users of the API-Checker can have different log/header output.