### PR TITLE
REP-3222 Upgrade to Scala v2.11

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -21,7 +21,7 @@
     </modules>
 
     <properties>
-        <argot.version>1.0.1</argot.version>
+        <argot.version>1.0.4</argot.version>
         <slf4j.version>1.7.7</slf4j.version>
         <log4j.version>2.1</log4j.version>
     </properties>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -34,7 +34,7 @@
         </dependency>
         <dependency>
             <groupId>org.clapper</groupId>
-            <artifactId>argot_2.10</artifactId>
+            <artifactId>argot_${scala.major}.${scala.minor}</artifactId>
             <version>${argot.version}</version>
         </dependency>
         <dependency>

--- a/cli/wadl2checker/pom.xml
+++ b/cli/wadl2checker/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                  <groupId>net.alchim31.maven</groupId>
                  <artifactId>scala-maven-plugin</artifactId>
-                 <version>3.1.3</version>
+                 <version>3.2.0</version>
                  <configuration>
                     <args>
                         <arg>-unchecked</arg>

--- a/cli/wadl2dot/pom.xml
+++ b/cli/wadl2dot/pom.xml
@@ -23,7 +23,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.1.3</version>
+                <version>3.2.0</version>
                 <configuration>
                     <args>
                         <arg>-unchecked</arg>

--- a/cli/wadltest/pom.xml
+++ b/cli/wadltest/pom.xml
@@ -40,7 +40,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.1.3</version>
+                <version>3.2.0</version>
                 <configuration>
                     <args>
                         <arg>-unchecked</arg>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.1.3</version>
+                <version>3.2.0</version>
                 <configuration>
                     <args>
                         <arg>-unchecked</arg>

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
@@ -18,7 +18,7 @@ package com.rackspace.com.papi.components.checker
 import com.rackspace.com.papi.components.checker.handler.{ResultHandler, ServletResultHandler}
 
 import scala.annotation.StaticAnnotation
-import scala.reflect.BeanProperty
+import scala.beans.BeanProperty
 import scala.reflect.runtime.universe
 import scala.xml._
 

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Validator.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Validator.scala
@@ -26,7 +26,7 @@ import javax.xml.transform.sax._
 import javax.xml.transform.stream._
 
 import com.codahale.metrics.RatioGauge.Ratio
-import com.codahale.metrics.{MetricRegistry, RatioGauge}
+import com.codahale.metrics.{JmxReporter, MetricRegistry, RatioGauge}
 import com.rackspace.com.papi.components.checker.handler.ResultHandler
 import com.rackspace.com.papi.components.checker.servlet._
 import com.rackspace.com.papi.components.checker.step.base.{Step, StepContext}
