### PR TITLE
Add support for spaces in role names in rax:roles extension.

### DIFF
--- a/core/src/main/resources/xsl/raxRoles.xsl
+++ b/core/src/main/resources/xsl/raxRoles.xsl
@@ -108,10 +108,14 @@
             <xsl:for-each select="$roles">
                 <wadl:param name="X-ROLES" style="header" rax:code="403"
                             rax:message="You are forbidden to perform the operation" type="xsd:string" required="true">
-                    <xsl:attribute name="fixed" select="."/>
+                    <xsl:attribute name="fixed" select="rax:transformNBSP(.)"/>
                 </wadl:param>
             </xsl:for-each>
         </xsl:if>
-
     </xsl:template>
+
+    <xsl:function name="rax:transformNBSP" as="xsd:string">
+      <xsl:param name="in" as="xsd:string"/>
+      <xsl:value-of select="replace($in,'&#xA0;',' ')"/>
+    </xsl:function>
 </xsl:stylesheet>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames.scala
@@ -51,7 +51,7 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames extends Fl
         </grammars>
         <resources base="https://test.api.openstack.com">
           <resource path="/a" rax:roles="a:admin-foo">
-            <method href="#putOnA" rax:roles="a:observer%"/>
+            <method href="#putOnA" rax:roles="a:observer% a:observer&#xA0;wsp"/>
             <resource path="/b" rax:roles="b:creator">
               <method href="#postOnB"/>
               <method href="#putOnB"/>
@@ -71,11 +71,14 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames extends Fl
       </application>)
       , configuration)
 
-    // PUT /a has resource level a:admin-foo, method level a:observer%
+    // PUT /a has resource level a:admin-foo, method level a:observer% and 'a:observer '
     it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:admin-foo"), description)
     it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer%"), description)
     it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer%", "a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer wsp"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer wsp", "a:admin-foo"), description)
     it should behave like accessIsForbidden(validator, "PUT", "/a", List("AR-Payments-Billing-Support"), description)
+    it should behave like accessIsForbidden(validator, "PUT", "/a", List("a:observer"), description)
     it should behave like accessIsForbiddenWhenNoXRoles(validator, "PUT", "/a", description)
 
     // DELETE /a has resource level a:admin-foo, method is not defined
@@ -86,6 +89,7 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames extends Fl
     it should behave like accessIsAllowed(validator, "POST", "/a/b", List("a:admin-foo"), description)
     it should behave like accessIsAllowed(validator, "POST", "/a/b", List("b:creator"), description)
     it should behave like accessIsForbidden(validator, "POST", "/a/b", List("a:observer%"), description)
+    it should behave like accessIsForbidden(validator, "POST", "/a/b", List("a:observer wsp"), description)
     it should behave like accessIsForbiddenWhenNoXRoles(validator, "POST", "/a/b", description)
 
     // PUT /a/b has parent resource level a:admin-foo, resource level b:creator, method level AR-Payments-Billing-Support
@@ -104,6 +108,7 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames extends Fl
     it should behave like accessIsAllowed(validator, "DELETE", "/a/b", List("b:admin"), description)
     it should behave like accessIsForbidden(validator, "DELETE", "/a/b", List(), description)
     it should behave like accessIsForbidden(validator, "DELETE", "/a/b", List("a:observer%"), description)
+    it should behave like accessIsForbidden(validator, "DELETE", "/a/b", List("a:observer wsp"), description)
     it should behave like accessIsForbidden(validator, "DELETE", "/a/b", List("b:foo"), description)
     it should behave like accessIsForbiddenWhenNoXRoles(validator, "DELETE", "/a/b", description)
 
@@ -113,9 +118,15 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames extends Fl
     it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo"), description, List("'b'","yes","no"))
     it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer%"), description)
     it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo", "a:observer%"), description)
+    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer wsp"), description)
+    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo", "a:observer wsp"), description)
     it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer%"), description, List("'b'","yes","no"))
+    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer wsp"), description, List("'b'","yes","no"))
     it should behave like accessIsForbidden(validator, "GET", "/a/yes", List("a:observer%"), description)
     it should behave like accessIsForbidden(validator, "GET", "/a/no", List("a:observer%"), description)
     it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:observer%"), description, List("'b'","yes","no"))
+    it should behave like accessIsForbidden(validator, "GET", "/a/yes", List("a:observer wsp"), description)
+    it should behave like accessIsForbidden(validator, "GET", "/a/no", List("a:observer wsp"), description)
+    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:observer wsp"), description, List("'b'","yes","no"))
   }
 }

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNamesMasked.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNamesMasked.scala
@@ -51,7 +51,7 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNamesMasked exte
         </grammars>
         <resources base="https://test.api.openstack.com">
           <resource path="/a" rax:roles="a:admin-foo">
-            <method href="#putOnA" rax:roles="a:observer%"/>
+            <method href="#putOnA" rax:roles="a:observer% a:observer&#xA0;wsp"/>
             <resource path="/b" rax:roles="b:creator">
               <method href="#postOnB"/>
               <method href="#putOnB"/>
