### PR TITLE
Fixed values not working in template parameters...

### DIFF
--- a/core/src/main/resources/xsl/builder.xsl
+++ b/core/src/main/resources/xsl/builder.xsl
@@ -467,10 +467,12 @@
             </xsl:choose>
         </xsl:variable>
         <xsl:variable name="templatePath" select="starts-with(@path,'{')" as="xsd:boolean"/>
+        <xsl:variable name="templatePathFixedValue" as="xsd:string?"
+                      select="if ($templatePath) then check:paramForTemplatePath(.)/@fixed else ()"/>
         <step>
             <xsl:attribute name="type">
                 <xsl:choose>
-                    <xsl:when test="$templatePath and check:isXSDURL(.)">
+                    <xsl:when test="$templatePath and not($templatePathFixedValue) and check:isXSDURL(.)">
                         <xsl:text>URLXSD</xsl:text>
                     </xsl:when>
                     <xsl:otherwise>
@@ -481,6 +483,9 @@
             <xsl:attribute name="id" select="generate-id()"/>
             <xsl:attribute name="match">
                 <xsl:choose>
+                    <xsl:when test="$templatePathFixedValue">
+                        <xsl:value-of select="check:toRegExEscaped($templatePathFixedValue)"/>
+                    </xsl:when>
                     <xsl:when test="$templatePath">
                         <xsl:call-template name="check:getTemplateMatch"/>
                     </xsl:when>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLSuite.scala
@@ -369,6 +369,39 @@ class ValidatorWADLSuite extends BaseValidatorSuite {
   }
 
   //
+  // validator_FIXED allows a GET on /a/FOO/c. That is, the 2nd URI
+  // component may be the value FOO, but foo is described as a FIXED
+  // string. The validator is used in the following tests.
+  //
+  val validator_FIXED = Validator(
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="a/{foo}/c">
+                   <param name="foo" style="template" type="xsd:string" fixed="FOO"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+    </application>
+    , assertConfig)
+
+  test ("GET on /a/FOO/c should pass with validator_FOO") {
+    validator_FIXED.validate(request("GET","/a/FOO/c"), response, chain)
+  }
+
+  test ("GET on /a/foo/c should fail on validator_FOO") {
+    assertResultFailed(validator_FIXED.validate(request("GET","/a/foo/c"), response, chain), 404)
+  }
+
+  test ("GET on /a/bar/c should fail on validator_FOO") {
+    assertResultFailed(validator_FIXED.validate(request("GET","/a/bar/c"), response, chain), 404)
+  }
+
+  //
   // validator_RT allows:
   //
   // PUT /a/b with json and xml support


### PR DESCRIPTION
````xml
<?xml version="1.0" encoding="UTF-8"?>

<application  xmlns="http://wadl.dev.java.net/2009/02"
              xmlns:xs="http://www.w3.org/2001/XMLSchema"
              xmlns:lbbpi="http://doc.rackspace.com/apis/lbbpi"
              xmlns:rax="http://docs.rackspace.com/api">
    <grammars>
        <xs:schema targetNamespace="http://doc.rackspace.com/apis/lbbpi">
            <xs:simpleType name="BigBucketType">
                <xs:restriction base="xs:string">
                    <xs:assertion test="$value != 'rsag'"/>
                </xs:restriction>
            </xs:simpleType>
        </xs:schema>
    </grammars>
    <resources>
        <resource path="/a/{rsag}/b/c">
            <param style="template" name="rsag" type="xs:string" required="true" fixed="rsag"/>
            <method name="GET" rax:roles="RSAG"/>
        </resource>
        <resource path="/a/{other}/b/c">
            <param  style="template"  name="other" type="lbbpi:BigBucketType" required="true"/>
            <method name="GET" rax:roles="BigBucket"/>
        </resource>
    </resources>
</application>
````

Is producing 

![lb](https://cloud.githubusercontent.com/assets/348314/5842194/989e3c88-a168-11e4-8ae4-882066099065.png)


Notice that rsng should not be .*


