### PR TITLE
Create HEADER_ALL steps.

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -745,6 +745,34 @@
        4. [X] Test capture header with non-repeating headers
        5. [X] Test rax:roles and rax:roles masked along side of
           non-repeating headers
+** DONE Header_All and Header_Any Extension [3/3]
+   1. [X] Header_All [9/9]
+      1. [X] Extend XSD to support HEADER_ALL
+      2. [X] Add support to XSL (essentially replacing default
+         HEADER_ALL support)
+      3. [X] Checker assertions related to HEADER_ALL
+      4. [X] Priority map related to HEADER_ALL
+      5. [X] RaxRoles Mask related to HEADER_ALL
+      6. [X] Ensure that wadl2dot correctly displays HEADER_ALL
+      7. [X] Ensure that optimizations work correctly with HEADER_ALL
+      8. [X] Create new step
+      9. [X] Update handler for new step
+   2. [X] Header_Any Extension [4/4]
+      1. [X] New config option for header_any (defualt to true)
+      2. [X] Update cli tools to support new config option
+      3. [X] Update XSL to support XSL any
+      4. [X] Ensure that rax_roles enables header_any by default
+   3. [X] Testing [6/6]
+      1. [X] Update newly broken tests
+      2. [X] Step
+      3. [X] Builder
+      4. [X] Validator
+      5. [X] capture header
+      6. [X] rax:roles and rax:roles masked with other header_all
+** TODO Document Breaking Changes [0/3]
+   1. [ ] Use of repeating with headers
+   2. [ ] Use of header_all and header_any
+   3. [ ] capture_header and message and code changes
 ** TODO Compile Performance improvements
 ** TODO Assign CONTENT_FAIL to XSL steps in builder
 ** TODO Investigate whether there is an issue with rax:roles with other headers

