### PR TITLE
REP-3166 publish usable snapshot

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -34,7 +34,7 @@
         </dependency>
         <dependency>
             <groupId>org.clapper</groupId>
-            <artifactId>argot_${scala.major}.${scala.minor}</artifactId>
+            <artifactId>argot_${scala.MajDotMin}</artifactId>
             <version>${argot.version}</version>
         </dependency>
         <dependency>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>api-checker</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.api-checker</groupId>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.rackspace.papi.components.api-checker</groupId>
             <artifactId>checker-core</artifactId>
-            <version>1.1.5-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.clapper</groupId>

--- a/cli/wadl2checker/pom.xml
+++ b/cli/wadl2checker/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.api-checker</groupId>
         <artifactId>cli</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.api-checker.cli</groupId>

--- a/cli/wadl2checker/pom.xml
+++ b/cli/wadl2checker/pom.xml
@@ -21,10 +21,10 @@
         <testSourceDirectory>src/test/scala</testSourceDirectory>
         <plugins>
             <plugin>
-                 <groupId>net.alchim31.maven</groupId>
-                 <artifactId>scala-maven-plugin</artifactId>
-                 <version>3.2.0</version>
-                 <configuration>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
                     <args>
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
@@ -42,39 +42,39 @@
                 </executions>
             </plugin>
             <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-shade-plugin</artifactId>
-              <version>2.1</version>
-              <inherited>false</inherited>
-              <executions>
-                <execution>
-                  <phase>package</phase>
-                  <goals>
-                    <goal>shade</goal>
-                  </goals>
-                  <configuration>
-                    <minimizeJar>false</minimizeJar>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
-                    <transformers>
-                      <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                        <mainClass>com.rackspace.com.papi.components.checker.cli.Wadl2Checker</mainClass>
-                      </transformer>
-                    </transformers>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                  </configuration>
-                </execution>
-              </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.1</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <minimizeJar>false</minimizeJar>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.rackspace.com.papi.components.checker.cli.Wadl2Checker</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/cli/wadl2dot/pom.xml
+++ b/cli/wadl2dot/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.api-checker</groupId>
         <artifactId>cli</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.api-checker.cli</groupId>

--- a/cli/wadl2dot/pom.xml
+++ b/cli/wadl2dot/pom.xml
@@ -42,39 +42,39 @@
                 </executions>
             </plugin>
             <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-shade-plugin</artifactId>
-              <version>2.1</version>
-              <inherited>false</inherited>
-              <executions>
-                <execution>
-                  <phase>package</phase>
-                  <goals>
-                    <goal>shade</goal>
-                  </goals>
-                  <configuration>
-                    <minimizeJar>false</minimizeJar>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
-                    <transformers>
-                      <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                        <mainClass>com.rackspace.com.papi.components.checker.cli.Wadl2Dot</mainClass>
-                      </transformer>
-                    </transformers>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                  </configuration>
-                </execution>
-              </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.1</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <minimizeJar>false</minimizeJar>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.rackspace.com.papi.components.checker.cli.Wadl2Dot</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/cli/wadltest/pom.xml
+++ b/cli/wadltest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.components.api-checker</groupId>
         <artifactId>cli</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.api-checker.cli</groupId>

--- a/cli/wadltest/pom.xml
+++ b/cli/wadltest/pom.xml
@@ -17,20 +17,20 @@
     </description>
 
     <properties>
-      <jetty.version>9.2.13.v20150730</jetty.version>
+        <jetty.version>9.2.13.v20150730</jetty.version>
     </properties>
 
     <dependencies>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -59,39 +59,39 @@
                 </executions>
             </plugin>
             <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-shade-plugin</artifactId>
-              <version>2.1</version>
-              <inherited>false</inherited>
-              <executions>
-                <execution>
-                  <phase>package</phase>
-                  <goals>
-                    <goal>shade</goal>
-                  </goals>
-                  <configuration>
-                    <minimizeJar>false</minimizeJar>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                    <shadedArtifactAttached>true</shadedArtifactAttached>
-                    <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
-                    <transformers>
-                      <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                        <mainClass>com.rackspace.com.papi.components.checker.cli.WadlTest</mainClass>
-                      </transformer>
-                    </transformers>
-                    <filters>
-                        <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                  </configuration>
-                </execution>
-              </executions>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.1</version>
+                <inherited>false</inherited>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <minimizeJar>false</minimizeJar>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.rackspace.com.papi.components.checker.cli.WadlTest</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.rackspace.papi.components</groupId>
         <artifactId>api-checker</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.rackspace.papi.components.api-checker</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <scala.major>2</scala.major>
         <scala.minor>11</scala.minor>
         <scala.patch>7</scala.patch>
+        <scala.MajDotMin>${scala.major}.${scala.minor}</scala.MajDotMin>
         <saxon-ee.version>9.4.0.9</saxon-ee.version>
         <scala.test.version>2.2.6</scala.test.version>
         <scala.uri.version>0.4.2</scala.uri.version>
@@ -73,7 +74,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scala.major}.${scala.minor}.${scala.patch}</version>
+            <version>${scala.MajDotMin}.${scala.patch}</version>
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>
@@ -108,17 +109,17 @@
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_${scala.major}.${scala.minor}</artifactId>
+            <artifactId>scalatest_${scala.MajDotMin}</artifactId>
             <version>${scala.test.version}</version>
         </dependency>
         <dependency>
             <groupId>com.netaporter</groupId>
-            <artifactId>scala-uri_${scala.major}.${scala.minor}</artifactId>
+            <artifactId>scala-uri_${scala.MajDotMin}</artifactId>
             <version>${scala.uri.version}</version>
         </dependency>
         <dependency>
             <groupId>com.rackspace.cloud.api</groupId>
-            <artifactId>wadl-tools_${scala.major}.${scala.minor}</artifactId>
+            <artifactId>wadl-tools_${scala.MajDotMin}</artifactId>
             <version>${wadl-tools.version}</version>
         </dependency>
         <dependency>
@@ -143,7 +144,7 @@
         </dependency>
         <dependency>
             <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging-slf4j_${scala.major}.${scala.minor}</artifactId>
+            <artifactId>scala-logging-slf4j_${scala.MajDotMin}</artifactId>
             <version>${scala-logging.version}</version>
         </dependency>
         <dependency>
@@ -184,7 +185,7 @@
         </dependency>
         <dependency>
             <groupId>com.rackspace.cloud.api</groupId>
-            <artifactId>wadl-tools_${scala.major}.${scala.minor}</artifactId>
+            <artifactId>wadl-tools_${scala.MajDotMin}</artifactId>
             <version>${wadl-tools.version}</version>
             <type>test-jar</type>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rackspace.papi.components</groupId>
     <artifactId>api-checker</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>API Checker</name>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <scm>
         <connection>scm:git:git@github.com:rackerlabs/api-checker.git</connection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <repositories>
         <repository>
@@ -132,11 +132,11 @@
             <artifactId>commons-codec</artifactId>
             <version>${codec.version}</version>
         </dependency>
-         <dependency>
-             <groupId>org.glassfish</groupId>
-             <artifactId>javax.servlet</artifactId>
-             <version>${servlet.version}</version>
-         </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.servlet</artifactId>
+            <version>${servlet.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>


### PR DESCRIPTION
This is intended to be a usable snapshot that we can start testing Repose with before the final version is released. Since it has breaking features, I went ahead and bumped the version up to v2.