### PR TITLE
Make sure we maintain spaces and comments in XML

### DIFF
--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/XMLParserPool.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/XMLParserPool.scala
@@ -39,14 +39,16 @@ private class XMLParserFactory extends PoolableObjectFactory[DocumentBuilder] {
 
   //
   //  Setup the builder factory so that it works within the security
-  //  constraints of a webservice.
+  //  constraints of a webservice, but preserves comments and
+  //  whitespaces.
   //
   builderFactory.setCoalescing(true)
-  builderFactory.setIgnoringComments(true)
+  builderFactory.setIgnoringComments(false)
   builderFactory.setNamespaceAware(true)
   builderFactory.setValidating(false)
   builderFactory.setXIncludeAware(false)
   builderFactory.setExpandEntityReferences (false)
+  builderFactory.setIgnoringElementContentWhitespace(false)
   builderFactory.setFeature (FEATURE_SECURE_PROCESSING, true)
 
   def makeObject = builderFactory.newDocumentBuilder()

--- a/core/src/test/resources/xml/sample.xml
+++ b/core/src/test/resources/xml/sample.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xml xmlns="http://valid">
+  This is valid XML
+  Here     we have a processing instruction<?pr?>
+
+  <element att="1">
+    <!-- He we have a comment -->
+    <subElement />
+  </element>
+</xml>


### PR DESCRIPTION
We currently lose these when we processes XML and have no idea if the backend service needs the data.