@@ -43,6 +43,8 @@ import scala.util.Try
 object Validator {
   /** The application wide metrics registry. */
   val metricRegistry = new com.codahale.metrics.MetricRegistry()
+  val reporter = JmxReporter.forRegistry(metricRegistry).inDomain(getClass.getPackage.getName).build()
+  reporter.start()
 
   def apply (name : String, startStep : Step, config : Config) : Validator = {
     val validator = new Validator(name, startStep, config)

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Validator.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Validator.scala
@@ -31,7 +31,7 @@ import com.rackspace.com.papi.components.checker.handler.ResultHandler
 import com.rackspace.com.papi.components.checker.servlet._
 import com.rackspace.com.papi.components.checker.step.base.{Step, StepContext}
 import com.rackspace.com.papi.components.checker.step.results.Result
-import com.rackspace.com.papi.components.checker.util.{Instrumented, IdentityTransformPool, JmxObjectNameFactory}
+import com.rackspace.com.papi.components.checker.util.{IdentityTransformPool, Instrumented, JmxObjectNameFactory}
 import com.rackspace.com.papi.components.checker.wadl.{StepBuilder, WADLDotBuilder}
 import org.apache.commons.codec.digest.DigestUtils.sha1Hex
 import org.w3c.dom.Document
@@ -169,12 +169,10 @@ class Validator private (private val _name : String, val startStep : Step, val c
 
   private val timer = metricRegistry.timer(MetricRegistry.name(getRegistryClassName(getClass), name, TIMER_NAME))
   private val failMeter = metricRegistry.meter(MetricRegistry.name(getRegistryClassName(getClass), name, FAIL_METER_NAME, FAIL_METER_EVENT))
-  guard[ValidatorFailGauge](() => {
-    metricRegistry.register(
-      MetricRegistry.name(getRegistryClassName(getClass), name, FAIL_RATE_NAME),
-      new ValidatorFailGauge(timer, failMeter)
-    )
-  })
+  gaugeOrAdd(
+    MetricRegistry.name(getRegistryClassName(getClass), name, FAIL_RATE_NAME),
+    new ValidatorFailGauge(timer, failMeter)
+  )
 
   private val resultHandler = {
     if (config == null) {

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Validator.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Validator.scala
@@ -107,8 +107,8 @@ class Validator private (private val _name : String, val startStep : Step, val c
 
 
   private val platformMBeanServer = ManagementFactory.getPlatformMBeanServer()
-  private val objectName = new ObjectName("\"com.rackspace.com.papi.components.checker\":type=\"Validator\",scope=\""+
-                                 name+"\",name=\"checker\"")
+  private val objectName = new ObjectName("com.rackspace.com.papi.components.checker:type=Validator,scope="+
+                                 name+",name=checker")
 
   private val TIMER_NAME       = "validation-timer"
   private val FAIL_METER_NAME  = "fail-meter"
@@ -167,11 +167,11 @@ class Validator private (private val _name : String, val startStep : Step, val c
     override def getRatio: Ratio = Ratio.of(failMeter.oneMinuteRate, timer.oneMinuteRate)
   }
 
-  private val timer = metrics.timer(TIMER_NAME, name)
-  private val failMeter = metrics.meter(MetricRegistry.name(FAIL_METER_NAME, FAIL_METER_EVENT, name))
+  private val timer = metrics.timer(name, TIMER_NAME)
+  private val failMeter = metrics.meter(MetricRegistry.name(name, FAIL_METER_NAME, FAIL_METER_EVENT))
   Try {
     metricRegistry.register(
-      MetricRegistry.name(getClass, FAIL_RATE_NAME, name),
+      MetricRegistry.name(getClass, name, FAIL_RATE_NAME),
       new ValidatorFailGauge(timer, failMeter)
     )
   } recover {
@@ -210,9 +210,9 @@ class Validator private (private val _name : String, val startStep : Step, val c
       platformMBeanServer.unregisterMBean(objectName)
     }
 
-    metricRegistry.remove(MetricRegistry.name(getClass, TIMER_NAME, name))
-    metricRegistry.remove(MetricRegistry.name(getClass, FAIL_METER_NAME, name))
-    metricRegistry.remove(MetricRegistry.name(getClass, FAIL_RATE_NAME, name))
+    metricRegistry.remove(MetricRegistry.name(getClass, name, TIMER_NAME))
+    metricRegistry.remove(MetricRegistry.name(getClass, name, FAIL_METER_NAME))
+    metricRegistry.remove(MetricRegistry.name(getClass, name, FAIL_RATE_NAME))
   }
 
   //

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/handler/ApiCoverageHandler.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/handler/ApiCoverageHandler.scala
@@ -21,11 +21,10 @@ import javax.servlet.FilterChain
 import com.rackspace.com.papi.components.checker.Validator
 import com.rackspace.com.papi.components.checker.servlet.{CheckerServletRequest, CheckerServletResponse}
 import com.rackspace.com.papi.components.checker.step.results.Result
-import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.slf4j.LoggerFactory
 import org.w3c.dom.Document
 
-class ApiCoverageHandler extends ResultHandler with LazyLogging {
+class ApiCoverageHandler extends ResultHandler {
   val coverageLogger = LoggerFactory.getLogger("api-coverage-logger")
 
   override def init(validator: Validator, checker: Option[Document]): Unit = {}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/handler/InstrumentedHandler.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/handler/InstrumentedHandler.scala
@@ -17,15 +17,16 @@ package com.rackspace.com.papi.components.checker.handler
 
 import java.lang.management._
 import java.net.URLDecoder
-import java.util.{Collections, LinkedHashMap}
 import java.util.concurrent.atomic.AtomicLong
+import java.util.{Collections, LinkedHashMap}
 import javax.management._
 import javax.servlet.FilterChain
 
-import com.rackspace.com.papi.components.checker.Validator
+import com.codahale.metrics.MetricRegistry
 import com.rackspace.com.papi.components.checker.servlet._
 import com.rackspace.com.papi.components.checker.step.results.{MismatchResult, MultiFailResult, Result}
-import com.yammer.metrics.scala.{Instrumented, Meter}
+import com.rackspace.com.papi.components.checker.{Instrumented, Validator}
+import nl.grons.metrics.scala.Meter
 import org.w3c.dom.{Document, Element}
 
 class InstrumentedHandler extends ResultHandler with Instrumented with InstrumentedHandlerMBean {
@@ -58,7 +59,7 @@ class InstrumentedHandler extends ResultHandler with Instrumented with Instrumen
         val id = elm.getAttribute("id")
         val etype = elm.getAttribute("type")
 
-        stepMeters = stepMeters + (id -> metrics.meter(id, etype, validator.name))
+        stepMeters = stepMeters + (id -> metrics.meter(MetricRegistry.name(id, etype, validator.name)))
       }
     }
 
@@ -111,7 +112,7 @@ class InstrumentedHandler extends ResultHandler with Instrumented with Instrumen
     }
 
     if (validator.isDefined) {
-      stepMeters.keys.foreach ( k => metricsRegistry.removeMetric(getClass, k, validator.get.name))
+      stepMeters.keys.foreach(k => metricRegistry.remove(MetricRegistry.name(getClass, k, validator.get.name)))
       validator = None
       stepMeters = Map.empty
     }

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/handler/InstrumentedHandler.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/handler/InstrumentedHandler.scala
@@ -59,15 +59,15 @@ class InstrumentedHandler extends ResultHandler with Instrumented with Instrumen
         val id = elm.getAttribute("id")
         val etype = elm.getAttribute("type")
 
-        stepMeters = stepMeters + (id -> metrics.meter(MetricRegistry.name(id, etype, validator.name)))
+        stepMeters = stepMeters + (id -> metrics.meter(MetricRegistry.name(validator.name, id)))
       }
     }
 
     //
     // Register the MBean
     //
-    latestFailMBeanName = Some(new ObjectName("\"com.rackspace.com.papi.components.checker.handler\":type=\"InstrumentedHandler\",scope=\""+
-                                   validator.name+"\",name=\"latestFails\""))
+    latestFailMBeanName = Some(new ObjectName("com.rackspace.com.papi.components.checker.handler:type=InstrumentedHandler,scope="+
+                                   validator.name+",name=latestFails"))
     platformMBeanServer.registerMBean(this,latestFailMBeanName.get)
   }
 
@@ -112,7 +112,7 @@ class InstrumentedHandler extends ResultHandler with Instrumented with Instrumen
     }
 
     if (validator.isDefined) {
-      stepMeters.keys.foreach(k => metricRegistry.remove(MetricRegistry.name(getClass, k, validator.get.name)))
+      stepMeters.keys.foreach(k => metricRegistry.remove(MetricRegistry.name(getClass, validator.get.name, k)))
       validator = None
       stepMeters = Map.empty
     }

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/IdentityTransformPool.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/IdentityTransformPool.scala
@@ -17,7 +17,7 @@ package com.rackspace.com.papi.components.checker.util
 
 import javax.xml.transform.{Transformer, TransformerFactory}
 
-import com.yammer.metrics.scala.Instrumented
+import com.rackspace.com.papi.components.checker.Instrumented
 import org.apache.commons.pool.PoolableObjectFactory
 import org.apache.commons.pool.impl.SoftReferenceObjectPool
 

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/Instrumented.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/Instrumented.scala
@@ -1,0 +1,62 @@
+package com.rackspace.com.papi.components.checker.util
+
+import com.codahale.metrics.{Gauge, Metric, MetricFilter, MetricRegistry}
+import com.rackspace.com.papi.components.checker.Validator
+import com.typesafe.scalalogging.slf4j.LazyLogging
+
+/**
+  * @see nl.grons.metrics.scala.InstrumentedBuilder
+  */
+trait Instrumented extends LazyLogging {
+  /** The base name for all metrics created from this builder. */
+  val metricBaseName = Validator.metricDomain
+
+  /**
+    * The MetricRegistry where created metrics are registered.
+    */
+  val metricRegistry: MetricRegistry = Validator.metricRegistry
+
+  def getRegistryClassName(clazz: Class[_]): String = {
+    clazz.getName
+      .replace(metricBaseName, "")
+      // @see nl.grons.metrics.scala.MetricName
+      .replaceAllLiterally("$$anonfun", ".")
+      .replaceAllLiterally("$apply", ".")
+      .replaceAll("""\$\d*""", ".")
+      .replaceAllLiterally(".package.", ".")
+      .replaceAll("""^\.""", "")
+      .replaceAll("""\.$""", "")
+  }
+
+  def guard[A](buildMetric: () => A): Option[A] = {
+    try {
+      Some(buildMetric())
+    } catch {
+      case e: IllegalArgumentException =>
+        logger.warn("Failed to add new metric. Reason: {}", e.getMessage)
+        logger.debug("", e)
+        None
+    }
+  }
+
+  /**
+    * @see com.codahale.metrics.MetricRegistry.getOrAdd
+    */
+  def gaugeOrAdd[T](name: String)(f: => T): Gauge[T] = {
+    val gauge = guard[Gauge[T]](() => {
+      metricRegistry.register(name, new Gauge[T] {
+        def getValue: T = f
+      })
+    })
+    if (gauge.isDefined) {
+      gauge.get
+    } else {
+      metricRegistry.getGauges(new MetricFilter() {
+        override def matches(filterName: String, metric: Metric): Boolean = {
+          filterName.equals(name) &&
+            metric.isInstanceOf[Gauge[T]]
+        }
+      }).get(name).asInstanceOf[Gauge[T]]
+    }
+  }
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/JmxObjectNameFactory.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/JmxObjectNameFactory.scala
@@ -1,0 +1,65 @@
+/***
+  *   Copyright 2014 Rackspace US, Inc.
+  *
+  *   Licensed under the Apache License, Version 2.0 (the "License");
+  *   you may not use this file except in compliance with the License.
+  *   You may obtain a copy of the License at
+  *
+  *       http://www.apache.org/licenses/LICENSE-2.0
+  *
+  *   Unless required by applicable law or agreed to in writing, software
+  *   distributed under the License is distributed on an "AS IS" BASIS,
+  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  *   See the License for the specific language governing permissions and
+  *   limitations under the License.
+  */
+package com.rackspace.com.papi.components.checker.util
+
+import javax.management.{MalformedObjectNameException, ObjectName}
+
+import com.codahale.metrics.ObjectNameFactory
+import com.typesafe.scalalogging.slf4j.LazyLogging
+
+class JmxObjectNameFactory extends ObjectNameFactory with LazyLogging {
+  override def createName(`type`: String, domain: String, name: String): ObjectName = {
+    try {
+      val nameDot = name.lastIndexOf('.')
+      val nameVal = name.substring(nameDot+1)
+      val scopeDot = name.substring(0, nameDot).lastIndexOf('.')
+      val scopeVal = name.substring(scopeDot+1, nameDot)
+      val typeVal = name.substring(0, scopeDot)
+      val nameBuilder = new StringBuilder(domain)
+      nameBuilder.append(':')
+      if(!typeVal.isEmpty) {
+        nameBuilder.append("type=")
+        nameBuilder.append(typeVal)
+        nameBuilder.append(',')
+      }
+      if(!scopeVal.isEmpty) {
+        nameBuilder.append("scope=")
+        nameBuilder.append(scopeVal)
+        nameBuilder.append(',')
+      }
+      nameBuilder.append("name=")
+      nameBuilder.append(nameVal)
+
+      val objectName: ObjectName = new ObjectName(nameBuilder.toString())
+      if (objectName.isPattern) {
+        new ObjectName(domain, "name", ObjectName.quote(name))
+      } else {
+        objectName
+      }
+    }
+    catch {
+      case e: MalformedObjectNameException =>
+        try {
+          new ObjectName(domain, "name", ObjectName.quote(name))
+        }
+        catch {
+          case e1: MalformedObjectNameException =>
+            logger.warn("Unable to register {}.{}", domain, name, e1)
+            throw new RuntimeException(e1)
+        }
+    }
+  }
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/ObjectMapperPool.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/ObjectMapperPool.scala
@@ -15,29 +15,19 @@
  */
 package com.rackspace.com.papi.components.checker.util
 
+import com.codahale.metrics.MetricRegistry
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.rackspace.com.papi.components.checker.Instrumented
-import com.typesafe.scalalogging.slf4j.LazyLogging
-
-import scala.util.Try
 
 /*
  * Actually, this is only a pool for legacy reasons.
  * we converted from JSONSimple to Jackson and Jackson
  * has a threadsafe object mapper.
  */
-object ObjectMapperPool extends Instrumented with LazyLogging {
+object ObjectMapperPool extends Instrumented {
   private val om = new ObjectMapper()
-  Try {
-    metrics.gauge("Active")(numActive)
-  } recover {
-    case e: RuntimeException => logger.info("Problem adding new Active gauge metric.", e)
-  }
-  Try {
-    metrics.gauge("Idle")(numIdle)
-  } recover {
-    case e: RuntimeException => logger.info("Problem adding new Idle gauge metric.", e)
-  }
+  val registryClassName = getRegistryClassName(getClass)
+  gaugeOrAdd(MetricRegistry.name(registryClassName, "Active"))(numActive)
+  gaugeOrAdd(MetricRegistry.name(registryClassName, "Idle"))(numIdle)
 
   def borrowParser : ObjectMapper = om
   def returnParser (parser : ObjectMapper) : Unit = {}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/ObjectMapperPool.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/ObjectMapperPool.scala
@@ -16,7 +16,7 @@
 package com.rackspace.com.papi.components.checker.util
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.yammer.metrics.scala.Instrumented
+import com.rackspace.com.papi.components.checker.Instrumented
 
 /*
  * Actually, this is only a pool for legacy reasons.

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/TransformPool.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/TransformPool.scala
@@ -17,10 +17,10 @@ package com.rackspace.com.papi.components.checker.util
 
 import javax.xml.transform.{Templates, Transformer}
 
-import com.yammer.metrics.core.Gauge
-import com.yammer.metrics.scala.Instrumented
+import com.rackspace.com.papi.components.checker.Instrumented
 import net.sf.saxon.Controller
 import net.sf.saxon.serialize.MessageWarner
+import nl.grons.metrics.scala.Gauge
 import org.apache.commons.pool.PoolableObjectFactory
 import org.apache.commons.pool.impl.SoftReferenceObjectPool
 

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/ValidatorHandlerPool.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/ValidatorHandlerPool.scala
@@ -17,9 +17,9 @@ package com.rackspace.com.papi.components.checker.util
 
 import javax.xml.validation.{Schema, ValidatorHandler}
 
+import com.rackspace.com.papi.components.checker.Instrumented
 import com.saxonica.jaxp.SchemaReference
-import com.yammer.metrics.core.Gauge
-import com.yammer.metrics.scala.Instrumented
+import nl.grons.metrics.scala.Gauge
 import org.apache.commons.pool.PoolableObjectFactory
 import org.apache.commons.pool.impl.SoftReferenceObjectPool
 

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/ValidatorPool.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/ValidatorPool.scala
@@ -17,9 +17,9 @@ package com.rackspace.com.papi.components.checker.util
 
 import javax.xml.validation.{Schema, Validator}
 
+import com.rackspace.com.papi.components.checker.Instrumented
 import com.saxonica.jaxp.SchemaReference
-import com.yammer.metrics.core.Gauge
-import com.yammer.metrics.scala.Instrumented
+import nl.grons.metrics.scala.Gauge
 import org.apache.commons.pool.PoolableObjectFactory
 import org.apache.commons.pool.impl.SoftReferenceObjectPool
 

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/XMLParserPool.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/XMLParserPool.scala
@@ -18,7 +18,7 @@ package com.rackspace.com.papi.components.checker.util
 import javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING
 import javax.xml.parsers.{DocumentBuilder, DocumentBuilderFactory}
 
-import com.yammer.metrics.scala.Instrumented
+import com.rackspace.com.papi.components.checker.Instrumented
 import org.apache.commons.pool.PoolableObjectFactory
 import org.apache.commons.pool.impl.SoftReferenceObjectPool
 

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/XPathExpressionPool.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/XPathExpressionPool.scala
@@ -18,8 +18,8 @@ package com.rackspace.com.papi.components.checker.util
 import javax.xml.namespace.NamespaceContext
 import javax.xml.xpath.XPathExpression
 
-import com.yammer.metrics.core.Gauge
-import com.yammer.metrics.scala.Instrumented
+import com.rackspace.com.papi.components.checker.Instrumented
+import nl.grons.metrics.scala.Gauge
 import org.apache.commons.pool.PoolableObjectFactory
 import org.apache.commons.pool.impl.SoftReferenceObjectPool
 

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/handler/InstrumentedHandlerSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/handler/InstrumentedHandlerSuite.scala
@@ -86,7 +86,7 @@ class InstrumentedHandlerSuite extends BaseValidatorSuite {
   val platformMBeanServer = ManagementFactory.getPlatformMBeanServer()
 
   def getStepObjectName (stepId : String) : ObjectName = {
-    new ObjectName("\"com.rackspace.com.papi.components.checker.handler\":type=\"InstrumentedHandler\",scope=\"MyInstTestValidator\",name=\""+stepId+"\"")
+    new ObjectName("com.rackspace.com.papi.components.checker:name=com.rackspace.com.papi.components.checker.handler.InstrumentedHandler.MyInstTestValidator."+stepId)
   }
 
   def getStepCount (stepId : String) : Long = {

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/handler/InstrumentedHandlerSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/handler/InstrumentedHandlerSuite.scala
@@ -86,7 +86,7 @@ class InstrumentedHandlerSuite extends BaseValidatorSuite {
   val platformMBeanServer = ManagementFactory.getPlatformMBeanServer()
 
   def getStepObjectName (stepId : String) : ObjectName = {
-    new ObjectName("com.rackspace.com.papi.components.checker:name=com.rackspace.com.papi.components.checker.handler.InstrumentedHandler.MyInstTestValidator."+stepId)
+    new ObjectName(s"com.rackspace.com.papi.components.checker:type=handler.InstrumentedHandler,scope=MyInstTestValidator,name=$stepId")
   }
 
   def getStepCount (stepId : String) : Long = {

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,11 @@
     </distributionManagement>
 
     <properties>
-        <scala.version>2.10.3</scala.version>
-        <scala.dep.version>2.10</scala.dep.version>
+        <scala.major>2</scala.major>
+        <scala.minor>11</scala.minor>
+        <scala.patch>7</scala.patch>
         <saxon-ee.version>9.4.0.9</saxon-ee.version>
-        <scala.test.version>2.0</scala.test.version>
+        <scala.test.version>2.2.6</scala.test.version>
         <scala.uri.version>0.4.2</scala.uri.version>
         <junit.version>4.10</junit.version>
         <wadl-tools.version>1.0.32</wadl-tools.version>
@@ -58,7 +59,7 @@
         <pool.version>1.6</pool.version>
         <codec.version>1.7</codec.version>
         <xalan.version>2.7.1</xalan.version>
-        <metrics-scala.version>2.2.0</metrics-scala.version>
+        <metrics-scala.version>3.5.2_a2.3</metrics-scala.version>
         <jackson-databind.version>2.2.3</jackson-databind.version>
         <json-schema-validator.version>2.1.7</json-schema-validator.version>
         <scala-logging.version>2.1.2</scala-logging.version>
@@ -71,7 +72,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.version}</version>
+            <version>${scala.major}.${scala.minor}.${scala.patch}</version>
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>
@@ -106,17 +107,17 @@
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.10</artifactId>
+            <artifactId>scalatest_${scala.major}.${scala.minor}</artifactId>
             <version>${scala.test.version}</version>
         </dependency>
         <dependency>
             <groupId>com.netaporter</groupId>
-            <artifactId>scala-uri_2.10</artifactId>
+            <artifactId>scala-uri_${scala.major}.${scala.minor}</artifactId>
             <version>${scala.uri.version}</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.cloud.api</groupId>
-            <artifactId>wadl-tools_2.10</artifactId>
+            <artifactId>wadl-tools_${scala.major}.${scala.minor}</artifactId>
             <version>${wadl-tools.version}</version>
         </dependency>
         <dependency>
@@ -134,14 +135,14 @@
              <artifactId>javax.servlet</artifactId>
              <version>${servlet.version}</version>
          </dependency>
-         <dependency>
+        <dependency>
              <groupId>nl.grons</groupId>
-             <artifactId>metrics-scala_${scala.dep.version}</artifactId>
+             <artifactId>metrics-scala_${scala.major}.${scala.minor}</artifactId>
              <version>${metrics-scala.version}</version>
          </dependency>
         <dependency>
             <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging-slf4j_2.10</artifactId>
+            <artifactId>scala-logging-slf4j_${scala.major}.${scala.minor}</artifactId>
             <version>${scala-logging.version}</version>
         </dependency>
         <dependency>
@@ -182,7 +183,7 @@
         </dependency>
         <dependency>
             <groupId>com.rackspace.cloud.api</groupId>
-            <artifactId>wadl-tools_2.10</artifactId>
+            <artifactId>wadl-tools_${scala.major}.${scala.minor}</artifactId>
             <version>${wadl-tools.version}</version>
             <type>test-jar</type>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -142,11 +142,6 @@
             <version>${metrics-core.version}</version>
         </dependency>
         <dependency>
-             <groupId>nl.grons</groupId>
-             <artifactId>metrics-scala_${scala.major}.${scala.minor}</artifactId>
-             <version>${metrics-scala.version}</version>
-         </dependency>
-        <dependency>
             <groupId>com.typesafe.scala-logging</groupId>
             <artifactId>scala-logging-slf4j_${scala.major}.${scala.minor}</artifactId>
             <version>${scala-logging.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <pool.version>1.6</pool.version>
         <codec.version>1.7</codec.version>
         <xalan.version>2.7.1</xalan.version>
+        <metrics-core.version>3.1.2</metrics-core.version>
         <metrics-scala.version>3.5.2_a2.3</metrics-scala.version>
         <jackson-databind.version>2.2.3</jackson-databind.version>
         <json-schema-validator.version>2.1.7</json-schema-validator.version>
@@ -135,6 +136,11 @@
              <artifactId>javax.servlet</artifactId>
              <version>${servlet.version}</version>
          </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${metrics-core.version}</version>
+        </dependency>
         <dependency>
              <groupId>nl.grons</groupId>
              <artifactId>metrics-scala_${scala.major}.${scala.minor}</artifactId>


### PR DESCRIPTION
**NOTE:** The old yammer `metrics.gauge` did not care if there was already a metric with the same name, it just passively went on with life. The new `dropwizard`/`codahale`/`nl.grons` version now throws a `RuntimeException`. Currently this is being handled by logging the fact at the `INFO` level. This could be ignored or made less verbose. However, this is the exceptional case and should not usually be hit outside of testing. The other alternative would be to add a deconstructor to each of the pools and have them usregister the gauges that were registered upon helper object instantiation.