@@ -75,18 +75,22 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNamesMasked exte
     it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:admin-foo"), description)
     it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer%"), description)
     it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer%", "a:admin-foo"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer wsp"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer wsp", "a:admin-foo"), description)
     it should behave like methodNotAllowed(validator, "PUT", "/a", List("AR-Payments-Billing-Support"), description)
     it should behave like resourceNotFoundWhenNoXRoles(validator, "PUT", "/a", description)
 
     // DELETE /a has resource level a:admin-foo, method is not defined
     it should behave like methodNotAllowed(validator, "DELETE", "/a", List("a:admin-foo"), description, List("does not match","'PUT'"))
     it should behave like methodNotAllowed(validator, "DELETE", "/a", List("a:observer%"), description, List("does not match","'PUT'"))
+    it should behave like methodNotAllowed(validator, "DELETE", "/a", List("a:observer wsp"), description, List("does not match","'PUT'"))
     it should behave like resourceNotFound(validator, "DELETE", "/a", List(), description)
 
     // POST /a/b has parent resource level a:admin-foo, resource level b:creator
     it should behave like accessIsAllowed(validator, "POST", "/a/b", List("a:admin-foo"), description)
     it should behave like accessIsAllowed(validator, "POST", "/a/b", List("b:creator"), description)
     it should behave like resourceNotFound(validator, "POST", "/a/b", List("a:observer%"), description)
+    it should behave like resourceNotFound(validator, "POST", "/a/b", List("a:observer wsp"), description)
     it should behave like methodNotAllowed(validator, "POST", "/a/b", List("AR-Payments-Billing-Support"), description, List("does not match","'DELETE|PUT'"))
     it should behave like resourceNotFoundWhenNoXRoles(validator, "POST", "/a/b", description)
 
@@ -107,6 +111,7 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNamesMasked exte
     it should behave like accessIsAllowed(validator, "DELETE", "/a/b", List("b:admin"), description)
     it should behave like resourceNotFound(validator, "DELETE", "/a/b", List(), description)
     it should behave like resourceNotFound(validator, "DELETE", "/a/b", List("a:observer%"), description)
+    it should behave like resourceNotFound(validator, "DELETE", "/a/b", List("a:observer wsp"), description)
     it should behave like resourceNotFound(validator, "DELETE", "/a/b", List("b:foo"), description)
     it should behave like resourceNotFoundWhenNoXRoles(validator, "DELETE", "/a/b", description)
 
@@ -120,5 +125,11 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNamesMasked exte
     it should behave like resourceNotFound(validator, "GET", "/a/yes", List("a:observer%"), description, List("{yes}"))
     it should behave like resourceNotFound(validator, "GET", "/a/no", List("a:observer%"), description, List("{no}"))
     it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:observer%"), description, List("{foo}"))
