### PR TITLE
Request body issues sometimes causes the request input stream to be closed

### DIFF
--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/CheckerServletRequest.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/CheckerServletRequest.scala
@@ -70,6 +70,12 @@ class CheckerServletRequest(val request : HttpServletRequest) extends HttpServle
                          Array[String]()
   }
 
+  private var clearInput = false
+
+  def clearInputStream : Unit = {
+    clearInput = true
+  }
+
   def pathToSegment(uriLevel : Int) : String = {
     "/" + URISegment.slice(0, uriLevel).reduceLeft( _ + "/" +_ )
   }
@@ -154,7 +160,9 @@ class CheckerServletRequest(val request : HttpServletRequest) extends HttpServle
   }
 
   override def getInputStream : ServletInputStream = {
-    if (parsedXML != null) {
+    if (clearInput) {
+      new ByteArrayServletInputStream(Array[Byte]())
+    } else if (parsedXML != null) {
       var transformer : Transformer = null
       val bout = new ByteArrayOutputStream()
       try {
@@ -185,7 +193,9 @@ class CheckerServletRequest(val request : HttpServletRequest) extends HttpServle
   }
 
   override def getReader : BufferedReader = {
-    if (parsedXML != null) {
+    if (clearInput) {
+      new BufferedReader(new InputStreamReader (getInputStream, "UTF-8"))
+    } else if (parsedXML != null) {
       new BufferedReader(new InputStreamReader (getInputStream, parsedXML.getInputEncoding))
     } else if (parsedJSON != null) {
       new BufferedReader(new InputStreamReader (getInputStream, "UTF-8"))

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/WellFormedJSON.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/WellFormedJSON.scala
@@ -38,6 +38,7 @@ class WellFormedJSON(id : String, label : String, val priority : Long, next : Ar
     } catch {
       case e : Exception => req.contentError = e
                             req.contentErrorPriority = priority
+                            req.clearInputStream
     } finally {
       if (parser != null) returnParser(parser)
     }

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/WellFormedXML.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/WellFormedXML.scala
@@ -41,6 +41,7 @@ class WellFormedXML(id : String, label : String, val priority : Long, next : Arr
     }catch {
       case e : Exception => req.contentError = e
                             req.contentErrorPriority = priority
+                            req.clearInputStream
     }
     finally {
       if (parser != null) returnParser(parser)


### PR DESCRIPTION
I don't have as much information about the issue as I would have liked, but I'm hoping the error pattern points to something.

When Repose is configured with API Validator and any other filter, if IntraFilter Logging is turned on, it will  sometimes fail because the input stream has been closed.  This error happens when we try to read the contents of the stream in the request (either to copy them to another stream or to copy them to a string for printing).

All of the cases I tried were error cases (i.e. bad request body).  The requests all had a Content Type of "application/atom+xml".

When I send => What I get
Some random text => stream closed error
JSON text => stream closed error
XML with root element: <a/> => nice error with message "Bad Content: Expecting the root element to be: atom:entry"
XML with root element: <atom:entry/> => stream closed error

So some type of XML check isn't closing the stream but another type is.

I put more details about my testing here:  https://repose.atlassian.net/browse/REP-3894