--- a/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
+++ b/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
@@ -85,6 +85,9 @@ object Wadl2Checker {
   val captureHeader = parser.flag[Boolean] (List("c", "disable-capture-header-ext"),
                                             "Disable capture header extension : false")
 
+  val anyMatch  = parser.flag[Boolean] (List("a", "disable-any-match"),
+                                            "Disable any match extension : false")
+
   val dontValidate = parser.flag[Boolean] (List("D", "dont-validate"),
                                        "Don't validate produced checker Default: false")
 
@@ -158,6 +161,7 @@ object Wadl2Checker {
         c.enableIgnoreJSONSchemaExtension = !ignoreJSON.value.getOrElse(false)
         c.enableMessageExtension = !message.value.getOrElse(false)
         c.enableCaptureHeaderExtension = !captureHeader.value.getOrElse(false)
+        c.enableAnyMatchExtension = !anyMatch.value.getOrElse(false)
         c.xpathVersion = xpathVersion.value.getOrElse(1)
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)

--- a/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
+++ b/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
@@ -85,6 +85,10 @@ object Wadl2Dot {
   val captureHeader = parser.flag[Boolean] (List("c", "disable-capture-header-ext"),
                                             "Disable capture header extension : false")
 
+  val anyMatch  = parser.flag[Boolean] (List("a", "disable-any-match"),
+                                            "Disable any match extension : false")
+
+
   val dontValidate = parser.flag[Boolean] (List("D", "dont-validate"),
                                        "Don't validate produced checker Default: false")
 
@@ -161,6 +165,7 @@ object Wadl2Dot {
         c.enableIgnoreJSONSchemaExtension = !ignoreJSON.value.getOrElse(false)
         c.enableMessageExtension = !message.value.getOrElse(false)
         c.enableCaptureHeaderExtension = !captureHeader.value.getOrElse(false)
+        c.enableAnyMatchExtension = !anyMatch.value.getOrElse(false)
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)
         c.validateChecker = !dontValidate.value.getOrElse(false)

--- a/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
+++ b/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
@@ -92,6 +92,9 @@ object WadlTest {
   val captureHeader = parser.flag[Boolean] (List("c", "disable-capture-header-ext"),
                                             "Disable capture header extension : false")
 
+  val anyMatch  = parser.flag[Boolean] (List("a", "disable-any-match"),
+                                            "Disable any match extension : false")
+
   val dontValidate = parser.flag[Boolean] (List("D", "dont-validate"),
                                        "Don't validate produced checker Default: false")
 
@@ -261,6 +264,7 @@ object WadlTest {
         c.enableIgnoreJSONSchemaExtension = !ignoreJSON.value.getOrElse(false)
         c.enableMessageExtension = !message.value.getOrElse(false)
         c.enableCaptureHeaderExtension = !captureHeader.value.getOrElse(false)
+        c.enableAnyMatchExtension = !anyMatch.value.getOrElse(false)
         c.xpathVersion = xpathVersion.value.getOrElse(1)
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)

--- a/core/src/main/resources/xsd/checker.xsd
+++ b/core/src/main/resources/xsd/checker.xsd
@@ -111,6 +111,7 @@
                 <alternative test="@type eq 'HEADERXSD_SINGLE'" type="chk:HeaderXSDSingleStep"/>
                 <alternative test="@type eq 'HEADER_ANY'" type="chk:HeaderAnyStep"/>
                 <alternative test="@type eq 'HEADERXSD_ANY'" type="chk:HeaderXSDAnyStep"/>
+                <alternative test="@type eq 'HEADER_ALL'" type="chk:HeaderAllStep"/>
                 <alternative test="@type eq 'JSON_SCHEMA'" type="chk:JsonSchemaStep"/>
             </element>
         </sequence>
@@ -425,6 +426,36 @@
         </annotation>
         <complexContent>
             <extension base="chk:HeaderStep"/>
+        </complexContent>
+    </complexType>
+
+    <complexType name="HeaderAllStep">
+        <annotation>
+            <documentation xmlns:html="http://www.w3.org/1999/xhtml">
+                <html:p>
+                    Like HeaderStep, except that all values must match
+                    at least one of the XSD types in the match
+                    attribute OR must match against the optional regex
+                    value.
+                </html:p>
+                <html:p>
+                    Although both match and matchRegEx are optional,
+                    at least one of those attributes should be
+                    specified.
+                </html:p>
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="chk:GenContentFailStep">
+                <attribute name="name" type="xsd:string" use="required"/>
+                <attribute name="match" type="chk:QNameList" use="optional"/>
+                <attribute name="matchRegEx" type="xsd:string" use="optional"/>
+                <attributeGroup ref="chk:MessageAttributes"/>
+                <attributeGroup ref="chk:ToRequestHeaderAttributes"/>
+                <assert test="@match or @matchRegEx"
+                        saxon:message="A HEADER_ALL step must contain a match or matchRegEx attribute."
+                        xerces:message="A HEADER_ALL step must contain a match or matchRegEx attribute."/>
+            </extension>
         </complexContent>
     </complexType>
 
@@ -753,6 +784,7 @@
             <enumeration value="HEADERXSD_ANY"/>
             <enumeration value="HEADER_SINGLE"/>
             <enumeration value="HEADERXSD_SINGLE"/>
+            <enumeration value="HEADER_ALL"/>
             <enumeration value="JSON_SCHEMA"/>
         </restriction>
     </simpleType>

--- a/core/src/main/resources/xsl/checker2dot.xsl
+++ b/core/src/main/resources/xsl/checker2dot.xsl
@@ -151,14 +151,14 @@
                                        <xsl:otherwise>
                                            <xsl:value-of select="substring($nextStep/@type,1,1)"/>
                                            <xsl:choose>
-                                               <xsl:when test="$nextStep/@match">
+                                               <xsl:when test="$nextStep/@match or $nextStep/@matchRegEx">
                                                  <xsl:text> (</xsl:text>
                                                  <xsl:choose>
                                                      <xsl:when test="$nextStep/@name">
-                                                         <xsl:value-of select="concat($nextStep/@name,' : ',check:escapeRegex($nextStep/@match))"/>
+                                                         <xsl:value-of select="concat($nextStep/@name,' : ',check:matchValue($nextStep))"/>
                                                      </xsl:when>
                                                      <xsl:otherwise>
-                                                         <xsl:value-of select="check:escapeRegex($nextStep/@match)"/>
+                                                         <xsl:value-of select="check:matchValue($nextStep)"/>
                                                      </xsl:otherwise>
                                                  </xsl:choose>
                                                  <xsl:text>)</xsl:text>
@@ -170,7 +170,7 @@
                                                          <xsl:value-of select="concat($nextStep/@name,':&#x2190;? ',$nextStep/@value)"/>
                                                      </xsl:when>
                                                      <xsl:otherwise>
-                                                         <xsl:value-of select="check:escapeRegex($nextStep/@match)"/>
+                                                         <xsl:value-of select="check:matchValue($nextStep)"/>
                                                      </xsl:otherwise>
                                                  </xsl:choose>
                                                  <xsl:text>)</xsl:text>
@@ -206,16 +206,16 @@
                          <xsl:value-of select="@id"/>
                      </xsl:when>
                      <xsl:when test="@label">
-                         <xsl:value-of select="concat(check:escapeRegex(@match),' \n(',@label,')')"/>
+                         <xsl:value-of select="concat(check:matchValue(.),' \n(',@label,')')"/>
                      </xsl:when>
-                     <xsl:when test="@name and @match">
-                         <xsl:value-of select="concat(@name,' : ',check:escapeRegex(@match))"/>
+                     <xsl:when test="@name and (@match or @matchRegEx)">
+                         <xsl:value-of select="concat(@name,' : ',check:matchValue(.))"/>
                      </xsl:when>
                      <xsl:when test="@name and @value">
                          <xsl:value-of select="concat(@name,':&#x2190;? ',@value)"/>
                      </xsl:when>
-                     <xsl:when test="@match">
-                         <xsl:value-of select="check:escapeRegex(@match)"/>
+                     <xsl:when test="@match or @matchRegEx">
+                         <xsl:value-of select="check:matchValue(.)"/>
                      </xsl:when>
                      <xsl:when test="@notMatch and @notTypes">
                          <xsl:value-of select="check:notMatchRegex((tokenize(@notMatch,' '), tokenize(@notTypes,' ')))"/>
@@ -347,5 +347,9 @@
            <xsl:value-of select="$shape"/>
            <xsl:text>"]&#x0a;</xsl:text>
        </xsl:value-of>
+   </xsl:function>
+   <xsl:function name="check:matchValue" as="xsd:string">
+     <xsl:param name="step" as="node()"/>
+     <xsl:value-of select="for $m in ($step/@match, $step/@matchRegEx) return check:escapeRegex($m)" separator=" "/>
    </xsl:function>
 </xsl:stylesheet>

--- a/core/src/main/resources/xsl/opt/removeDups-rules.xml
+++ b/core/src/main/resources/xsl/opt/removeDups-rules.xml
@@ -39,6 +39,10 @@
     <rule types="HEADER HEADERXSD HEADER_ANY HEADERXSD_ANY HEADER_SINGLE HEADERXSD_SINGLE" required="next name match" optional="captureHeader code message">
         Rule for Header, HeaderXSD, HeaderAny.
     </rule>
+    <rule types="HEADER_ALL" required="next name" optional="match matchRegEx captureHeader code message">
+        Rule for HEADER_ALL.  Although both match and matchRegEx are
+        optional at least one of these should be specified.
+    </rule>
     <rule types="SET_HEADER" required="next name value">
         Rule for SET_HEADER.
     </rule>

--- a/core/src/main/resources/xsl/priority-map.xml
+++ b/core/src/main/resources/xsl/priority-map.xml
@@ -39,6 +39,7 @@
     <map type="HEADERXSD_SINGLE" priority="41000"/>
     <map type="HEADER_ANY"    priority="41000"/>
     <map type="HEADERXSD_ANY" priority="41000"/>
+    <map type="HEADER_ALL"    priority="41000"/>
     <map type="WELL_XML"      priority="41000"/>
     <map type="WELL_JSON"     priority="41000"/>
     <map type="XPATH"         priority="41000"/>

--- a/core/src/main/resources/xsl/raxRoles.xsl
+++ b/core/src/main/resources/xsl/raxRoles.xsl
@@ -115,7 +115,7 @@
         <xsl:param name="roles" as="xsd:string*" select="()"/>
         <xsl:if test="not('#all' = $roles)">
             <xsl:for-each select="$roles">
-                <wadl:param name="X-ROLES" style="header" rax:code="403"
+                <wadl:param name="X-ROLES" style="header" rax:code="403" rax:anyMatch="true"
                             rax:message="You are forbidden to perform the operation" type="xsd:string"
                             required="true" repeating="true">
                     <xsl:attribute name="fixed" select="rax:transformNBSP(.)"/>

--- a/core/src/main/resources/xsl/raxRolesMask.xsl
+++ b/core/src/main/resources/xsl/raxRolesMask.xsl
@@ -88,7 +88,7 @@
     <xsl:variable name="searchStates"
                   select="('URL',
                           'URLXSD','METHOD','HEADER','HEADER_ANY',
-                          'HEADERXSD','HEADERXSD_ANY',
+                          'HEADERXSD','HEADERXSD_ANY', 'HEADER_ALL',
                           'HEADER_SINGLE', 'HEADERXSD_SINGLE')"
                   as="xs:string*"/>
 

--- a/core/src/main/resources/xsl/util/funs.xsl
+++ b/core/src/main/resources/xsl/util/funs.xsl
@@ -57,7 +57,7 @@
     <xsl:variable name="cont-error-types" as="xs:string*" select="('WELL_XML','WELL_JSON', 'XSD',
                                                                    'XPATH', 'XSL', 'HEADER',
                                                                    'HEADERXSD', 'HEADER_ANY', 'HEADERXSD_ANY',
-                                                                   'HEADER_SINGLE', 'HEADERXSD_SINGLE',
+                                                                   'HEADER_SINGLE', 'HEADERXSD_SINGLE', 'HEADER_ALL',
                                                                    'JSON_SCHEMA')"/>
 
     <!--

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
@@ -243,6 +243,15 @@ class Config {
   var enableCaptureHeaderExtension : Boolean = true
 
   //
+  //  When rax:anyMatch boolean attribute is specificed on a
+  //  parameter, enable matching any value of a parameter when
+  //  multiple parameters of the same name are specificed.
+  //
+  @BeanProperty
+  @AffectsChecker
+  var enableAnyMatchExtension : Boolean = true
+
+  //
   //  The XSL 1.0 engine to use.  Possible choices are Xalan, XalanC,
   //  and Saxon. Note that Saxon is an XSL 2.0 engine, but most 1.0
   //  XSLs should work fine.

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/HeaderAll.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/HeaderAll.scala
@@ -1,0 +1,103 @@
+/***
+ *   Copyright 2016 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.step
+
+import javax.servlet.FilterChain
+import javax.xml.namespace.QName
+import javax.xml.validation.Schema
+
+import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.step.base.{ConnectedStep, Step, StepContext}
+import com.rackspace.com.papi.components.checker.util.HeaderUtil._
+import org.xml.sax.SAXParseException
+
+import scala.collection.JavaConversions._
+import scala.util.matching.Regex
+import scala.annotation.tailrec
+
+
+class HeaderAll(id : String, label : String, val name : String, val valueTypes : Option[List[QName]],
+                schema : Option[Schema], val value : Option[Regex], val message : Option[String],
+                val code : Option[Int], val captureHeader : Option[String],
+                val priority : Long, next : Array[Step]) extends ConnectedStep(id, label, next) {
+
+  override val mismatchMessage : String = message.getOrElse({
+    val matchString = {
+      val v1 = valueTypes.getOrElse(List()).map(vt => vt.toString)
+      val v2 = { if (value.isEmpty) List() else List(value.get.toString) }
+      (v1 ++ v2).mkString(" ")
+    }
+    s"Expecting an HTTP header $name to have a value matching $matchString"
+  })
+
+  val mismatchCode : Int = code.getOrElse(400)
+
+  val xsds : Option[List[XSDStringValidator]] = valueTypes.map(vts => vts.map ( vt=> new XSDStringValidator(vt, schema.get, id)))
+
+  @tailrec
+  private[this] def filterHeaders (headers : List[String], xsds : List[XSDStringValidator]) : List[String] = xsds match {
+    case Nil => headers
+    case xsd :: tail if (headers.isEmpty) => headers
+    case xsd :: tail => filterHeaders(headers.filterNot(h => xsd.validate(h).isEmpty), tail)
+  }
+
+  override def checkStep(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, context : StepContext) : Option[StepContext] = {
+    val headers : List[String] = getHeaders(context, req, name)
+
+    //
+    //  If there are no headers matching the name, then we set an
+    //  error and return None.
+    //
+    if (headers.isEmpty) {
+      req.contentError(new Exception(mismatchMessage), mismatchCode, priority)
+      None
+    } else {
+      //
+      //  We filter out the values that match the valueRegEx if we
+      //  have one.
+      //
+      val headersSansValue = {
+        if (value.isEmpty) {
+          headers
+        } else {
+          val vr = value.get
+          headers.filterNot(v => v match { case vr() => true ; case _ => false})
+        }
+      }
+
+      //
+      // Next we filter out values that match value types.
+      //
+      val mismatchHeaders = filterHeaders(headersSansValue, xsds.getOrElse(Nil))
+
+      //
+      // If we have don't have mismatch header values then we return a
+      // valid context, otherwise we set an error.
+      //
+      if (mismatchHeaders.isEmpty) {
+        captureHeader match {
+          case None => Some(context)
+          case Some(h) => Some(context.copy (requestHeaders = context.requestHeaders.addHeaders(h, headers)))
+        }
+      } else {
+        val mhlist = mismatchHeaders.mkString(" ")
+        req.contentError(new Exception(s"$mismatchMessage. The following header values did not match: $mhlist."),
+          mismatchCode, priority)
+        None
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithRolesAtMethodLevel.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithRolesAtMethodLevel.scala
@@ -57,6 +57,7 @@ class GivenAWadlWithRolesAtMethodLevel extends FlatSpec with RaxRolesBehaviors {
         <resource path="/c">
           <param name="X-Auth-Token" style="header" required="true"/>
           <param name="X-INT" style="header" type="xs:int" required="true"/>
+          <param name="X-INT" style="header" type="xs:double" required="true"/>
           <method name="GET" rax:roles="a:admin">
             <request>
               <representation mediaType="application/xml"/>
@@ -83,6 +84,7 @@ class GivenAWadlWithRolesAtMethodLevel extends FlatSpec with RaxRolesBehaviors {
             <request>
               <param name="X-Auth-Token" style="header" required="true"/>
               <param name="X-INT" style="header" type="xs:int" required="true"/>
+              <param name="X-INT" style="header" type="xs:double" required="true"/>
               <representation mediaType="application/xml"/>
             </request>
           </method>
@@ -123,6 +125,74 @@ class GivenAWadlWithRolesAtMethodLevel extends FlatSpec with RaxRolesBehaviors {
         <resource path="/c">
           <param name="X-Auth-Token" style="header" required="true" repeating="true"/>
           <param name="X-INT" style="header" type="xs:int" required="true" repeating="true"/>
+          <method name="GET" rax:roles="a:admin">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="POST" rax:roles="a:observer a:admin">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="PUT" rax:roles="#all">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="DELETE" rax:roles="a:admin">
+            <request>
+              <param name="some-generic-header" style="header" required="true" repeating="true"/>
+            </request>
+          </method>
+        </resource>
+        <resource path="/d">
+          <method name="GET" rax:roles="a:admin">
+            <request>
+              <param name="X-Auth-Token" style="header" required="true" repeating="true"/>
+              <param name="X-INT" style="header" type="xs:int" required="true" repeating="true"/>
+              <param name="X-INT" style="header" type="xs:double" required="true" repeating="true"/>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="POST" rax:roles="#all">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+        </resource>
+      </resources>
+    </application>,
+    "Repeat Headers, anyMatch" -> <application xmlns="http://wadl.dev.java.net/2009/02"
+                 xmlns:rax="http://docs.rackspace.com/api"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/a">
+          <method name="POST" rax:roles="a:admin">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="GET" rax:roles="a:observer b:test&#xA0;with&#xA0;space">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="PUT">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="DELETE" rax:roles="a:observer a:admin b:test with space">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+        </resource>
+        <resource path="/c">
+          <param name="X-Auth-Token" style="header" required="true" repeating="true" rax:anyMatch="true"/>
+          <param name="X-INT" style="header" type="xs:int" required="true" repeating="true" rax:anyMatch="1"/>
+          <param name="X-INT" style="header" type="xs:double" required="true" repeating="true" rax:anyMatch="1"/>
           <method name="GET" rax:roles="a:admin">
             <request>
               <representation mediaType="application/xml"/>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithRolesAtMethodLevelMasked.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithRolesAtMethodLevelMasked.scala
@@ -68,6 +68,7 @@ class GivenAWadlWithRolesAtMethodLevelMasked extends FlatSpec with RaxRolesBehav
         <resource path="/c">
           <param name="X-Auth-Token" style="header" required="true" repeating="true"/>
           <param name="X-INT" style="header" type="xs:int" required="true" repeating="true"/>
+          <param name="X-INT" style="header" type="xs:double" required="true" repeating="true"/>
           <method name="GET" rax:roles="a:admin">
             <request>
               <representation mediaType="application/xml"/>
@@ -94,6 +95,87 @@ class GivenAWadlWithRolesAtMethodLevelMasked extends FlatSpec with RaxRolesBehav
             <request>
               <param name="X-Auth-Token" style="header" required="true" repeating="true"/>
               <param name="X-INT" style="header" type="xs:int" required="true" repeating="true"/>
+              <param name="X-INT" style="header" type="xs:double" required="true" repeating="true"/>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="POST" rax:roles="#all">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+        </resource>
+      </resources>
+    </application>,
+    "Repeat Headers, anyMatch=true" -> <application xmlns="http://wadl.dev.java.net/2009/02"
+                 xmlns:rax="http://docs.rackspace.com/api"
+                 xmlns:xs="http://www.w3.org/2001/XMLSchema">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/a">
+          <method name="POST" rax:roles="a:admin">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="GET" rax:roles="a:observer b:test&#xA0;with&#xA0;space">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="PUT">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="DELETE" rax:roles="a:observer a:admin b:test with space">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+        </resource>
+        <resource path="/b">
+          <method name="POST" rax:roles="a:admin">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="DELETE" rax:roles="a:observer a:admin">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+        </resource>
+        <resource path="/c">
+          <param name="X-Auth-Token" style="header" required="true" repeating="true" rax:anyMatch="true"/>
+          <param name="X-INT" style="header" type="xs:int" required="true" repeating="true" rax:anyMatch="true"/>
+          <param name="X-INT" style="header" type="xs:double" required="true" repeating="true" rax:anyMatch="true"/>
+          <method name="GET" rax:roles="a:admin">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="POST" rax:roles="a:observer a:admin">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="PUT" rax:roles="#all">
+            <request>
+              <representation mediaType="application/xml"/>
+            </request>
+          </method>
+          <method name="DELETE" rax:roles="a:admin">
+            <request>
+              <param name="some-generic-header" style="header" required="true" repeating="true"/>
+            </request>
+          </method>
+        </resource>
+        <resource path="/d">
+          <method name="GET" rax:roles="a:admin">
+            <request>
+              <param name="X-Auth-Token" style="header" required="true" repeating="true" rax:anyMatch="true"/>
+              <param name="X-INT" style="header" type="xs:int" required="true" repeating="true" rax:anyMatch="true"/>
+              <param name="X-INT" style="header" type="xs:double" required="true" repeating="true" rax:anyMatch="true"/>
               <representation mediaType="application/xml"/>
             </request>
           </method>
@@ -146,6 +228,7 @@ class GivenAWadlWithRolesAtMethodLevelMasked extends FlatSpec with RaxRolesBehav
         <resource path="/c">
           <param name="X-Auth-Token" style="header" required="true"/>
           <param name="X-INT" style="header" type="xs:int" required="true"/>
+          <param name="X-INT" style="header" type="xs:double" required="true"/>
           <method name="GET" rax:roles="a:admin">
             <request>
               <representation mediaType="application/xml"/>
@@ -172,6 +255,7 @@ class GivenAWadlWithRolesAtMethodLevelMasked extends FlatSpec with RaxRolesBehav
             <request>
               <param name="X-Auth-Token" style="header" required="true"/>
               <param name="X-INT" style="header" type="xs:int" required="true"/>
+              <param name="X-INT" style="header" type="xs:double" required="true"/>
               <representation mediaType="application/xml"/>
             </request>
           </method>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLHeaderSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLHeaderSuite.scala
@@ -57,6 +57,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   //
   val validator_Header = Validator((localWADLURI,
       <application xmlns="http://wadl.dev.java.net/2009/02"
+                   xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -64,7 +65,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" required="true" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -94,7 +95,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   //  Like validator_Header, but with header defaults enabled
   //
   val validator_HeaderDefaults = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -102,7 +103,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" required="true" default="test" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" required="true" default="test" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -141,7 +142,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" required="true" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -179,7 +180,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" rax:message="No!" required="true" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" rax:message="No!" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -217,7 +218,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" required="true" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -246,7 +247,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   // Like validator header, but expects the header to contain a fixed value
   //
   val validator_HeaderFixed = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -254,7 +255,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -284,7 +285,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   // Like header fixed, but expects the header to contain one of multiple fixed values
   //
   val validator_HeaderFixed2 = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -292,8 +293,8 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true"/>
-               <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -322,7 +323,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   // Like header fixed2, but also expects a non-fixed header value.
   //
   val validator_HeaderFixed3 = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -330,9 +331,9 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true"/>
-               <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true"/>
-               <param name="X-TESTO" style="header" type="xsd:string" required="true" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TESTO" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -362,7 +363,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   //  Like header fixed 3, but with default values set
   //
   val validator_HeaderFixed3Defaults = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -370,9 +371,9 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" default="foo!" repeating="true"/>
-               <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true"/>
-               <param name="X-TESTO" style="header" type="xsd:string" required="true" default="texto" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" default="foo!" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TESTO" style="header" type="xsd:string" required="true" default="texto" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -411,8 +412,8 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" fixed="foo!" required="true" repeating="true"/>
-               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" fixed="bar!" required="true" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" fixed="foo!" required="true" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" fixed="bar!" required="true" repeating="true" rax:anyMatch="true"/>
                <param name="X-TESTO" style="header" type="xsd:string" rax:code="401" rax:message="No!" required="true" repeating="true"/>
                <method name="PUT">
                   <request>
@@ -443,7 +444,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   // Like header fixed3, but has remove dups optimization enabled
   //
   val validator_HeaderFixed3Opt = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -451,9 +452,9 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true"/>
-               <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true"/>
-               <param name="X-TESTO" style="header" type="xsd:string" required="true" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TESTO" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -483,7 +484,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   //
 
   val validator_HeaderFixed3DefaultsOpt = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -491,9 +492,9 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" default="foo!" repeating="true"/>
-               <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true"/>
-               <param name="X-TESTO" style="header" type="xsd:string" required="true" default="texto" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" default="foo!" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TESTO" style="header" type="xsd:string" required="true" default="texto" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -532,9 +533,9 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" fixed="foo!" required="true" repeating="true"/>
-               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" fixed="bar!" required="true" repeating="true"/>
-               <param name="X-TESTO" style="header" type="xsd:string" rax:code="401" rax:message="No!" required="true" repeating="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" fixed="foo!" required="true" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" fixed="bar!" required="true" repeating="true" rax:anyMatch="true"/>
+               <param name="X-TESTO" style="header" type="xsd:string" rax:code="401" rax:message="No!" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -564,7 +565,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   // Like header fixed3, but fixed values are only allowed in the PUT request.
   //
   val validator_HeaderFixed4 = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -572,11 +573,11 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TESTO" style="header" type="xsd:string" required="true" repeating="true"/>
+               <param name="X-TESTO" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
-                      <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true"/>
-                      <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true"/>
+                      <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" rax:anyMatch="true"/>
+                      <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:anyMatch="true"/>
                       <representation mediaType="application/xml" element="tst:a"/>
                       <representation mediaType="application/json"/>
                   </request>
@@ -603,7 +604,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   // Like header fixed4, but with remove dups optimization on.
   //
   val validator_HeaderFixed4Opt = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -611,11 +612,11 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TESTO" style="header" type="xsd:string" required="true" repeating="true"/>
+               <param name="X-TESTO" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
-                      <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true"/>
-                      <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true"/>
+                      <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" rax:anyMatch="true"/>
+                      <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:anyMatch="true"/>
                       <representation mediaType="application/xml" element="tst:a"/>
                       <representation mediaType="application/json"/>
                   </request>
@@ -642,7 +643,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   // Like validator header, but expects the header to be a UUID.
   //
   val validator_HeaderUUID = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -650,7 +651,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST-UUID" style="header" type="tst:UUID" required="true" repeating="true"/>
+               <param name="X-TEST-UUID" style="header" type="tst:UUID" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -679,7 +680,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   // Like validator header, but expects the header to be an int.
   //
   val validator_HeaderInt = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -687,7 +688,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST-INT" style="header" type="xsd:int" required="true" repeating="true"/>
+               <param name="X-TEST-INT" style="header" type="xsd:int" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -725,7 +726,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-               <param name="X-TEST-INT" style="header" type="xsd:int" rax:code="401" rax:message="No!" required="true" repeating="true"/>
+               <param name="X-TEST-INT" style="header" type="xsd:int" rax:code="401" rax:message="No!" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml" element="tst:a"/>
@@ -755,7 +756,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   // Like validator header int, but expects the header to only be required in the PUT request.
   //
   val validator_HeaderIntPut = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -765,7 +766,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
            <resource path="/a/b">
                <method name="PUT">
                   <request>
-                      <param name="X-TEST-INT" style="header" type="xsd:int" required="true" repeating="true"/>
+                      <param name="X-TEST-INT" style="header" type="xsd:int" required="true" repeating="true" rax:anyMatch="true"/>
                       <representation mediaType="application/xml" element="tst:a"/>
                       <representation mediaType="application/json"/>
                   </request>
@@ -793,7 +794,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   // Like validator header int, but expects the header to only be required in the PUT request.
   //
   val validator_HeaderIntPutMix = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -801,10 +802,10 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-              <param name="X-TEST" style="header" type="xsd:string" required="true" repeating="true"/>
+              <param name="X-TEST" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
-                      <param name="X-TEST-INT" style="header" type="xsd:int" required="true" repeating="true"/>
+                      <param name="X-TEST-INT" style="header" type="xsd:int" required="true" repeating="true" rax:anyMatch="true"/>
                       <representation mediaType="application/xml" element="tst:a"/>
                       <representation mediaType="application/json"/>
                   </request>
@@ -831,7 +832,7 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
   //  Like validator_HeaderIntPutMix but with defaults enabled
   //
   val validator_HeaderIntPutMixDefaults = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
+      <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
                    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
         <grammars>
@@ -839,10 +840,10 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-              <param name="X-TEST" style="header" type="xsd:string" required="true" default="foo!" repeating="true"/>
+              <param name="X-TEST" style="header" type="xsd:string" required="true" default="foo!" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
-                      <param name="X-TEST-INT" style="header" type="xsd:int" required="true" default="54321" repeating="true"/>
+                      <param name="X-TEST-INT" style="header" type="xsd:int" required="true" default="54321" repeating="true" rax:anyMatch="true"/>
                       <representation mediaType="application/xml" element="tst:a"/>
                       <representation mediaType="application/json"/>
                   </request>
@@ -878,10 +879,10 @@ class ValidatorWADLHeaderSuite extends BaseValidatorSuite {
         </grammars>
         <resources base="https://test.api.openstack.com">
            <resource path="/a/b">
-              <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" required="true" repeating="true"/>
+              <param name="X-TEST" style="header" type="xsd:string" rax:code="401" rax:message="No!" required="true" repeating="true" rax:anyMatch="true"/>
                <method name="PUT">
                   <request>
-                      <param name="X-TEST-INT" style="header" type="xsd:int" rax:code="401" rax:message="No!" required="true" repeating="true"/>
+                      <param name="X-TEST-INT" style="header" type="xsd:int" rax:code="401" rax:message="No!" required="true" repeating="true" rax:anyMatch="true"/>
                       <representation mediaType="application/xml" element="tst:a"/>
                       <representation mediaType="application/json"/>
                   </request>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLHeaderSuite2.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLHeaderSuite2.scala
@@ -53,14 +53,107 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
   val checkHeadersDisabledConfigDups : CaseConfig = ("check headers disabled and remove dups enabled", TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, false, false, false))
   val checkHeadersConfig : CaseConfig = ("check headers enabled", TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, true, false, false))
   val checkHeadersConfigDups : CaseConfig = ("check headers and remove dups enabled", TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, false, false))
-  val checkHeadersDefaultsConfig : CaseConfig = ("check headers and param defaults enabled", { val t = TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, true, false, false); t.setParamDefaults = true; t })
-  val checkHeadersDefaultsConfigDups : CaseConfig = ("check headers, param defaults,  and remove dups enabled", { val t = TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, false, false); t.setParamDefaults = true; t})
-  val checkHeadersDisabledMsgConfig : CaseConfig = ("check headers disabled, message extension enabled", TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, false, false, true))
-  val checkHeadersDisabledMsgConfigDups : CaseConfig = ("check headers disabled and remove dups enabled and message extension enabled", TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, false, false, true))
-  val checkHeadersMsgConfig : CaseConfig = ("check headers enabled and message extension enabled", TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, true, false, true))
-  val checkHeadersMsgConfigDups : CaseConfig = ("check headers and remove dups enabled and message extension enabled", TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, false, true))
-  val checkHeadersMsgDefaultsConfig : CaseConfig = ("check headers and param defaults enabled and message extension enabled", { val t = TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, true, false, true); t.setParamDefaults = true; t })
-  val checkHeadersMsgDefaultsConfigDups : CaseConfig = ("check headers, param defaults,  and remove dups enabled and message extension enabled", { val t = TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, false, true); t.setParamDefaults = true; t})
+  val checkHeadersConfigDisableAnyMatch  : CaseConfig = ("check headers enabled, anymatch extension disabled", {
+    val tc = TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, true, false, false)
+    tc.enableAnyMatchExtension = false
+    tc
+  })
+  val checkHeadersConfigDupsDisableAnyMatch : CaseConfig = ("check headers and remove dups enabled, anymatch disabled", {
+    val tc = TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, false, false)
+    tc.enableAnyMatchExtension = false
+    tc
+  })
+
+  val checkHeadersDefaultsConfig : CaseConfig = ("check headers and param defaults enabled", {
+    val t = TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, true, false, false);
+    t.setParamDefaults = true;
+    t
+  })
+  val checkHeadersDefaultsConfigDups : CaseConfig = ("check headers, param defaults,  and remove dups enabled", {
+    val t = TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, false, false);
+    t.setParamDefaults = true;
+    t
+  })
+
+  val checkHeadersDefaultsConfigDisableAnyMatch : CaseConfig = ("check headers and param defaults enabled disabled anyMatch", {
+    val t = TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, true, false, false);
+    t.setParamDefaults = true;
+    t.enableAnyMatchExtension = false
+    t
+  })
+  val checkHeadersDefaultsConfigDupsDisableAnyMatch : CaseConfig = ("check headers, param defaults,  and remove dups enabled, disabled anyMatch", {
+    val t = TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, false, false);
+    t.setParamDefaults = true;
+    t.enableAnyMatchExtension = false
+    t
+  })
+
+  val checkHeadersDisabledMsgConfig : CaseConfig = ("check headers disabled, message extension enabled",
+                                                    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, false, false, true))
+
+  val checkHeadersDisabledMsgConfigDups : CaseConfig = ("check headers disabled and remove dups enabled and message extension enabled",
+                                                        TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, false, false, true))
+
+
+  val checkHeadersDisabledMsgConfigDisableAnyMatch : CaseConfig = ("check headers disabled, message extension enabled disable any match", {
+    val t = TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, false, false, true)
+    t.enableAnyMatchExtension = false
+    t
+  })
+
+  val checkHeadersDisabledMsgConfigDupsDisableAnyMatch : CaseConfig = ("check headers disabled and remove dups enabled and message extension enabled disable any match", {
+    val t = TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, false, false, true)
+    t.enableAnyMatchExtension = false
+    t
+  })
+
+
+  val checkHeadersMsgConfig : CaseConfig = ("check headers enabled and message extension enabled",
+                                            TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, true, false, true))
+
+  val checkHeadersMsgConfigDups : CaseConfig = ("check headers and remove dups enabled and message extension enabled",
+                                                TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, false, true))
+
+
+  val checkHeadersMsgConfigDisableAnyMatch : CaseConfig = ("check headers enabled and message extension enabled disable any match", {
+    val t = TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, true, false, true)
+    t.enableAnyMatchExtension = false
+    t
+  })
+
+  val checkHeadersMsgConfigDupsDisableAnyMatch : CaseConfig = ("check headers and remove dups enabled and message extension enabled disable any match", {
+    val t = TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, false, true)
+    t.enableAnyMatchExtension = false
+    t
+  })
+
+
+  val checkHeadersMsgDefaultsConfig : CaseConfig = ("check headers and param defaults enabled and message extension enabled", {
+    val t = TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, true, false, true);
+    t.setParamDefaults = true;
+    t
+  })
+
+  val checkHeadersMsgDefaultsConfigDups : CaseConfig = ("check headers, param defaults,  and remove dups enabled and message extension enabled", {
+    val t = TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, false, true);
+    t.setParamDefaults = true;
+    t
+  })
+
+
+  val checkHeadersMsgDefaultsConfigDisableAnyMatch : CaseConfig = ("check headers and param defaults enabled and message extension enabled disable any match", {
+    val t = TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", false, true, false, true);
+    t.setParamDefaults = true;
+    t.enableAnyMatchExtension = false
+    t
+  })
+
+  val checkHeadersMsgDefaultsConfigDupsDisableAnyMatch : CaseConfig = ("check headers, param defaults,  and remove dups enabled and message extension enabled disable any match", {
+    val t = TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, false, true);
+    t.setParamDefaults = true;
+    t.enableAnyMatchExtension = false
+    t
+  })
 
   val resourceHeadersWADL : TestWADL = ("WADL with mixed same name headers at the resource level",
                                             <application xmlns="http://wadl.dev.java.net/2009/02"
@@ -69,9 +162,10 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                               xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
                                           <resources base="https://test.api.openstack.com">
                                       <resource path="/a/b">
-                                        <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" default="foo!" rax:code="401" rax:message="No!"/>
-                                        <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:code="401" rax:message="No!"/>
-                                        <param name="X-TEST" style="header" type="xsd:dateTime" required="true" repeating="true" rax:code="401" rax:message="No!"/>
+                                        <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" default="foo!" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                        <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                        <param name="X-TEST" style="header" type="xsd:dateTime" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                        <param name="X-TEST" style="header" type="xsd:date" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
                                         <param name="X-TESTO" style="header" type="xsd:int" required="true" repeating="true" default="42" rax:message="Bad Testo"/>
                                         <method name="PUT">
                                           <request>
@@ -96,6 +190,42 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                       </resources>
                                       </application>)
 
+  val resourceHeadersAllMatchWADL : TestWADL = ("WADL with mixed same name headers at the resource level anyMatch=false",
+                                            <application xmlns="http://wadl.dev.java.net/2009/02"
+                                              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                                              xmlns:rax="http://docs.rackspace.com/api"
+                                              xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
+                                          <resources base="https://test.api.openstack.com">
+                                      <resource path="/a/b">
+                                        <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" default="foo!" rax:code="401" rax:message="No!" rax:anyMatch="false"/>
+                                        <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="false"/>
+                                        <param name="X-TEST" style="header" type="xsd:dateTime" required="true" repeating="true" rax:code="401" rax:message="No!"/>
+                                        <param name="X-TEST" style="header" type="xsd:date" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="0"/>
+                                        <param name="X-TESTO" style="header" type="xsd:int" required="true" repeating="true" default="42" rax:message="Bad Testo"/>
+                                        <method name="PUT">
+                                          <request>
+                                            <representation mediaType="application/xml" element="tst:a"/>
+                                            <representation mediaType="application/json"/>
+                                          </request>
+                                        </method>
+                                        <method name="POST">
+                                          <request>
+                                            <representation mediaType="application/xml" element="tst:e"/>
+                                          </request>
+                                        </method>
+                                      </resource>
+                                      <resource path="/c">
+                                        <method name="POST">
+                                          <request>
+                                            <representation mediaType="application/json"/>
+                                          </request>
+                                        </method>
+                                        <method name="GET"/>
+                                       </resource>
+                                      </resources>
+                                      </application>)
+
+
   val resourceHeadersNoRepeatWADL : TestWADL = ("WADL with mixed same name non-repeating headers at the resource level",
                                             <application xmlns="http://wadl.dev.java.net/2009/02"
                                               xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -106,6 +236,7 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                         <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="false" default="foo!" rax:code="401" rax:message="No!"/>
                                         <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" rax:code="401" rax:message="No!"/>
                                         <param name="X-TEST" style="header" type="xsd:dateTime" required="true" rax:code="401" rax:message="No!"/>
+                                        <param name="X-TEST" style="header" type="xsd:date" required="true" repeating="false" rax:code="401" rax:message="No!"/>
                                         <param name="X-TESTO" style="header" type="xsd:int" required="true" default="42" rax:message="Bad Testo"/>
                                         <method name="PUT">
                                           <request>
@@ -130,6 +261,7 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                       </resources>
                                       </application>)
 
+
   val requestHeadersWADL : TestWADL = ("WADL with mixed same name headers at the request level",
                                             <application xmlns="http://wadl.dev.java.net/2009/02"
                                               xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -145,9 +277,10 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                         </method>
                                         <method name="POST">
                                           <request>
-                                             <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" default="foo!" rax:code="401" rax:message="No!"/>
-                                             <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:code="401" rax:message="No!"/>
-                                             <param name="X-TEST" style="header" type="xsd:dateTime" required="true" repeating="true" rax:code="401" rax:message="No!"/>
+                                             <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" default="foo!" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                             <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                             <param name="X-TEST" style="header" type="xsd:dateTime" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                             <param name="X-TEST" style="header" type="xsd:date" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
                                              <param name="X-TESTO" style="header" type="xsd:int" required="true" repeating="true" default="42" rax:message="Bad Testo"/>
                                              <representation mediaType="application/xml" element="tst:e"/>
                                           </request>
@@ -163,6 +296,42 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                        </resource>
                                       </resources>
                                       </application>)
+
+  val requestHeadersAllMatchWADL : TestWADL = ("WADL with mixed same name headers at the request level anyMatch = false",
+                                            <application xmlns="http://wadl.dev.java.net/2009/02"
+                                              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                                              xmlns:rax="http://docs.rackspace.com/api"
+                                              xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
+                                          <resources base="https://test.api.openstack.com">
+                                      <resource path="/a/b">
+                                        <method name="PUT">
+                                          <request>
+                                            <representation mediaType="application/xml" element="tst:a"/>
+                                            <representation mediaType="application/json"/>
+                                          </request>
+                                        </method>
+                                        <method name="POST">
+                                          <request>
+                                             <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" default="foo!" rax:code="401" rax:message="No!" rax:anyMatch="false"/>
+                                             <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="false"/>
+                                             <param name="X-TEST" style="header" type="xsd:dateTime" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="0"/>
+                                             <param name="X-TEST" style="header" type="xsd:date" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="0"/>
+                                             <param name="X-TESTO" style="header" type="xsd:int" required="true" repeating="true" default="42" rax:message="Bad Testo"/>
+                                             <representation mediaType="application/xml" element="tst:e"/>
+                                          </request>
+                                        </method>
+                                      </resource>
+                                      <resource path="/c">
+                                        <method name="POST">
+                                          <request>
+                                            <representation mediaType="application/json"/>
+                                          </request>
+                                        </method>
+                                        <method name="GET"/>
+                                       </resource>
+                                      </resources>
+                                      </application>)
+
 
   val requestHeadersNoRepeatWADL : TestWADL = ("WADL with mixed same name no repeat headers at the request level",
                                             <application xmlns="http://wadl.dev.java.net/2009/02"
@@ -182,6 +351,7 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                              <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" default="foo!" rax:code="401" rax:message="No!"/>
                                              <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="false" rax:code="401" rax:message="No!"/>
                                              <param name="X-TEST" style="header" type="xsd:dateTime" required="true" repeating="0" rax:code="401" rax:message="No!"/>
+                                             <param name="X-TEST" style="header" type="xsd:date" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
                                              <param name="X-TESTO" style="header" type="xsd:int" required="true" default="42" rax:message="Bad Testo"/>
                                              <representation mediaType="application/xml" element="tst:e"/>
                                           </request>
@@ -224,6 +394,11 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
     test(s"$desc : should allow PUT on /a/b with X-TEST=2001-10-26T19:32:52Z and X-TESTO=23 and goodXML") {
       validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
                                  Map("X-TEST"->List("2001-10-26T19:32:52Z"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=2001-10-26 and X-TESTO=23 and goodXML") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("2001-10-26"), "X-TESTO"->List("23"))), response, chain)
     }
 
     test(s"$desc : should allow PUT on /a/b with X-TEST=foo!, baz, bing and X-TESTO=23 and goodXML") {
@@ -289,6 +464,104 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
 
   }
 
+
+  def mixedHeaderHappyPathTestsAllMatch (desc : String, validator : Validator) : Unit = {
+    test(s"$desc : should allow GET on /c ") {
+      validator.validate(request("GET","/c"), response, chain)
+    }
+
+    test(s"$desc : should allow json post on /c, with no headers") {
+      validator.validate(request("POST", "/c", "application/json", goodJSON, false, Map[String,List[String]]()), response, chain)
+    }
+
+    test(s"$desc : should allow json post on /c, with weird X-TEST header") {
+      validator.validate(request("POST", "/c", "application/json", goodJSON, false, Map("X-TEST"->List("foo"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=foo! and X-TESTO=23 and goodXML") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=bar! and X-TESTO=23 and goodXML") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("bar!"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=2001-10-26T19:32:52Z and X-TESTO=23 and goodXML") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("2001-10-26T19:32:52Z"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=2001-10-26 and X-TESTO=23 and goodXML") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("2001-10-26"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=foo!, 2001-10-26,  2001-10-26T19:32:52Z, bar! and X-TESTO=23 and goodXML") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!", "2001-10-26", "2001-10-26T19:32:52Z", "bar!"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=bar!, 2001-10-26,  2001-10-26T19:32:52Z and X-TESTO=23 and goodXML") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("bar!", "2001-10-26", "2001-10-26T19:32:52Z"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=2001-10-26T19:32:52Z, foo!, bar! and X-TESTO=23 and goodXML") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!", "bar!", "2001-10-26T19:32:52Z"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=foo! and X-TESTO=23 and goodJSON") {
+      validator.validate(request("PUT", "/a/b", "application/json", goodJSON, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=bar! and X-TESTO=23 and goodJSON") {
+      validator.validate(request("PUT", "/a/b", "application/json", goodJSON, false,
+                                 Map("X-TEST"->List("bar!"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=2001-10-26T19:32:52Z and X-TESTO=23 and goodJSON") {
+      validator.validate(request("PUT", "/a/b", "application/json", goodJSON, false,
+                                 Map("X-TEST"->List("2001-10-26T19:32:52Z"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+
+    test(s"$desc : should allow POST on /a/b with X-TEST=foo! and X-TESTO=23 and goodXML") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST on /a/b with X-TEST=bar! and X-TESTO=23 and goodXML") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("bar!"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST on /a/b with X-TEST=2001-10-26T19:32:52Z and X-TESTO=23 and goodXML") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("2001-10-26T19:32:52Z"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST on /a/b with X-TEST=foo!, bar!, 1975-07-08 and X-TESTO=23 and goodXML") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("foo!", "bar!", "1975-07-08"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST on /a/b with X-TEST=bar!, 1975-07-08, foo! and X-TESTO=23 and goodXML") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("bar!", "1975-07-08", "foo!"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST on /a/b with X-TEST=2001-10-26T19:32:52Z, 1975-07-08, foo! and X-TESTO=23 and goodXML") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("1975-07-08", "foo!", "2001-10-26T19:32:52Z"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+  }
+
+
   def mixedHeaderHappyPathNoRepeatTests (desc : String, validator : Validator) : Unit = {
     test(s"$desc : should allow GET on /c ") {
       validator.validate(request("GET","/c"), response, chain)
@@ -337,6 +610,12 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
       validator.validate(request("PUT", "/a/b", "application/json", goodJSON, false,
                                  Map("X-TEST"->List("2001-10-26T19:32:52Z"), "X-TESTO"->List("23"))), response, chain)
     }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=2001-10-26 and X-TESTO=23 and goodJSON") {
+      validator.validate(request("PUT", "/a/b", "application/json", goodJSON, false,
+                                 Map("X-TEST"->List("2001-10-26T19:32:52Z"), "X-TESTO"->List("23"))), response, chain)
+    }
+
 
     test(s"$desc : should allow POST on /a/b with X-TEST=foo! and X-TESTO=23 and goodXML") {
       validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
@@ -562,6 +841,126 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
 
   }
 
+
+  def mixedHeaderNegHeaderTestsAll (desc : String, validator : Validator) : Unit = {
+
+
+    test(s"$desc : should not allow PUT /a/b with no headers") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map[String,List[String]]()), response, chain), 400,
+                                            List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO is not set") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TEST is not set") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b with no headers") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map[String,List[String]]()), response, chain), 400,
+                                            List("X-TEST","header"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO is not set") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST is not set") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing!"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing!"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, bing!") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","bing!"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header","bing!"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, 1975-07-08, 9999-99-99") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","1975-07-08","9999-99-99"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header","9999-99-99"))
+    }
+
+  }
+
+
   def mixedHeaderMsgNegHeaderTests (desc : String, validator : Validator) : Unit = {
 
 
@@ -665,6 +1064,126 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
     }
 
   }
+
+def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Unit = {
+
+
+    test(s"$desc : should not allow PUT /a/b with no headers") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map[String,List[String]]()), response, chain), 401,
+                                            List("No!"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO is not set") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TEST is not set") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b with no headers") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map[String,List[String]]()), response, chain), 401,
+                                            List("No!"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO is not set") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST is not set") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing!"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing!"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, bing!") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","bing!"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, 1975-07-08, 9999-99-99") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","1975-07-08","9999-99-99"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+
+  }
+
+
 
   def mixedHeaderNegHeaderNoRepeatTests (desc : String, validator : Validator) : Unit = {
 
@@ -903,6 +1422,153 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
 
   }
 
+  def mixedHeaderDefaultHeaderTestsAll (desc : String, validator : Validator) : Unit = {
+
+    test(s"$desc : should allow PUT /a/b with no headers, default X-TEST and X-TESTO should be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map[String,List[String]]())
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO is not set, default value for X-TESTO should be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map("X-TEST"->List("bar!")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("bar!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : allow PUT /a/b if X-TEST is not set, default vaule of X-TEST should be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map("X-TESTO"->List("23")))
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("23"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should allow POST /a/b with no headers, default X-TEST and X-TESTO should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map[String,List[String]]())
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow POST /a/b if X-TESTO is not set, default value for X-TESTO should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map("X-TEST"->List("bar!")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("bar!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow POST /a/b if X-TEST is not set, default value for X-TEST should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map("X-TESTO"->List("23")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("23"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing!"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing!"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, bing!") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","bing!"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header","bing!"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, 1975-07-08, 9999-99-99") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","1975-07-08","9999-99-99"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header","9999-99-99"))
+    }
+
+
+  }
+
 
   def mixedHeaderMsgDefaultHeaderTests (desc : String, validator : Validator) : Unit = {
 
@@ -1036,6 +1702,154 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
     }
 
   }
+
+
+  def mixedHeaderMsgDefaultHeaderTestsAll (desc : String, validator : Validator) : Unit = {
+
+    test(s"$desc : should allow PUT /a/b with no headers, default X-TEST and X-TESTO should be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map[String,List[String]]())
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO is not set, default value for X-TESTO should be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map("X-TEST"->List("bar!")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("bar!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : allow PUT /a/b if X-TEST is not set, default vaule of X-TEST should be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map("X-TESTO"->List("23")))
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("23"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+
+    test(s"$desc : should not allow PUT /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should allow POST /a/b with no headers, default X-TEST and X-TESTO should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map[String,List[String]]())
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow POST /a/b if X-TESTO is not set, default value for X-TESTO should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map("X-TEST"->List("bar!")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("bar!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow POST /a/b if X-TEST is not set, default value for X-TEST should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map("X-TESTO"->List("23")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("23"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing!"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing!"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, bing!") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","bing!"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, 1975-07-08, 9999-99-99") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","1975-07-08","9999-99-99"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+  }
+
 
 
   def mixedHeaderDefaultHeaderNoRepeatTests (desc : String, validator : Validator) : Unit = {
@@ -1266,6 +2080,116 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
 
   }
 
+
+  def mixedReqHeaderNegHeaderTestsAll (desc : String, validator : Validator) : Unit = {
+
+
+    test(s"$desc : should allow PUT /a/b with no headers") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map[String,List[String]]()), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO is not set") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TEST is not set") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TEST=foo") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TEST=baz, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=foo") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=baz, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=23, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing"))), response, chain)
+    }
+
+    test(s"$desc : should not allow POST /a/b with no headers") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map[String,List[String]]()), response, chain), 400,
+                                            List("X-TEST","header"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO is not set") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST is not set") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing!"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing!"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+     test(s"$desc : should not allow POST /a/b if X-TEST=foo!, bing!") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","bing!"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header","bing!"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, 1975-07-08, 9999-99-99") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","1975-07-08","9999-99-99"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header","9999-99-99"))
+    }
+
+  }
+
+
   def mixedReqHeaderMsgNegHeaderTests (desc : String, validator : Validator) : Unit = {
 
 
@@ -1362,6 +2286,116 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
   }
 
 
+  def mixedReqHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Unit = {
+
+
+    test(s"$desc : should allow PUT /a/b with no headers") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map[String,List[String]]()), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO is not set") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TEST is not set") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TEST=foo") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TEST=baz, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=foo") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=baz, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=23, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing"))), response, chain)
+    }
+
+    test(s"$desc : should not allow POST /a/b with no headers") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map[String,List[String]]()), response, chain), 401,
+                                            List("No!"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO is not set") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST is not set") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing!"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing!"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, bing!") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","bing!"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, 1975-07-08, 9999-99-99") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","1975-07-08","9999-99-99"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+
+  }
+
+
   def mixedReqHeaderNegHeaderNoRepeatTests (desc : String, validator : Validator) : Unit = {
 
 
@@ -1434,7 +2468,7 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
     test(s"$desc : should not allow POST /a/b if X-TEST=baz, bing") {
       assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
                                                     Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 400,
-                       List("X-TEST","Header","1 and only 1"))
+                       List("X-TEST","date"))
     }
 
     test(s"$desc : should not allow POST /a/b if X-TESTO=foo") {
@@ -1585,6 +2619,149 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
 
   }
 
+  def mixedReqHeaderDefaultHeaderTestsAll (desc : String, validator : Validator) : Unit = {
+
+    test(s"$desc : should allow PUT /a/b with no headers, default X-TEST and X-TESTO should not be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map[String,List[String]]())
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == Nil)
+        assert (csReq.getHeaders("X-TESTO").toList == Nil)
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO is not set, default value for X-TESTO should not be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map("X-TEST"->List("bar!")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("bar!"))
+        assert (csReq.getHeaders("X-TESTO").toList == Nil)
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : allow PUT /a/b if X-TEST is not set, default vaule of X-TEST should not be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map("X-TESTO"->List("23")))
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == Nil)
+        assert (csReq.getHeaders("X-TESTO").toList == List("23"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TEST=foo") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TEST=baz, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=foo") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=baz, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=23, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST /a/b with no headers, default X-TEST and X-TESTO should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map[String,List[String]]())
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow POST /a/b if X-TESTO is not set, default value for X-TESTO should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map("X-TEST"->List("bar!")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("bar!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow POST /a/b if X-TEST is not set, default value for X-TEST should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map("X-TESTO"->List("23")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("23"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing!"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing!"))), response, chain), 400,
+                       List("X-TESTO","header"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, bing!") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","bing!"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header","bing!"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, 1975-07-08, 9999-99-99") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","1975-07-08","9999-99-99"), "X-TESTO"->List("23"))), response, chain), 400,
+                       List("X-TEST","header","9999-99-99"))
+    }
+
+
+  }
+
+
+
 
   def mixedReqHeaderMsgDefaultHeaderTests (desc : String, validator : Validator) : Unit = {
 
@@ -1714,6 +2891,147 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
   }
 
 
+  def mixedReqHeaderMsgDefaultHeaderTestsAll (desc : String, validator : Validator) : Unit = {
+
+    test(s"$desc : should allow PUT /a/b with no headers, default X-TEST and X-TESTO should not be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map[String,List[String]]())
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == Nil)
+        assert (csReq.getHeaders("X-TESTO").toList == Nil)
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO is not set, default value for X-TESTO should not be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map("X-TEST"->List("bar!")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("bar!"))
+        assert (csReq.getHeaders("X-TESTO").toList == Nil)
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : allow PUT /a/b if X-TEST is not set, default vaule of X-TEST should not be set") {
+      val req = request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                        Map("X-TESTO"->List("23")))
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == Nil)
+        assert (csReq.getHeaders("X-TESTO").toList == List("23"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TEST=foo") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TEST=baz, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=foo") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=baz, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT /a/b if X-TESTO=23, bing") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST /a/b with no headers, default X-TEST and X-TESTO should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map[String,List[String]]())
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow POST /a/b if X-TESTO is not set, default value for X-TESTO should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map("X-TEST"->List("bar!")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("bar!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("42"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should allow POST /a/b if X-TEST is not set, default value for X-TEST should be set") {
+      val req = request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                        Map("X-TESTO"->List("23")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq : CheckerServletRequest, csResp : CheckerServletResponse, res : Result) => {
+        assert (csReq.getHeaders("X-TEST").toList == List("foo!"))
+        assert (csReq.getHeaders("X-TESTO").toList == List("23"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=foo") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("foo"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=baz, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("baz", "bing!"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TESTO=23, bing") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!"), "X-TESTO"->List("23", "bing!"))), response, chain), 400,
+                       List("Bad Testo"))
+    }
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, bing!") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","bing!"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+
+    test(s"$desc : should not allow POST /a/b if X-TEST=foo!, 1975-07-08, 9999-99-99") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                                    Map("X-TEST"->List("foo!","1975-07-08","9999-99-99"), "X-TESTO"->List("23"))), response, chain), 401,
+                       List("No!"))
+    }
+
+  }
+
+
   def mixedReqHeaderDefaultHeaderNoRepeatTests (desc : String, validator : Validator) : Unit = {
 
     test(s"$desc : should allow PUT /a/b with no headers, default X-TEST and X-TESTO should not be set") {
@@ -1818,7 +3136,7 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
     test(s"$desc : should not allow POST /a/b if X-TEST=baz, bing") {
       assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
                                                     Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain), 400,
-                       List("X-TEST","Header","1 and only 1"))
+                       List("X-TEST","date"))
     }
 
     test(s"$desc : should not allow POST /a/b if X-TESTO=foo") {
@@ -1855,6 +3173,21 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
   run(mixedHeadersMsgDisabledCase)
 
 
+  val mixedHeadersAllMatchDisabledCase : TestCase = (resourceHeadersAllMatchWADL,
+                                                     List(checkHeadersDisabledConfig, checkHeadersDisabledConfigDups),
+                                                     List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDisabledHeaderTests))
+
+  run(mixedHeadersAllMatchDisabledCase)
+
+
+  val mixedHeadersAllMatchMsgDisabledCase : TestCase = (resourceHeadersAllMatchWADL,
+                                                        List(checkHeadersDisabledMsgConfig, checkHeadersDisabledMsgConfigDups),
+                                                        List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDisabledHeaderTests))
+
+  run(mixedHeadersAllMatchMsgDisabledCase)
+
+
+
 
   val mixedHeadersDisabledNoRepeatCase : TestCase = (resourceHeadersNoRepeatWADL,
                                      List(checkHeadersDisabledConfig, checkHeadersDisabledConfigDups),
@@ -1877,11 +3210,41 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
 
   run(mixedHeadersCase)
 
+
+  val mixedHeadersAllCase : TestCase = (resourceHeadersAllMatchWADL,
+                                     List(checkHeadersConfig, checkHeadersConfigDups),
+                                     List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderNegHeaderTestsAll))
+
+  run(mixedHeadersAllCase)
+
+
+  val mixedHeadersDisableAnyCase : TestCase = (resourceHeadersWADL,
+                                     List(checkHeadersConfigDisableAnyMatch, checkHeadersConfigDupsDisableAnyMatch),
+                                     List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderNegHeaderTestsAll))
+
+  run(mixedHeadersDisableAnyCase)
+
+
+
   val mixedHeadersMsgCase : TestCase = (resourceHeadersWADL,
                                      List(checkHeadersMsgConfig, checkHeadersMsgConfigDups),
                                      List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderMsgNegHeaderTests))
 
   run(mixedHeadersMsgCase)
+
+
+  val mixedHeadersMsgAllCase : TestCase = (resourceHeadersAllMatchWADL,
+                                     List(checkHeadersMsgConfig, checkHeadersMsgConfigDups),
+                                     List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderMsgNegHeaderTestsAll))
+
+  run(mixedHeadersMsgAllCase)
+
+  val mixedHeadersMsgDisableAnyCase : TestCase = (resourceHeadersWADL,
+                                     List(checkHeadersMsgConfigDisableAnyMatch, checkHeadersMsgConfigDupsDisableAnyMatch),
+                                     List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderMsgNegHeaderTestsAll))
+
+  run(mixedHeadersMsgDisableAnyCase)
+
 
 
 
@@ -1907,11 +3270,41 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
   run(mixedHeadersDefaultCase)
 
 
+  val mixedHeadersDefaultAllCase : TestCase = (resourceHeadersAllMatchWADL,
+                                            List(checkHeadersDefaultsConfig, checkHeadersDefaultsConfigDups),
+                                            List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderDefaultHeaderTestsAll))
+
+  run(mixedHeadersDefaultAllCase)
+
+
+  val mixedHeadersDefaultDisableAnyCase : TestCase = (resourceHeadersWADL,
+                                            List(checkHeadersDefaultsConfigDisableAnyMatch, checkHeadersDefaultsConfigDupsDisableAnyMatch),
+                                            List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderDefaultHeaderTestsAll))
+
+  run(mixedHeadersDefaultDisableAnyCase)
+
+
+
   val mixedHeadersMsgDefaultCase : TestCase = (resourceHeadersWADL,
                                                List(checkHeadersMsgDefaultsConfig, checkHeadersMsgDefaultsConfigDups),
                                                List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderMsgDefaultHeaderTests))
 
   run(mixedHeadersMsgDefaultCase)
+
+
+  val mixedHeadersMsgDefaultAllCase : TestCase = (resourceHeadersAllMatchWADL,
+                                               List(checkHeadersMsgDefaultsConfig, checkHeadersMsgDefaultsConfigDups),
+                                               List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderMsgDefaultHeaderTestsAll))
+
+  run(mixedHeadersMsgDefaultAllCase)
+
+
+  val mixedHeadersMsgDefaultDisabledAnyCase : TestCase = (resourceHeadersWADL,
+                                                          List(checkHeadersMsgDefaultsConfigDisableAnyMatch, checkHeadersMsgDefaultsConfigDupsDisableAnyMatch),
+                                                          List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderMsgDefaultHeaderTestsAll))
+
+  run(mixedHeadersMsgDefaultDisabledAnyCase)
+
 
 
   val mixedHeadersDefaultNoRepeatCase : TestCase = (resourceHeadersNoRepeatWADL,
@@ -1936,11 +3329,27 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
   run(mixedReqHeadersDisabledCase)
 
 
+
   val mixedReqHeadersMsgDisabledCase : TestCase = (requestHeadersWADL,
                                                    List(checkHeadersDisabledMsgConfig, checkHeadersDisabledMsgConfigDups),
                                                    List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDisabledHeaderTests))
 
   run(mixedReqHeadersMsgDisabledCase)
+
+
+  val mixedReqHeadersAllMatchDisabledCase : TestCase = (requestHeadersAllMatchWADL,
+                                                        List(checkHeadersDisabledConfig, checkHeadersDisabledConfigDups),
+                                                        List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDisabledHeaderTests))
+
+  run(mixedReqHeadersAllMatchDisabledCase)
+
+
+
+  val mixedReqHeadersAllMatchMsgDisabledCase : TestCase = (requestHeadersAllMatchWADL,
+                                                           List(checkHeadersDisabledMsgConfig, checkHeadersDisabledMsgConfigDups),
+                                                           List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDisabledHeaderTests))
+
+  run(mixedReqHeadersAllMatchMsgDisabledCase)
 
 
 
@@ -1966,11 +3375,40 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
   run(mixedReqHeadersCase)
 
 
+  val mixedReqHeadersAllCase : TestCase = (requestHeadersAllMatchWADL,
+                                        List(checkHeadersConfig, checkHeadersConfigDups),
+                                        List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests,mixedReqHeaderNegHeaderTestsAll))
+
+  run(mixedReqHeadersAllCase)
+
+
+  val mixedReqHeadersDisableAnyCase : TestCase = (requestHeadersWADL,
+                                        List(checkHeadersConfigDisableAnyMatch, checkHeadersConfigDupsDisableAnyMatch),
+                                        List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderNegHeaderTestsAll))
+
+  run(mixedReqHeadersDisableAnyCase)
+
+
   val mixedReqHeadersMsgCase : TestCase = (requestHeadersWADL,
                                            List(checkHeadersMsgConfig, checkHeadersMsgConfigDups),
                                            List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedReqHeaderMsgNegHeaderTests))
 
   run(mixedReqHeadersMsgCase)
+
+
+  val mixedReqHeadersMsgAllCase : TestCase = (requestHeadersAllMatchWADL,
+                                           List(checkHeadersMsgConfig, checkHeadersMsgConfigDups),
+                                           List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderMsgNegHeaderTestsAll))
+
+  run(mixedReqHeadersMsgAllCase)
+
+  val mixedReqHeadersMsgDisableAnyCase : TestCase = (requestHeadersWADL,
+                                           List(checkHeadersMsgConfigDisableAnyMatch, checkHeadersMsgConfigDupsDisableAnyMatch),
+                                           List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderMsgNegHeaderTestsAll))
+
+  run(mixedReqHeadersMsgDisableAnyCase)
+
+
 
 
   val mixedReqHeadersNoRepeatCase : TestCase = (requestHeadersNoRepeatWADL,
@@ -1994,11 +3432,41 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
 
   run(mixedReqHeadersDefaultCase)
 
+
+  val mixedReqHeadersDefaultAllCase : TestCase = (requestHeadersAllMatchWADL,
+                                               List(checkHeadersDefaultsConfig, checkHeadersDefaultsConfigDups),
+                                               List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderDefaultHeaderTestsAll))
+
+  run(mixedReqHeadersDefaultAllCase)
+
+
+  val mixedReqHeadersDefaultAnyCase : TestCase = (requestHeadersWADL,
+                                               List(checkHeadersDefaultsConfigDisableAnyMatch, checkHeadersDefaultsConfigDupsDisableAnyMatch),
+                                               List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderDefaultHeaderTestsAll))
+
+  run(mixedReqHeadersDefaultAnyCase)
+
+
+
   val mixedReqHeadersMsgDefaultCase : TestCase = (requestHeadersWADL,
                                                   List(checkHeadersMsgDefaultsConfig, checkHeadersMsgDefaultsConfigDups),
                                                   List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedReqHeaderMsgDefaultHeaderTests))
 
   run(mixedReqHeadersMsgDefaultCase)
+
+
+  val mixedReqHeadersMsgDefaultAllCase : TestCase = (requestHeadersAllMatchWADL,
+                                                  List(checkHeadersMsgDefaultsConfig, checkHeadersMsgDefaultsConfigDups),
+                                                  List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderMsgDefaultHeaderTestsAll))
+
+  run(mixedReqHeadersMsgDefaultAllCase)
+
+
+  val mixedReqHeadersMsgDefaultAnyCase : TestCase = (requestHeadersWADL,
+                                                  List(checkHeadersMsgDefaultsConfigDisableAnyMatch, checkHeadersMsgDefaultsConfigDupsDisableAnyMatch),
+                                                  List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderMsgDefaultHeaderTestsAll))
+
+  run(mixedReqHeadersMsgDefaultAnyCase)
 
 
 

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/step/StepSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/step/StepSuite.scala
@@ -4646,6 +4646,1623 @@ class StepSuite extends BaseStepSuite with MockitoSugar {
     assert (newContext.get.requestHeaders.get("X-TEST").get == List("FOO", "BAR"),"The header should be set in the context with the correct value")
   }
 
+
+  test ("In a headerAll step, with a single RegEx value if the header is not avaliable the result of checkStep should be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r),  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header is not available a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r),  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("foo"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("foo"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header is not available and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r),  Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header is not available and a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r),  None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("foo"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("foo"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header is not available and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r),  Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header value does not match the result of checkStep should be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r),  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header value does not match a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r),  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("foo"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("foo"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header vaule does not match and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r),  Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header value does not match a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r),  None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("foo"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("foo"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header value does not match and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r),  Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header value contains multiple values and some do not match then checkStep should return None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("foo", "goo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header contains multiple values and some do not match a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("foo", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("did not match"))
+    assert (req1.contentError.getMessage.contains("FOO"))
+    assert (req1.contentError.getMessage.contains("BAR"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("did not match"))
+    assert (req2.contentError.getMessage.contains("goo"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header contains multiple values and some do not match and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r), Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("foo", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header contains multiple values and some do not match and a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r), None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("foo", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("did not match"))
+    assert (req1.contentError.getMessage.contains("FOO"))
+    assert (req1.contentError.getMessage.contains("BAR"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("did not match"))
+    assert (req2.contentError.getMessage.contains("goo"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header contians multiple values and some do not match and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r), Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("foo", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header contians a single valid value, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("foo")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("foo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header contians a single valid value, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("foo")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("foo")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+  }
+
+
+  test ("In a headerAll step, with a single RegEx value , if the header contians multiple valid values, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("foo","foo")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("foo","foo","foo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header contians a multiple valid values, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("foo", "foo")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("foo", "foo", "foo")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+  }
+
+
+  test("In a headerAll step, with a single RegEx value , if the header contains a valid value and a capture header is specified then it should be set"){
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r), None, None, Some("X-TEST-COPY"), 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("foo")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("foo")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.get("X-TEST-COPY").get == List("foo"))
+    assert (ctx2.get.requestHeaders.get("X-TEST-COPY").get == List("foo"))
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header contians a single or multiple valid value, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("f.*".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("fun")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("function","future", "furthermore")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a single RegEx value , if the header contians a single or multiple  valid value, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("f.*".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("fun")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("function","future", "furthermore")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+  }
+
+  test("In a headerAll step, with a single RegEx value , if the header contains a valid value or multiple values and a capture header is specified then it should be set"){
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("f.*".r), None, None, Some("X-TEST-COPY"), 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("fun")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("function", "future", "furthermore")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.get("X-TEST-COPY").get == List("fun"))
+    assert (ctx2.get.requestHeaders.get("X-TEST-COPY").get == List("function", "future", "furthermore"))
+  }
+
+  test ("In a headerAll step, with a single XSD value if the header is not avaliable the result of checkStep should be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None,  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header is not available a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None,  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header is not available and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None,  Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header is not available and a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None,  None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header is not available and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None,  Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header value does not match the result of checkStep should be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None,  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header value does not match a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None,  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header vaule does not match and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None,  Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header value does not match a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None,  None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header value does not match and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None,  Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header value contains multiple values and some do not match then checkStep should return None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header contains multiple values and some do not match a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("did not match"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("BAR"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("did not match"))
+    assert (req2.contentError.getMessage.contains("goo"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header contains multiple values and some do not match and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header contains multiple values and some do not match and a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("did not match"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("BAR"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("did not match"))
+    assert (req2.contentError.getMessage.contains("goo"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header contians multiple values and some do not match and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header contians a single valid value, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header contians a single valid value, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+  }
+
+
+  test ("In a headerAll step, with a single XSD value , if the header contians multiple valid values, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7","c411271a-1ba9-11e6-acd4-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7","e6d9d404-1ba9-11e6-874f-28cfe92134e7","26171654-1baa-11e6-9c78-28cfe92134e7")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header contians a multiple valid values, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "c411271a-1ba9-11e6-acd4-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "e6d9d404-1ba9-11e6-874f-28cfe92134e7", "26171654-1baa-11e6-9c78-28cfe92134e7")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+  }
+
+
+  test("In a headerAll step, with a single XSD value , if the header contains a valid value and a capture header is specified then it should be set"){
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, None, None, Some("X-TEST-COPY"), 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("e6d9d404-1ba9-11e6-874f-28cfe92134e7")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.get("X-TEST-COPY").get == List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7"))
+    assert (ctx2.get.requestHeaders.get("X-TEST-COPY").get == List("e6d9d404-1ba9-11e6-874f-28cfe92134e7"))
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header contians a single or multiple valid value, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("26171654-1baa-11e6-9c78-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("678569ec-1baa-11e6-9fd0-28cfe92134e7","77efe348-1baa-11e6-8354-28cfe92134e7", "87bac87e-1baa-11e6-9219-28cfe92134e7")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a single XSD value , if the header contians a single or multiple  valid value, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("26171654-1baa-11e6-9c78-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("678569ec-1baa-11e6-9fd0-28cfe92134e7","77efe348-1baa-11e6-8354-28cfe92134e7", "87bac87e-1baa-11e6-9219-28cfe92134e7")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+  }
+
+  test("In a headerAll step, with a single XSD value , if the header contains a valid value or multiple values and a capture header is specified then it should be set"){
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType)), Some(testSchema), None, None, None, Some("X-TEST-COPY"), 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("26171654-1baa-11e6-9c78-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("678569ec-1baa-11e6-9fd0-28cfe92134e7", "77efe348-1baa-11e6-8354-28cfe92134e7", "87bac87e-1baa-11e6-9219-28cfe92134e7")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.get("X-TEST-COPY").get == List("26171654-1baa-11e6-9c78-28cfe92134e7"))
+    assert (ctx2.get.requestHeaders.get("X-TEST-COPY").get == List("678569ec-1baa-11e6-9fd0-28cfe92134e7", "77efe348-1baa-11e6-8354-28cfe92134e7", "87bac87e-1baa-11e6-9219-28cfe92134e7"))
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value if the header is not avaliable the result of checkStep should be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None,  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header is not available a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None,  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header is not available and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None,  Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header is not available and a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None,  None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header is not available and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None,  Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header value does not match the result of checkStep should be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None,  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header value does not match a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None,  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header vaule does not match and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None,  Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header value does not match a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None,  None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header value does not match and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None,  Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header value contains multiple values and some do not match then checkStep should return None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header contains multiple values and some do not match a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("did not match"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentError.getMessage.contains("BAR"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("did not match"))
+    assert (req2.contentError.getMessage.contains("goo"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header contains multiple values and some do not match and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header contains multiple values and some do not match and a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("did not match"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentError.getMessage.contains("BAR"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("did not match"))
+    assert (req2.contentError.getMessage.contains("goo"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header contians multiple values and some do not match and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header contians a single valid value, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header contians a single valid value, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+  }
+
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header contians multiple valid values, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7","c411271a-1ba9-11e6-acd4-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7","e6d9d404-1ba9-11e6-874f-28cfe92134e7","26171654-1baa-11e6-9c78-28cfe92134e7")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header contians a multiple valid values, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "c411271a-1ba9-11e6-acd4-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "e6d9d404-1ba9-11e6-874f-28cfe92134e7", "ACCEPT")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+  }
+
+
+  test("In a headerAll step, with a multiple XSDs value , if the header contains a valid value and a capture header is specified then it should be set"){
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, None, None, Some("X-TEST-COPY"), 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("e6d9d404-1ba9-11e6-874f-28cfe92134e7")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.get("X-TEST-COPY").get == List("START"))
+    assert (ctx2.get.requestHeaders.get("X-TEST-COPY").get == List("e6d9d404-1ba9-11e6-874f-28cfe92134e7"))
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header contians a single or multiple valid value, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("26171654-1baa-11e6-9c78-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("678569ec-1baa-11e6-9fd0-28cfe92134e7","ACCEPT", "87bac87e-1baa-11e6-9219-28cfe92134e7")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs value , if the header contians a single or multiple  valid value, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("26171654-1baa-11e6-9c78-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("678569ec-1baa-11e6-9fd0-28cfe92134e7","ACCEPT", "87bac87e-1baa-11e6-9219-28cfe92134e7")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+  }
+
+  test("In a headerAll step, with a multiple XSDs value , if the header contains a valid value or multiple values and a capture header is specified then it should be set"){
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), None, None, None, Some("X-TEST-COPY"), 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("26171654-1baa-11e6-9c78-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("678569ec-1baa-11e6-9fd0-28cfe92134e7", "ACCEPT", "87bac87e-1baa-11e6-9219-28cfe92134e7")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.get("X-TEST-COPY").get == List("26171654-1baa-11e6-9c78-28cfe92134e7"))
+    assert (ctx2.get.requestHeaders.get("X-TEST-COPY").get == List("678569ec-1baa-11e6-9fd0-28cfe92134e7", "ACCEPT", "87bac87e-1baa-11e6-9219-28cfe92134e7"))
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value if the header is not avaliable the result of checkStep should be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r),  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header is not available a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r),  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header is not available and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r),  Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header is not available and a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r),  None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header is not available and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r),  Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map[String, List[String]]())
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST"->List("FOO")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header value does not match the result of checkStep should be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r),  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header value does not match a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r),  None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header vaule does not match and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r),  Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header value does not match a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r),  None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header value does not match and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r),  Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("FOO")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header value contains multiple values and some do not match then checkStep should return None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "foo", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) == None)
+    assert (header.checkStep(req2, response, chain, StepContext()) == None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contains multiple values and some do not match a correct error message should be set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "foo", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("did not match"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentError.getMessage.contains("BAR"))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("did not match"))
+    assert (req2.contentError.getMessage.contains("goo"))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contains multiple values and some do not match and a custom message is set, make sure the message is reflected") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), Some("Error! :-("), None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "foo", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 400)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 400)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contains multiple values and some do not match and a custom error code is set, then the error code should be retuned") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), None, Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "foo", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("xpecting"))
+    assert (req1.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req1.contentError.getMessage.contains("did not match"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}UUID"))
+    assert (req1.contentError.getMessage.contains("{http://www.rackspace.com/repose/wadl/checker/step/test}StepType"))
+    assert (req1.contentError.getMessage.contains("BAR"))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("xpecting"))
+    assert (req2.contentError.getMessage.contains("X-TEST-HEADER"))
+    assert (req2.contentError.getMessage.contains("did not match"))
+    assert (req2.contentError.getMessage.contains("goo"))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contians multiple values and some do not match and a custom error code and message is set, then then these should be returend") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), Some("Error! :-("), Some(403), None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "foo", "BAR")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "goo")))
+
+    header.checkStep(req1, response, chain, StepContext())
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[Exception])
+    assert (req1.contentError.getMessage.contains("Error! :-("))
+    assert (req1.contentErrorCode == 403)
+    assert (req1.contentErrorPriority == 12345)
+    header.checkStep(req2, response, chain, StepContext())
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[Exception])
+    assert (req2.contentError.getMessage.contains("Error! :-("))
+    assert (req2.contentErrorCode == 403)
+    assert (req2.contentErrorPriority == 12345)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contians a single valid value, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7")))
+    val req3 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("foo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+    assert (header.checkStep(req3, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contians a single valid value, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7")))
+    val req3 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("foo")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+    val ctx3 = header.checkStep(req3, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+    assert (ctx3.get.requestHeaders.isEmpty)
+  }
+
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contians multiple valid values, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START","c411271a-1ba9-11e6-acd4-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7","foo","ACCEPT")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contians a multiple valid values, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START", "c411271a-1ba9-11e6-acd4-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("4f8d8f24-1ba8-11e6-a581-28cfe92134e7", "foo", "ACCEPT")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+  }
+
+
+  test("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contains a valid value and a capture header is specified then it should be set"){
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), None, None, Some("X-TEST-COPY"), 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("START")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("e6d9d404-1ba9-11e6-874f-28cfe92134e7")))
+    val req3 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("foo")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+    val ctx3 = header.checkStep(req3, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.get("X-TEST-COPY").get == List("START"))
+    assert (ctx2.get.requestHeaders.get("X-TEST-COPY").get == List("e6d9d404-1ba9-11e6-874f-28cfe92134e7"))
+    assert (ctx3.get.requestHeaders.get("X-TEST-COPY").get == List("foo"))
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contians a single or multiple valid value, then the return context should not be None") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("26171654-1baa-11e6-9c78-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("678569ec-1baa-11e6-9fd0-28cfe92134e7","ACCEPT", "foo")))
+
+    assert (header.checkStep(req1, response, chain, StepContext()) != None)
+    assert (header.checkStep(req2, response, chain, StepContext()) != None)
+  }
+
+  test ("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contians a single or multiple  valid value, then the return context should not have additional headers set") {
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), None, None, None, 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("26171654-1baa-11e6-9c78-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("678569ec-1baa-11e6-9fd0-28cfe92134e7","ACCEPT", "foo")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.isEmpty)
+    assert (ctx2.get.requestHeaders.isEmpty)
+  }
+
+  test("In a headerAll step, with a multiple XSDs and a RegEx value , if the header contains a valid value or multiple values and a capture header is specified then it should be set"){
+    val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", Some(List(uuidType, stepType)), Some(testSchema), Some("foo".r), None, None, Some("X-TEST-COPY"), 12345, Array[Step]())
+
+    val req1 = request("GET", "/path/to/resource", "", "", false, Map("X-TEST-HEADER"->List("26171654-1baa-11e6-9c78-28cfe92134e7")))
+    val req2 = request("GET", "/path/to/resource", "", "", false, Map("X-test-HEADER"->List("678569ec-1baa-11e6-9fd0-28cfe92134e7", "ACCEPT", "foo")))
+
+    val ctx1 = header.checkStep(req1, response, chain, StepContext())
+    val ctx2 = header.checkStep(req2, response, chain, StepContext())
+
+    assert (ctx1.get.requestHeaders.get("X-TEST-COPY").get == List("26171654-1baa-11e6-9c78-28cfe92134e7"))
+    assert (ctx2.get.requestHeaders.get("X-TEST-COPY").get == List("678569ec-1baa-11e6-9fd0-28cfe92134e7", "ACCEPT", "foo"))
+  }
+
   test ("In a JSON Schema test, if the content contains valid JSON, the uriLevel should stay the same.") {
     val jsonSchema = new JSONSchema("JSONSchema","JSONSchema", testJSONSchema, 10, Array[Step]())
     val req1 = request ("PUT", "/a/b", "application/json", """

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
@@ -254,6 +254,66 @@ class BaseCheckerSpec extends BaseWADLSpec {
     stepsWithType(checker, "SET_HEADER").filter (n => (n \ "@name").text == name).filter (n => (n \ "@value").text == value)
   }
 
+  def stepsWithHeaderAll(checker : NodeSeq, name : String) : NodeSeq = {
+    stepsWithType(checker, "HEADER_ALL").filter (n => (n \ "@name").text == name)
+  }
+
+  def stepsWithHeaderAllValue(checker : NodeSeq, name : String, value : String) : NodeSeq = {
+    stepsWithHeaderAll(checker, name).filter (n => (n \ "@matchRegEx").text == value)
+  }
+
+  def stepsWithHeaderAllMatchTypes(checker : NodeSeq, name : String, matchTypes : String) : NodeSeq = {
+    stepsWithHeaderAll(checker, name).filter (n => (n \ "@match").text == matchTypes)
+  }
+
+  def stepsWithHeaderAllValueMessage(checker : NodeSeq, name : String, value : String, message : String) : NodeSeq = {
+    stepsWithHeaderAllValue(checker, name, value).filter(n => (n \ "@message").text == message)
+  }
+
+  def stepsWithHeaderAllValueMessageCode(checker : NodeSeq, name : String, value : String, message : String, code : Int) : NodeSeq = {
+    stepsWithHeaderAllValueMessage(checker, name, value, message).filter(n => (n \ "@code").text == code.toString)
+  }
+
+  def stepsWithHeaderAllValueCode(checker : NodeSeq, name : String, value : String, code : Int) : NodeSeq = {
+    stepsWithHeaderAllValue(checker, name, value).filter(n => (n \ "@code").text == code.toString)
+  }
+
+  def stepsWithHeaderAllMatchTypesMessage(checker : NodeSeq, name : String, matchTypes : String, message : String) : NodeSeq = {
+    stepsWithHeaderAllMatchTypes(checker, name, matchTypes).filter(n => (n \ "@message").text == message)
+  }
+
+  def stepsWithHeaderAllMatchTypesMessageCode(checker : NodeSeq, name : String, matchTypes : String, message : String, code : Int) : NodeSeq = {
+    stepsWithHeaderAllMatchTypesMessage(checker, name, matchTypes, message).filter(n => (n \ "@code").text == code.toString)
+  }
+
+  def stepsWithHeaderAllMatchTypesCode(checker : NodeSeq, name : String, matchTypes : String, code : Int) : NodeSeq = {
+    stepsWithHeaderAllMatchTypes(checker, name, matchTypes).filter(n => (n \ "@code").text == code.toString)
+  }
+
+  def stepsWithHeaderAllValueMatchTypes(checker : NodeSeq, name : String, value : String, matchTypes : String) : NodeSeq = {
+    stepsWithHeaderAllValue(checker, name, value).filter (n => (n \ "@match").text == matchTypes)
+  }
+
+  def stepsWithHeaderAllValueMatchTypesMessage(checker : NodeSeq, name : String, value : String, matchTypes : String, message : String) : NodeSeq = {
+    stepsWithHeaderAllValueMatchTypes(checker, name, value, matchTypes).filter(n => (n \ "@message").text == message)
+  }
+
+  def stepsWithHeaderAllValueMatchTypesCode(checker : NodeSeq, name : String, value : String, matchTypes : String, code : Int) : NodeSeq = {
+    stepsWithHeaderAllValueMatchTypes(checker, name, value, matchTypes).filter(n => (n \ "@code").text == code.toString)
+  }
+
+  def stepsWithHeaderAllValueMatchTypesMessageCode(checker : NodeSeq, name : String, value : String, matchTypes : String, message : String, code : Int) : NodeSeq = {
+    stepsWithHeaderAllValueMatchTypesMessage(checker, name, value, matchTypes, message).filter(n => (n \ "@code").text == code.toString)
+  }
+
+  def stepsWithHeaderAllValueMatchTypesMessageCodeCaptureHeader(checker : NodeSeq, name : String, value : String, matchTypes : String, message : String,
+    code : Int, captureHeader : String) : NodeSeq = {
+    stepsWithHeaderAllValueMatchTypesMessageCode(checker, name, value, matchTypes, message, code).filter(n => (n \ "@captureHeader").text == captureHeader)
+  }
+
+
+
+
   def Start : (NodeSeq) => NodeSeq = stepsWithType(_, "START")
   def Accept : (NodeSeq) => NodeSeq = stepsWithType(_, "ACCEPT")
   def URLFail : (NodeSeq) => NodeSeq = stepsWithType(_, "URL_FAIL")
@@ -311,7 +371,20 @@ class BaseCheckerSpec extends BaseWADLSpec {
   def HeaderXSDSingle(name : String, headerMatch : String, message : String) : (NodeSeq) => NodeSeq = stepsWithHeaderXSDSingleMessageMatch (_, name, headerMatch, message)
   def HeaderXSDSingle(name : String, headerMatch : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithHeaderXSDSingleCodeMatch (_, name, headerMatch, code)
   def HeaderXSDSingle(name : String, headerMatch : String, message : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithHeaderXSDSingleMessageCodeMatch (_, name, headerMatch, message, code)
-
+  def HeaderAll(name : String, headerMatch : String) : (NodeSeq) => NodeSeq = stepsWithHeaderAllValue(_, name, headerMatch)
+  def HeaderAll(name : String, headerMatch : String, message : String) : (NodeSeq) => NodeSeq = stepsWithHeaderAllValueMessage(_, name, headerMatch, message)
+  def HeaderAll(name : String, headerMatch : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithHeaderAllValueCode(_, name, headerMatch, code)
+  def HeaderAll(name : String, headerMatch : String, message : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithHeaderAllValueMessageCode(_, name, headerMatch, message, code)
+  def HeaderAllWithTypes(name : String, matchTypes : String) : (NodeSeq) => NodeSeq = stepsWithHeaderAllMatchTypes(_, name, matchTypes)
+  def HeaderAllWithTypes(name : String, matchTypes : String, message : String) : (NodeSeq) => NodeSeq = stepsWithHeaderAllMatchTypesMessage(_, name, matchTypes, message)
+  def HeaderAllWithTypes(name : String, matchTypes : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithHeaderAllMatchTypesCode(_, name, matchTypes, code)
+  def HeaderAllWithTypes(name : String, matchTypes : String, message : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithHeaderAllMatchTypesMessageCode(_, name, matchTypes, message, code)
+  def HeaderAllWithMatchAndTypes(name : String, headerMatch : String, matchTypes : String) : (NodeSeq) => NodeSeq = stepsWithHeaderAllValueMatchTypes(_, name, headerMatch, matchTypes)
+  def HeaderAllWithMatchAndTypes(name : String, headerMatch : String, matchTypes : String, message : String) : (NodeSeq) => NodeSeq = stepsWithHeaderAllValueMatchTypesMessage(_, name, headerMatch, matchTypes, message)
+  def HeaderAllWithMatchAndTypes(name : String, headerMatch : String, matchTypes : String, code : Int) : (NodeSeq) => NodeSeq =
+    stepsWithHeaderAllValueMatchTypesCode(_, name, headerMatch, matchTypes, code)
+  def HeaderAllWithMatchAndTypes(name : String, headerMatch : String, matchTypes : String, message : String, code : Int) : (NodeSeq) => NodeSeq =
+    stepsWithHeaderAllValueMatchTypesMessageCode(_, name, headerMatch, matchTypes, message, code)
 
   def SetHeader(name : String, value : String) : (NodeSeq) => NodeSeq = stepsWithSetHeader(_, name, value)
 

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerAssertSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerAssertSpec.scala
@@ -1843,7 +1843,7 @@ val configAdvance = {
       Then ("The checker should be rejected with an appropriate message")
       assert(checkerLog, "d47e23WF")
       assert(checkerLog, "reference")
-      assert(checkerLog, "WELL_XML or WELL_JSON or XSD or XPATH or XSL or HEADER or HEADERXSD or HEADER_ANY or HEADERXSD_ANY or HEADER_SINGLE or HEADERXSD_SINGLE or JSON_SCHEMA")
+      assert(checkerLog, "WELL_XML or WELL_JSON or XSD or XPATH or XSL or HEADER or HEADERXSD or HEADER_ANY or HEADERXSD_ANY or HEADER_SINGLE or HEADERXSD_SINGLE or HEADER_ALL or JSON_SCHEMA")
     }
 
     scenario ("Checker with a missing CONTENT_FAIL step (WELL_XML)") {

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerRaxCaptureHeaderSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerRaxCaptureHeaderSpec.scala
@@ -160,49 +160,49 @@ class WADLCheckerRaxCaptureHeaderSpec extends BaseCheckerSpec {
         <resource path="path/to/resource1">
           <method name="GET" rax:roles="headerRole">
             <request>
-              <param name="MyHeader" style="header" required="true" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" repeating="true"
                      rax:captureHeader="X-DEVICE-ID"/>
-              <param name="OtherHeader" style="header" required="true" repeating="true"
+              <param name="OtherHeader" style="header" rax:anyMatch="true" required="true" repeating="true"
                      type="xs:int"/>
             </request>
           </method>
           <method name="POST">
             <request>
-              <param name="MyHeader" style="header" required="true" fixed="FOO" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="FOO" repeating="true"
                      rax:captureHeader="X-DEVICE-ID"/>
-              <param name="MyHeader" style="header" required="true" fixed="FAR" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="FAR" repeating="true"
                      rax:captureHeader="X-DEVICE-ID"/>
-              <param name="MyHeader" style="header" required="true" fixed="OUT" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="OUT" repeating="true"
                      rax:captureHeader="X-DEVICE-ID"/>
             </request>
           </method>
           <method name="PUT">
             <request>
-              <param name="MyHeader" style="header" required="true" fixed="FOO" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="FOO" repeating="true"
                      type="xs:string" rax:captureHeader="X-DEVICE-ID"/>
-              <param name="MyHeader" style="header" required="true" fixed="FAR" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="FAR" repeating="true"
                      type="xs:string"/>
-              <param name="MyHeader" style="header" required="true" fixed="OUT" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="OUT" repeating="true"
                      type="xs:string"/>
             </request>
           </method>
           <method name="DELETE">
             <request>
-              <param name="MyHeader" style="header" required="true" fixed="1" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="1" repeating="true"
                      type="xs:int" rax:captureHeader="X-DEVICE-ID"/>
-              <param name="MyHeader" style="header" required="true" fixed="2" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="2" repeating="true"
                      type="xs:int" rax:captureHeader="X-DEVICE-ID"/>
-              <param name="MyHeader" style="header" required="true" fixed="3" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="3" repeating="true"
                      type="xs:int" rax:captureHeader="X-DEVICE-ID"/>
             </request>
           </method>
           <method name="PATCH">
             <request>
-              <param name="MyHeader" style="header" required="true" fixed="1" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="1" repeating="true"
                      type="xs:int" rax:captureHeader="X-DEVICE-ID"/>
-              <param name="MyHeader" style="header" required="true" fixed="2" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="2" repeating="true"
                      type="xs:int"/>
-              <param name="MyHeader" style="header" required="true" fixed="3" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="3" repeating="true"
                      type="xs:int"/>
             </request>
           </method>
@@ -275,49 +275,49 @@ class WADLCheckerRaxCaptureHeaderSpec extends BaseCheckerSpec {
         <resource path="path/to/resource1">
           <method name="GET" rax:roles="headerRole">
             <request>
-              <param name="MyHeader" style="header" required="true" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" repeating="true"
                      rax:device="true"/>
-              <param name="OtherHeader" style="header" required="true" repeating="true"
+              <param name="OtherHeader" style="header" rax:anyMatch="true" required="true" repeating="true"
                      type="xs:int"/>
             </request>
           </method>
           <method name="POST">
             <request>
-              <param name="MyHeader" style="header" required="true" fixed="FOO" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="FOO" repeating="true"
                      rax:device="true"/>
-              <param name="MyHeader" style="header" required="true" fixed="FAR" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="FAR" repeating="true"
                      rax:device="true"/>
-              <param name="MyHeader" style="header" required="true" fixed="OUT" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="OUT" repeating="true"
                      rax:device="true"/>
             </request>
           </method>
           <method name="PUT">
             <request>
-              <param name="MyHeader" style="header" required="true" fixed="FOO" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="FOO" repeating="true"
                      type="xs:string" rax:device="true"/>
-              <param name="MyHeader" style="header" required="true" fixed="FAR" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="FAR" repeating="true"
                      type="xs:string"/>
-              <param name="MyHeader" style="header" required="true" fixed="OUT" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="OUT" repeating="true"
                      type="xs:string"/>
             </request>
           </method>
           <method name="DELETE">
             <request>
-              <param name="MyHeader" style="header" required="true" fixed="1" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="1" repeating="true"
                      type="xs:int" rax:device="true"/>
-              <param name="MyHeader" style="header" required="true" fixed="2" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="2" repeating="true"
                      type="xs:int" rax:device="true"/>
-              <param name="MyHeader" style="header" required="true" fixed="3" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="3" repeating="true"
                      type="xs:int" rax:device="true"/>
             </request>
           </method>
           <method name="PATCH">
             <request>
-              <param name="MyHeader" style="header" required="true" fixed="1" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="1" repeating="true"
                      type="xs:int" rax:device="true"/>
-              <param name="MyHeader" style="header" required="true" fixed="2" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="2" repeating="true"
                      type="xs:int"/>
-              <param name="MyHeader" style="header" required="true" fixed="3" repeating="true"
+              <param name="MyHeader" style="header" rax:anyMatch="true" required="true" fixed="3" repeating="true"
                      type="xs:int"/>
             </request>
           </method>


### PR DESCRIPTION
The idea with HEADER_ALL is that you can say something like a header can be xsd:int or xsd:dateTime, but can't be anything else.  This is different from HEADER_ANY, which is currently the default -- this allows xsd:int, xsd:dateTime if any value matches then things go through.. but a value of "foo" won't be rejected.

HEADER_ALL should be the default instead of HEADER_ANY. -- you should be able to reactivate HEADER_ANY support via an extension.