### PR TITLE
Bring back ignored test that was disabled due to wadl-tools.

### DIFF
--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerSpec.scala
@@ -334,7 +334,7 @@ class WADLCheckerSpec extends BaseCheckerSpec {
       singlePathAssertions(checker)
     }
 
-    ignore("The WADL contains a single multi-path resource ending in /") {
+    scenario("The WADL contains a single multi-path resource ending in /") {
       Given("a WADL that contains a single multi-path resource with a GET, DELETE, and POST method and ending in /")
       val inWADL =
         <application xmlns="http://wadl.dev.java.net/2009/02">


### PR DESCRIPTION
The problem with WADL-Tools was resolved in the last release, so we no
longer need to ignore this test.