### PR TITLE
Default checker values are not filled in when validation is turned off...

### DIFF
--- a/core/src/main/resources/xsl/builder.xsl
+++ b/core/src/main/resources/xsl/builder.xsl
@@ -198,7 +198,7 @@
                 <xsl:variable name="ns" select="doc(@href)/xsd:schema/@targetNamespace"/>
                 <xsl:choose>
                     <xsl:when test="$ns">
-                        <grammar ns="{$ns}" href="{@href}"/>
+                        <grammar ns="{$ns}" href="{@href}" type="W3C_XML"/>
                     </xsl:when>
                     <xsl:otherwise>
                         <xsl:message>[WARNING] Don't understand XML grammar of <xsl:value-of select="@href"/> ignoring...</xsl:message>

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/StepHandler.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/StepHandler.scala
@@ -365,7 +365,11 @@ class StepHandler(var contentHandler : ContentHandler, val config : Config) exte
     val href = atts.getValue("href")
 
     atts.getValue("type") match {
-      case "W3C_XML" => {
+      //
+      // match null here for compatibility with older versions
+      // that didn't specify a type...
+      //
+      case "W3C_XML" | null => {
         if (href != null) {
           grammarSources += new SAXSource(new InputSource(href))
         }

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLSuite.scala
@@ -1611,6 +1611,41 @@ class ValidatorWADLSuite extends BaseValidatorSuite {
 
   WADLSchemaAssertions(validator_UUID)
 
+
+  //
+  // validator_UUID_noCheckerValid allows:
+  //
+  // The validator is used in the following tests, it uses an external
+  // grammar. It disables checker validation.
+  //
+  val conf_noCheck = TestConfig()
+  conf_noCheck.validateChecker = false
+  val validator_UUID_noCheckerValid = Validator((localWADLURI,
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+                 xmlns:csapi="http://docs.openstack.org/compute/api/v1.1">
+           <grammars>
+              <include href="src/test/resources/xsd/common.xsd"/>
+           </grammars>
+           <resources base="https://test.api.openstack.com">
+              <resource id="uuid" path="path/to/my/resource/{uuid}">
+                   <param name="uuid" style="template" type="csapi:UUID"/>
+                   <method href="#getMethod" />
+              </resource>
+              <resource id="progress" path="path/to/{progress}">
+                   <param name="progress" style="template" type="csapi:Progress"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+        </application>)
+    , conf_noCheck)
+
+  WADLSchemaAssertions(validator_UUID_noCheckerValid)
+
+
+
   //
   // validator_UUID_inline allows:
   //


### PR DESCRIPTION
We want to make sure we don't depend on default values being filled in by the validation process, since we want users to be able to disable it.