### PR TITLE
Init move to new wadl-tools.

### DIFF
--- a/core/src/main/resources/xsl/builder.xsl
+++ b/core/src/main/resources/xsl/builder.xsl
@@ -438,7 +438,7 @@
         </xsl:if>
     </xsl:template>
     
-    <xsl:template match="wadl:resource">
+    <xsl:template match="wadl:resource[@path]">
         <xsl:variable name="haveHeaders" as="xsd:boolean"
                       select="check:haveHeaders(.)"/>
         <xsl:variable name="nextSteps" as="xsd:string*">
@@ -1152,7 +1152,7 @@
         
     <xsl:function name="check:getNextURLLinks" as="xsd:string*">
         <xsl:param name="from" as="node()"/>
-        <xsl:sequence select="for $r in $from/wadl:resource return
+        <xsl:sequence select="for $r in $from/wadl:resource[@path] return
             if ($r/@path = '/') then
             (check:getNextURLLinks($r))
             else if (xsd:boolean($r/@rax:invisible)) then

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <scala.test.version>2.0</scala.test.version>
         <scala.uri.version>0.4.2</scala.uri.version>
         <junit.version>4.10</junit.version>
-        <wadl-tools.version>1.0.31</wadl-tools.version>
+        <wadl-tools.version>1.0.32</wadl-tools.version>
         <xmlsec.version>1.4.6</xmlsec.version>
         <xerces.version>2.12.1-rax</xerces.version>
         <servlet.version>3.1</servlet.version>


### PR DESCRIPTION
Update to use the latest wadl-tools.  This fixes two issues:

1. double slash (//) on the root resources caused problems when there was a method associated with it
2. A wadl with no resources was not handled correctly

