### PR TITLE
A call to getInputStream should invalidate cached XML or JSON...

### DIFF
--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/CheckerServletRequest.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/CheckerServletRequest.scala
@@ -165,6 +165,7 @@ class CheckerServletRequest(val request : HttpServletRequest) extends HttpServle
       } catch {
         case e : Exception => throw new IOException("Error while serializing!", e)
       } finally {
+        parsedXML = null
         returnTransformer(transformer)
       }
     } else if (parsedJSON != null) {
@@ -173,6 +174,7 @@ class CheckerServletRequest(val request : HttpServletRequest) extends HttpServle
         om = ObjectMapperPool.borrowParser
         new ByteArrayServletInputStream(om.writeValueAsBytes(parsedJSON))
       } finally {
+        parsedJSON = null
         if (om != null) {
           ObjectMapperPool.returnParser(om)
         }


### PR DESCRIPTION
We don't know if the call to getInputStream is transforming the request and an api-checker further in the chain may get the old data.