+    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer wsp"), description)
+    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo", "a:observer wsp"), description)
+    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer wsp"), description, List("'b'","yes","no"))
+    it should behave like resourceNotFound(validator, "GET", "/a/yes", List("a:observer wsp"), description, List("{yes}"))
+    it should behave like resourceNotFound(validator, "GET", "/a/no", List("a:observer wsp"), description, List("{no}"))
+    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:observer wsp"), description, List("{foo}"))
   }
 }

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithRolesAtMethodLevel.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithRolesAtMethodLevel.scala
@@ -36,7 +36,7 @@ class GivenAWadlWithRolesAtMethodLevel extends FlatSpec with RaxRolesBehaviors {
               <representation mediaType="application/xml"/>
             </request>
           </method>
-          <method name="GET" rax:roles="a:observer">
+          <method name="GET" rax:roles="a:observer b:test&#xA0;with&#xA0;space">
             <request>
               <representation mediaType="application/xml"/>
             </request>
@@ -46,7 +46,7 @@ class GivenAWadlWithRolesAtMethodLevel extends FlatSpec with RaxRolesBehaviors {
               <representation mediaType="application/xml"/>
             </request>
           </method>
-          <method name="DELETE" rax:roles="a:observer a:admin">
+          <method name="DELETE" rax:roles="a:observer a:admin b:test with space">
             <request>
               <representation mediaType="application/xml"/>
             </request>
@@ -102,6 +102,10 @@ class GivenAWadlWithRolesAtMethodLevel extends FlatSpec with RaxRolesBehaviors {
   it should behave like accessIsForbidden(validator, "GET", "/a", List("a:admin"), description)
   it should behave like accessIsForbiddenWhenNoXRoles(validator, "GET", "/a", description)
 
+  // GET on /a requires 'b:test with space' role
+  it should behave like accessIsAllowed(validator, "GET", "/a", List("b:test with space"), description)
+  it should behave like accessIsAllowed(validator, "GET", "/a", List("b:test with space", "a:bar"), description)
+
   // POST on /a requires a:admin role
   it should behave like accessIsAllowed(validator, "POST", "/a", List("a:admin"), description)
   it should behave like accessIsAllowed(validator, "POST", "/a", List("a:bar", "a:admin"), description)
@@ -117,15 +121,20 @@ class GivenAWadlWithRolesAtMethodLevel extends FlatSpec with RaxRolesBehaviors {
   it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:bar", "a:jawsome"), description)
   it should behave like accessIsAllowedWhenNoXRoles(validator, "PUT", "/a", description)
 
-  // DELETE has a:observer and a:admin, treated as ORs, not ANDs
+  // DELETE has a:observer, a:admin, and 'b:test with space' treated as ORs, not ANDs
   it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:observer", "a:bar"), description)
   it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:admin", "a:bar"), description)
   it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:bar", "a:admin"), description)
+  it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:bar", "b:test with space"), description)
+  it should behave like accessIsAllowed(validator, "DELETE", "/a", List("b:test with space","a:bar"), description)
   it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:observer", "a:admin"), description)
+  it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:observer", "b:test with space"), description)
+  it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:observer", "b:test with space", "a:admin"), description)
   it should behave like accessIsForbidden(validator, "DELETE", "/a", List(), description)
   it should behave like accessIsForbidden(validator, "DELETE", "/a", List("a:bar"), description)
   it should behave like accessIsForbidden(validator, "DELETE", "/a", List("a:bar", "a:jawsome"), description)
   it should behave like accessIsForbidden(validator, "DELETE", "/a", List("observer", "creator"), description)
+  it should behave like accessIsForbidden(validator, "DELETE", "/a", List("b:test  with space"), description) //extra space!
   it should behave like accessIsForbiddenWhenNoXRoles(validator, "DELETE", "/a", description)
 
   //GET on /c requires a header and a:admin role

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithRolesAtMethodLevelMasked.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithRolesAtMethodLevelMasked.scala
@@ -36,7 +36,7 @@ class GivenAWadlWithRolesAtMethodLevelMasked extends FlatSpec with RaxRolesBehav
               <representation mediaType="application/xml"/>
             </request>
           </method>
-          <method name="GET" rax:roles="a:observer">
+          <method name="GET" rax:roles="a:observer b:test&#xA0;with&#xA0;space">
             <request>
               <representation mediaType="application/xml"/>
             </request>
@@ -46,7 +46,7 @@ class GivenAWadlWithRolesAtMethodLevelMasked extends FlatSpec with RaxRolesBehav
               <representation mediaType="application/xml"/>
             </request>
           </method>
-          <method name="DELETE" rax:roles="a:observer a:admin">
+          <method name="DELETE" rax:roles="a:observer a:admin b:test with space">
             <request>
               <representation mediaType="application/xml"/>
             </request>
@@ -114,6 +114,11 @@ class GivenAWadlWithRolesAtMethodLevelMasked extends FlatSpec with RaxRolesBehav
   it should behave like methodNotAllowed(validator, "GET", "/a", List("a:admin"), description, List("does not match", "'DELETE|POST|PUT'"))
   it should behave like methodNotAllowedWhenNoXRoles(validator, "GET", "/a", description, List("does not match", "'PUT'"))
 
+  // GET on /a requires 'b:test with space' role
+  it should behave like accessIsAllowed(validator, "GET", "/a", List("b:test with space"), description)
+  it should behave like accessIsAllowed(validator, "GET", "/a", List("b:test with space", "a:bar"), description)
+
+
   // POST on /b requires admin role
   it should behave like accessIsAllowed(validator, "POST", "/b", List("a:admin"), description)
   it should behave like accessIsAllowed(validator, "POST", "/b", List("a:observer", "a:admin"), description)
@@ -155,8 +160,13 @@ class GivenAWadlWithRolesAtMethodLevelMasked extends FlatSpec with RaxRolesBehav
   it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:admin", "a:bar"), description)
   it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:bar", "a:admin"), description)
   it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:observer", "a:admin"), description)
+  it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:bar", "b:test with space"), description)
+  it should behave like accessIsAllowed(validator, "DELETE", "/a", List("b:test with space","a:bar"), description)
+  it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:observer", "b:test with space"), description)
+  it should behave like accessIsAllowed(validator, "DELETE", "/a", List("a:observer", "b:test with space", "a:admin"), description)
   it should behave like methodNotAllowed(validator, "DELETE", "/a", List(), description, List("does not match", "'PUT'"))
   it should behave like methodNotAllowed(validator, "DELETE", "/a", List("a:bar"), description, List("does not match", "'PUT'"))
+  it should behave like methodNotAllowed(validator, "DELETE", "/a", List("b:test  with space"), description, List("does not match", "'PUT'")) //extra space!
   it should behave like methodNotAllowed(validator, "DELETE", "/a", List("a:bar", "a:jawsome"), description, List("does not match", "'PUT'"))
   it should behave like methodNotAllowed(validator, "DELETE", "/a", List("observer", "creator"), description, List("does not match", "'PUT'"))
   it should behave like methodNotAllowedWhenNoXRoles(validator, "DELETE", "/a", description, List("does not match", "'PUT'"))


### PR DESCRIPTION
Support is added through the use of nonbreaking spaces.  Simply input
a nonbreaking space, in the place where the role name should have a
space. The easiest way to do this is to use the entity &amp;#xA0; but you
can also input nonbreaking spaces directily into the WADL...see:

https://en.wikipedia.org/wiki/Non-breaking_space#Keyboard_entry_methods