### PR TITLE
Set Warning Header when handling preproc extension and validation

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -769,10 +769,35 @@
       4. [X] Validator
       5. [X] capture header
       6. [X] rax:roles and rax:roles masked with other header_all
-** TODO Document Breaking Changes [3/3]
+** DONE Document Breaking Changes [3/3]
    1. [X] Use of repeating with headers
    2. [X] Use of header_all and header_any
    3. [X] capture_header and message and code changes
+** DONE SetHeaderAlways Step and introduce WARNING headers [3/3]
+   1. [X] SetHeaderAlways [5/5]
+      1. [X] Extend XSD to support SetHeaderAlways
+      2. [X] Checker assertions related to set header always (not needed)
+      3. [X] Ensure that optimizations work with header always
+      4. [X] Create new step
+      5. [X] Update handler for new step
+   2. [X] Warning Headers [4/4]
+      1. [X] Add Warning header config options
+      2. [X] Update builder to add new Warning headers
+      3. [X] Update CLI tools to support new config options
+      4. [X] Ensure that wadl2dot correctly lists set header always
+   3. [X] Testing [5/5]
+      1. [X] Config option, meta tests
+      2. [X] Fix broken tests
+      3. [X] Step
+      4. [X] Builder
+      5. [X] Validator [7/7]
+         1. [X] XSD with no grammer should not set warning
+         2. [X] XSD with grammer should set warning
+         3. [X] Preprocess with XSD no grammar (1 warning)
+         4. [X] Preprocess with XSD grammer (2 warnings)
+         5. [X] Many preprocesses (1 warning)
+         6. [X] Existing warning preserved
+         7. [X] Warn Agent config takes effect
 ** TODO Compile Performance improvements
 ** TODO Assign CONTENT_FAIL to XSL steps in builder
 ** TODO Investigate whether there is an issue with rax:roles with other headers

--- a/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
+++ b/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
@@ -88,6 +88,12 @@ object Wadl2Checker {
   val anyMatch  = parser.flag[Boolean] (List("a", "disable-any-match"),
                                             "Disable any match extension : false")
 
+  val warnHeaders = parser.flag[Boolean] (List("W", "disable-warn-headers"),
+                                          "Disable warn headers : false")
+
+  val warnAgent = parser.option[String] (List("A", "warn-agent"), "agent-name",
+                                            "The name of the agent used in WARNING headers. Default: -")
+
   val dontValidate = parser.flag[Boolean] (List("D", "dont-validate"),
                                        "Don't validate produced checker Default: false")
 
@@ -166,6 +172,8 @@ object Wadl2Checker {
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)
         c.validateChecker = !dontValidate.value.getOrElse(false)
+        c.enableWarnHeaders = !warnHeaders.value.getOrElse(false)
+        c.warnAgent = warnAgent.value.getOrElse("-")
 
         new WADLCheckerBuilder().build(getSource, getResult, c)
       }

--- a/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
+++ b/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
@@ -88,6 +88,12 @@ object Wadl2Dot {
   val anyMatch  = parser.flag[Boolean] (List("a", "disable-any-match"),
                                             "Disable any match extension : false")
 
+  val warnHeaders = parser.flag[Boolean] (List("W", "disable-warn-headers"),
+                                          "Disable warn headers : false")
+
+  val warnAgent = parser.option[String] (List("A", "warn-agent"), "agent-name",
+                                            "The name of the agent used in WARNING headers. Default: -")
+
 
   val dontValidate = parser.flag[Boolean] (List("D", "dont-validate"),
                                        "Don't validate produced checker Default: false")
@@ -169,6 +175,9 @@ object Wadl2Dot {
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)
         c.validateChecker = !dontValidate.value.getOrElse(false)
+        c.enableWarnHeaders = !warnHeaders.value.getOrElse(false)
+        c.warnAgent = warnAgent.value.getOrElse("-")
+
 
         new WADLDotBuilder().build(getSource, getResult,
           c,

--- a/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
+++ b/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
@@ -95,6 +95,13 @@ object WadlTest {
   val anyMatch  = parser.flag[Boolean] (List("a", "disable-any-match"),
                                             "Disable any match extension : false")
 
+  val warnHeaders = parser.flag[Boolean] (List("W", "disable-warn-headers"),
+                                          "Disable warn headers : false")
+
+  val warnAgent = parser.option[String] (List("A", "warn-agent"), "agent-name",
+                                            "The name of the agent used in WARNING headers. Default: -")
+
+
   val dontValidate = parser.flag[Boolean] (List("D", "dont-validate"),
                                        "Don't validate produced checker Default: false")
 
@@ -269,6 +276,9 @@ object WadlTest {
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)
         c.validateChecker = !dontValidate.value.getOrElse(false)
+        c.enableWarnHeaders = !warnHeaders.value.getOrElse(false)
+        c.warnAgent = warnAgent.value.getOrElse("-")
+
 
         val dot = File.createTempFile("chk", ".dot")
         dot.deleteOnExit()

--- a/core/src/main/resources/xsd/checker.xsd
+++ b/core/src/main/resources/xsd/checker.xsd
@@ -105,6 +105,7 @@
                 <alternative test="@type eq 'XPATH'" type="chk:XPathStep"/>
                 <alternative test="@type eq 'XSL'" type="chk:XSLStep"/>
                 <alternative test="@type eq 'SET_HEADER'" type="chk:SetHeaderStep"/>
+                <alternative test="@type eq 'SET_HEADER_ALWAYS'" type="chk:SetHeaderAlwaysStep"/>
                 <alternative test="@type eq 'HEADER'" type="chk:HeaderStep"/>
                 <alternative test="@type eq 'HEADERXSD'" type="chk:HeaderXSDStep"/>
                 <alternative test="@type eq 'HEADER_SINGLE'" type="chk:HeaderSingleStep"/>
@@ -365,6 +366,32 @@
                     added to the context with the given value. If a
                     header with the name already exist then no action
                     is taken.
+                </html:p>
+            </documentation>
+        </annotation>
+        <complexContent>
+          <extension base="chk:ConnectedStep">
+            <attribute name="name"  type="xsd:string" use="required"/>
+            <attribute name="value" type="xsd:string" use="required"/>
+          </extension>
+        </complexContent>
+    </complexType>
+
+    <complexType name="SetHeaderAlwaysStep">
+        <annotation>
+            <documentation xmlns:html="http://www.w3.org/1999/xhtml">
+                <html:p>
+                    Adds a header to the step context at this step,
+                    regardless of whether the header is already set.
+                </html:p>
+                <html:p>
+                    This step does not actually cause an assertion to
+                    occur, so the test never fails. If a header with
+                    the name does not exist, a new header will be
+                    added to the context with the given value. If a
+                    header with the name already exist then an
+                    additional header value will be set for that
+                    header.
                 </html:p>
             </documentation>
         </annotation>
@@ -778,6 +805,7 @@
             <enumeration value="XPATH"/>
             <enumeration value="XSL"/>
             <enumeration value="SET_HEADER"/>
+            <enumeration value="SET_HEADER_ALWAYS"/>
             <enumeration value="HEADER"/>
             <enumeration value="HEADERXSD"/>
             <enumeration value="HEADER_ANY"/>

--- a/core/src/main/resources/xsl/checker2dot.xsl
+++ b/core/src/main/resources/xsl/checker2dot.xsl
@@ -167,7 +167,7 @@
                                                  <xsl:text>ε (</xsl:text>
                                                  <xsl:choose>
                                                      <xsl:when test="$nextStep/@name">
-                                                         <xsl:value-of select="concat($nextStep/@name,':&#x2190;? ',$nextStep/@value)"/>
+                                                         <xsl:value-of select="concat($nextStep/@name,':&#x2190;? ',check:escapeRegex($nextStep/@value))"/>
                                                      </xsl:when>
                                                      <xsl:otherwise>
                                                          <xsl:value-of select="check:matchValue($nextStep)"/>
@@ -212,7 +212,7 @@
                          <xsl:value-of select="concat(@name,' : ',check:matchValue(.))"/>
                      </xsl:when>
                      <xsl:when test="@name and @value">
-                         <xsl:value-of select="concat(@name,':&#x2190;? ',@value)"/>
+                         <xsl:value-of select="concat(@name,':&#x2190;? ',check:escapeRegex(@value))"/>
                      </xsl:when>
                      <xsl:when test="@match or @matchRegEx">
                          <xsl:value-of select="check:matchValue(.)"/>
@@ -288,7 +288,8 @@
    </xsl:template>
    <xsl:function name="check:escapeRegex" as="xsd:string">
       <xsl:param name="in" as="xsd:string"/>
-      <xsl:value-of select="replace($in,'\\','\\\\')"/> 
+      <xsl:variable name="pass1" as="xsd:string" select="replace($in,'\\','\\\\')"/>
+      <xsl:value-of select="replace($pass1,'&quot;','\\&quot;')"/>
    </xsl:function>
    <xsl:function name="check:notMatchRegex" as="xsd:string">
        <xsl:param name="in" as="xsd:string*"/>

--- a/core/src/main/resources/xsl/opt/removeDups-rules.xml
+++ b/core/src/main/resources/xsl/opt/removeDups-rules.xml
@@ -43,8 +43,8 @@
         Rule for HEADER_ALL.  Although both match and matchRegEx are
         optional at least one of these should be specified.
     </rule>
-    <rule types="SET_HEADER" required="next name value">
-        Rule for SET_HEADER.
+    <rule types="SET_HEADER SET_HEADER_ALWAYS" required="next name value">
+        Rule for SET_HEADER and SET_HEADER_ALWAYS.
     </rule>
     <rule types="METHOD REQ_TYPE" required="next match">
         Steps that simply contain a match.

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
@@ -313,6 +313,24 @@ class Config {
   @AffectsChecker
   var preserveRequestBody : Boolean = false
 
+  //
+  // The name of the agent used in WARNING headers. Can be a host:port
+  // or a pseudonym, using - as the name allowed when the name of the
+  // agent is unknown.
+  //
+  @BeanProperty
+  @AffectsChecker
+  var warnAgent : String = "-"
+
+  //
+  // Enable warning headers per RFC 7234. These warnings come into
+  // play when a transformation is applied to a message body, for
+  // example.
+  //
+  @BeanProperty
+  @AffectsChecker
+  var enableWarnHeaders : Boolean = true
+
   /**
    * Returns checker metadata (<meta/> element in checker format) for
    * the config options that affect the checker.

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/SetHeaderAlways.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/SetHeaderAlways.scala
@@ -1,0 +1,36 @@
+/***
+ *   Copyright 2016 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.step
+
+import javax.servlet.FilterChain
+
+import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.step.base.{ConnectedStep, Step, StepContext}
+import com.rackspace.com.papi.components.checker.util.HeaderUtil._
+
+
+class SetHeaderAlways(id : String, label : String, val name : String, val value : String,
+                      next : Array[Step]) extends ConnectedStep(id, label, next) {
+
+  override def checkStep(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, context : StepContext) : Option[StepContext] = {
+    //
+    // Always set a header with the given value when this step
+    // executes.  If an existing header exists a new value will be
+    // added.
+    //
+    Some(context.copy(requestHeaders = context.requestHeaders.addHeader(name, value)))
+  }
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/StepHandler.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/StepHandler.scala
@@ -317,6 +317,7 @@ class StepHandler(var contentHandler : ContentHandler, val config : Config) exte
           case "HEADERXSD_ANY"  => addHeaderXSDAny(atts)
           case "HEADER_ALL" => addHeaderAll(atts)
           case "SET_HEADER"  => addSetHeader(atts)
+          case "SET_HEADER_ALWAYS"  => addSetHeaderAlways(atts)
           case "JSON_SCHEMA" => addJSONSchema(atts)
         }
       case "grammar" =>
@@ -914,6 +915,17 @@ class StepHandler(var contentHandler : ContentHandler, val config : Config) exte
 
     next += (id -> nexts)
     steps += (id -> new SetHeader(id, label, name, value, new Array[Step](nexts.length)))
+  }
+
+  private[this] def addSetHeaderAlways(atts : Attributes) : Unit = {
+    val nexts : Array[String] = atts.getValue("next").split(" ")
+    val id : String = atts.getValue("id")
+    val label : String = atts.getValue("label")
+    val name : String = atts.getValue("name")
+    val value : String = atts.getValue("value")
+
+    next += (id -> nexts)
+    steps += (id -> new SetHeaderAlways(id, label, name, value, new Array[Step](nexts.length)))
   }
 
   private[this] def addMethod(atts : Attributes) : Unit = {

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/step/StepSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/step/StepSuite.scala
@@ -4710,6 +4710,29 @@ class StepSuite extends BaseStepSuite with MockitoSugar {
     assert (newContext.get.requestHeaders.get("X-TEST").get == List("FOO", "BAR"),"The header should be set in the context with the correct value")
   }
 
+  test ("In a step header always step, if a header does not exist in the context it will be set when the step executes") {
+    val setHeaderAlways = new SetHeaderAlways("SET_HEADER_ALWAYS", "SET_HEADER_AWLAYS", "foo", "bar", Array[Step]())
+    val req = request("GET", "/path/to/resource", "", "", false, Map("OTHER"->List("FOOD", "BART")))
+    val context = StepContext()
+    val newContext = setHeaderAlways.checkStep(req, response, chain, context)
+    assert (newContext.get.requestHeaders.get("foo").get == List ("bar"), "The set header always header should be set.")
+  }
+
+  test ("In a step header always step, if a header exist in the context a new value should  when the step executes") {
+    val setHeaderAlways = new SetHeaderAlways("SET_HEADER_ALWAYS", "SET_HEADER_AWLAYS", "foo", "bar", Array[Step]())
+    val req = request("GET", "/path/to/resource", "", "", false, Map("OTHER"->List("FOOD", "BART")))
+    val context = StepContext(requestHeaders = (new HeaderMap).addHeaders("foo", List("broo")))
+    val newContext = setHeaderAlways.checkStep(req, response, chain, context)
+    assert (newContext.get.requestHeaders.get("foo").get == List ("broo","bar"), "The set header always header should be set.")
+  }
+
+  test ("In a step header always step, if a header exist in the context a new value should  when the step executes (case)") {
+    val setHeaderAlways = new SetHeaderAlways("SET_HEADER_ALWAYS", "SET_HEADER_AWLAYS", "foo", "bar", Array[Step]())
+    val req = request("GET", "/path/to/resource", "", "", false, Map("OTHER"->List("FOOD", "BART")))
+    val context = StepContext(requestHeaders = (new HeaderMap).addHeaders("fOO", List("broo")))
+    val newContext = setHeaderAlways.checkStep(req, response, chain, context)
+    assert (newContext.get.requestHeaders.get("foo").get == List ("broo","bar"), "The set header always header should be set.")
+  }
 
   test ("In a headerAll step, with a single RegEx value if the header is not avaliable the result of checkStep should be None") {
     val header = new HeaderAll("HEADER_ALL", "HEADER_ALL", "X-TEST-HEADER", None, None, Some("foo".r),  None, None, None, 12345, Array[Step]())

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
@@ -254,6 +254,15 @@ class BaseCheckerSpec extends BaseWADLSpec {
     stepsWithType(checker, "SET_HEADER").filter (n => (n \ "@name").text == name).filter (n => (n \ "@value").text == value)
   }
 
+  def stepsWithSetHeaderAlways (checker : NodeSeq, name: String) : NodeSeq = {
+    stepsWithType(checker, "SET_HEADER_ALWAYS").filter(n => (n \ "@name").text ==name)
+  }
+
+  def stepsWithSetHeaderAlways (checker : NodeSeq, name: String, value : String) : NodeSeq = {
+    stepsWithType(checker, "SET_HEADER_ALWAYS").filter(n => (n \ "@name").text ==name).filter (n => (n \ "@value").text == value)
+  }
+
+
   def stepsWithHeaderAll(checker : NodeSeq, name : String) : NodeSeq = {
     stepsWithType(checker, "HEADER_ALL").filter (n => (n \ "@name").text == name)
   }
@@ -387,6 +396,8 @@ class BaseCheckerSpec extends BaseWADLSpec {
     stepsWithHeaderAllValueMatchTypesMessageCode(_, name, headerMatch, matchTypes, message, code)
 
   def SetHeader(name : String, value : String) : (NodeSeq) => NodeSeq = stepsWithSetHeader(_, name, value)
+  def SetHeaderAlways(name : String) : (NodeSeq) => NodeSeq = stepsWithSetHeaderAlways(_, name)
+  def SetHeaderAlways(name : String, value : String) : (NodeSeq) => NodeSeq = stepsWithSetHeaderAlways(_, name, value)
 
   def assert (checker : NodeSeq, step_funs : ((NodeSeq) => NodeSeq)*) : Unit = {
 

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerHeaderSingleSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerHeaderSingleSpec.scala
@@ -146,7 +146,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -206,7 +206,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -267,7 +267,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val cfg = TestConfig(false, false, true, true, true, 1,
-                           true, true, true, "XalanC",
+                           true, false, true, "XalanC",
                            false, true)
       cfg.enableRaxRolesExtension  = true
       val checkerLog = log (Level.WARN) {
@@ -908,7 +908,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -968,7 +968,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -1030,7 +1030,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val cfg = TestConfig(false, false, true, true, true, 1,
-                           true, true, true, "XalanC",
+                           true, false, true, "XalanC",
                            false, true)
       cfg.enableRaxRolesExtension  = true
       val checkerLog = log (Level.WARN) {
@@ -1099,7 +1099,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val cfg = TestConfig(false, false, true, true, true, 1,
-                           true, true, true, "XalanC",
+                           true, false, true, "XalanC",
                            false, true)
       cfg.enableRaxRolesExtension  = true
       val checkerLog = log (Level.WARN) {
@@ -1168,7 +1168,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val cfg = TestConfig(false, false, true, true, true, 1,
-                           true, true, true, "XalanC",
+                           true, false, true, "XalanC",
                            false, true)
       cfg.enableRaxRolesExtension  = true
       val checkerLog = log (Level.WARN) {
@@ -1240,7 +1240,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val cfg = TestConfig(false, false, true, true, true, 1,
-                           true, true, true, "XalanC",
+                           true, false, true, "XalanC",
                            false, true)
       cfg.enableRaxRolesExtension  = true
       val checkerLog = log (Level.WARN) {
@@ -1311,7 +1311,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val cfg = TestConfig(false, false, true, true, true, 1,
-                           true, true, true, "XalanC",
+                           true, false, true, "XalanC",
                            false, true)
       cfg.enableRaxRolesExtension  = true
       val checkerLog = log (Level.WARN) {
@@ -1378,7 +1378,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -1439,7 +1439,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -1500,7 +1500,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(false, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       val checker = builder.build (inWADL, config)
@@ -1566,7 +1566,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(false, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       config.enableRaxRolesExtension=true
@@ -1635,7 +1635,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(false, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       When ("the WADL is translated")
@@ -1691,7 +1691,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(false, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       When ("the WADL is translated")
@@ -1747,7 +1747,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -1809,7 +1809,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -1871,7 +1871,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -1934,7 +1934,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -1997,7 +1997,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(false, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       val checker = builder.build (inWADL, config)
@@ -2061,7 +2061,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderDupsOnAssertions(checker)
       wellFormedAndHeaderDupsOnAssertions(checker)
@@ -2125,7 +2125,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(true, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.enableRaxRolesExtension=true
       val checkerLog = log (Level.WARN) {
@@ -2192,7 +2192,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderDupsOnAssertions(checker)
       wellFormedAndHeaderDupsOnAssertions(checker)
@@ -2252,7 +2252,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(true, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       val checker = builder.build (inWADL, config)
@@ -2318,7 +2318,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(true, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       config.enableRaxRolesExtension=true
@@ -2387,7 +2387,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderDupsOnAssertions(checker)
       wellFormedAndHeaderDupsOnAssertions(checker)
@@ -2449,7 +2449,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderDupsOnAssertions(checker)
       wellFormedAndHeaderDupsOnAssertions(checker)
@@ -2511,7 +2511,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderDupsOnAssertions(checker)
       wellFormedAndHeaderDupsOnAssertions(checker)
@@ -2574,7 +2574,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderDupsOnAssertions(checker)
       wellFormedAndHeaderDupsOnAssertions(checker)
@@ -2637,7 +2637,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(true, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       val checker = builder.build (inWADL, config)
@@ -2702,7 +2702,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -2764,7 +2764,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -2826,7 +2826,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -2890,7 +2890,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -2954,7 +2954,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config =TestConfig(true, false, true, true, true, 1,
-                             true, true, true, "XalanC",
+                             true, false, true, "XalanC",
                              false, true)
       config.setParamDefaults=true
       val checker = builder.build (inWADL, config)
@@ -3022,7 +3022,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderAssertions(checker)
       wellFormedAndHeaderAssertions(checker)
@@ -3079,7 +3079,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndXSDHeaderAssertions(checker)
       wellFormedAndXSDHeaderAssertions(checker)
@@ -3137,7 +3137,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndXSDHeaderAssertions(checker)
       wellFormedAndXSDHeaderAssertions(checker)
@@ -3195,7 +3195,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderXSDHeaderAssertions(checker)
       wellFormedAndHeaderXSDHeaderAssertions(checker)
@@ -3255,7 +3255,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderXSDHeaderAssertions(checker)
       wellFormedAndHeaderXSDHeaderAssertions(checker)
@@ -3315,7 +3315,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderXSDHeader2Assertions(checker)
       wellFormedAndHeaderXSDHeader2Assertions(checker)
@@ -3377,7 +3377,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndHeaderXSDHeader2Assertions(checker)
       wellFormedAndHeaderXSDHeader2Assertions(checker)
@@ -3437,7 +3437,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       true, true))
       reqTypeAndHeaderXSDHeader2Assertions(checker)
       wellFormedAndHeaderXSDHeader2Assertions(checker)
@@ -4114,7 +4114,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderAssertions(checker)
       wellFormedAndReqHeaderAssertions(checker)
@@ -4174,7 +4174,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderAssertions(checker)
       wellFormedAndReqHeaderAssertions(checker)
@@ -4234,7 +4234,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(false, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       val checker = builder.build (inWADL, config)
@@ -4302,7 +4302,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderAssertions(checker)
       wellFormedAndReqHeaderAssertions(checker)
@@ -4367,7 +4367,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(false, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       val checker = builder.build (inWADL, config)
@@ -4431,7 +4431,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderAssertions(checker)
       wellFormedAndReqHeaderAssertions(checker)
@@ -4494,7 +4494,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderAssertions(checker)
       wellFormedAndReqHeaderAssertions(checker)
@@ -4556,7 +4556,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderAssertions(checker)
       wellFormedAndReqHeaderAssertions(checker)
@@ -4619,7 +4619,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(false, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       val checker = builder.build (inWADL, config)
@@ -4684,7 +4684,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderDupsOnAssertions(checker)
       wellFormedAndReqHeaderDupsOnAssertions(checker)
@@ -4746,7 +4746,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderDupsOnAssertions(checker)
       wellFormedAndReqHeaderDupsOnAssertions(checker)
@@ -4808,7 +4808,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderDupsOnAssertions(checker)
       wellFormedAndReqHeaderDupsOnAssertions(checker)
@@ -4870,7 +4870,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderDupsOnAssertions(checker)
       wellFormedAndReqHeaderDupsOnAssertions(checker)
@@ -4933,7 +4933,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(true, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       val checker = builder.build (inWADL, config)
@@ -4998,7 +4998,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderAssertions(checker)
       wellFormedAndReqHeaderAssertions(checker)
@@ -5060,7 +5060,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderAssertions(checker)
       wellFormedAndReqHeaderAssertions(checker)
@@ -5122,7 +5122,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderAssertions(checker)
       wellFormedAndReqHeaderAssertions(checker)
@@ -5185,7 +5185,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(true, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       val checker = builder.build (inWADL, config)
@@ -5253,7 +5253,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderAssertions(checker)
       wellFormedAndReqHeaderAssertions(checker)
@@ -5310,7 +5310,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqXSDHeaderAssertions(checker)
       wellFormedAndReqXSDHeaderAssertions(checker)
@@ -5368,7 +5368,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqXSDHeaderAssertions(checker)
       wellFormedAndReqXSDHeaderAssertions(checker)
@@ -5426,7 +5426,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderXSDHeaderAssertions(checker)
       wellFormedAndReqHeaderXSDHeaderAssertions(checker)
@@ -5485,7 +5485,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderXSDHeaderAssertions(checker)
       wellFormedAndReqHeaderXSDHeaderAssertions(checker)
@@ -5545,7 +5545,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderXSDHeader2Assertions(checker)
       wellFormedAndReqHeaderXSDHeader2Assertions(checker)
@@ -5607,7 +5607,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderXSDHeader2Assertions(checker)
       wellFormedAndReqHeaderXSDHeader2Assertions(checker)
@@ -5667,7 +5667,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       true, true))
       reqTypeAndReqHeaderXSDHeader2Assertions(checker)
       wellFormedAndReqHeaderXSDHeader2Assertions(checker)
@@ -5728,7 +5728,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderXSDHeader2MixAssertions(checker)
       wellFormedAndReqHeaderXSDHeader2MixAssertions(checker)
@@ -5789,7 +5789,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderXSDHeader2MixAssertions(checker)
       wellFormedAndReqHeaderXSDHeader2MixAssertions(checker)
@@ -5851,7 +5851,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val config = TestConfig(false, false, true, true, true, 1,
-                              true, true, true, "XalanC",
+                              true, false, true, "XalanC",
                               false, true)
       config.setParamDefaults=true
       val checker = builder.build (inWADL, config)
@@ -5917,7 +5917,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderXSDHeader2MixAssertions(checker)
       wellFormedAndReqHeaderXSDHeader2MixAssertions(checker)
@@ -6024,7 +6024,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderXSDHeader2MixAssertionsNoReqType(checker)
       wellFormedAndReqHeaderXSDHeader2MixAssertionsNoReqType(checker)
@@ -6189,7 +6189,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(false, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderXSDHeader2MixAssertionsNoReqTypeSameName(checker)
       wellFormedAndReqHeaderXSDHeader2MixAssertionsNoReqTypeSameName(checker)
@@ -6251,7 +6251,7 @@ class WADLCheckerHeaderSingleSpec extends BaseCheckerSpec with LogAssertions {
                XML.loadFile("src/test/resources/xsd/test-urlxsd.xsd"))
       When("the wadl is translated")
       val checker = builder.build (inWADL, TestConfig(true, false, true, true, true, 1,
-                                                      true, true, true, "XalanC",
+                                                      true, false, true, "XalanC",
                                                       false, true))
       reqTypeAndReqHeaderXSDHeader2MixAssertionsNoReqTypeSameNameDups(checker)
       wellFormedAndReqHeaderXSDHeader2MixAssertionsNoReqTypeSameNameDups(checker)

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerMetaSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerMetaSpec.scala
@@ -466,6 +466,7 @@ class WADLCheckerMetaSpec extends BaseCheckerSpec {
       c.joinXPathChecks = false
       c.checkHeaders = false
       c.preserveRequestBody = false
+      c.enableWarnHeaders = false
 
       c
     }
@@ -510,7 +511,10 @@ class WADLCheckerMetaSpec extends BaseCheckerSpec {
     val nonBoolTests :  MetaTests =
       List(
            checkConfigOptionMatch("xpathVersion","1",(c : Config) => {c.joinXPathChecks=true; c.xpathVersion=1}),
-           checkConfigOptionMatch("xpathVersion","2",(c : Config) => {c.joinXPathChecks=true; c.xpathVersion=2})
+           checkConfigOptionMatch("xpathVersion","2",(c : Config) => {c.joinXPathChecks=true; c.xpathVersion=2}),
+           checkConfigOptionMatch("warnAgent", "-", (c : Config) => {c.warnAgent="-"}),
+           checkConfigOptionMatch("warnAgent", "api-checker", (c : Config) => {c.warnAgent="api-checker"}),
+           checkConfigOptionMatch("warnAgent", "api-checker:8080", (c : Config) => {c.warnAgent="api-checker:8080"})
          )
 
     val optionTests : MetaTests = trueTests ++ falseTests ++ nonBoolTests

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerOptSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerOptSpec.scala
@@ -565,15 +565,15 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("y"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"), XSL, Accept)
+             XPath("/foo:bar/@junk"), XSL, SetHeaderAlways("Warning"), Accept)
 
       assert(checker,Start, URL("x"),  Method("POST"), Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"), XSL, Accept)
+             XPath("/foo:bar/@junk"), XSL, SetHeaderAlways("Warning"), Accept)
 
       assert(checker,Start, URL("x"),  Method("POST"), Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:foo"),
-             XPath("/foo:foo/@junk"), XSL, Accept)
+             XPath("/foo:foo/@junk"), XSL, SetHeaderAlways("Warning"), Accept)
 
       And ("The Following counts should hold")
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 4")
@@ -606,15 +606,15 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("y"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"), XSL, Accept)
+             XPath("/foo:bar/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"), XSL, Accept)
+             XPath("/foo:bar/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:foo"),
-             XPath("/foo:foo/@junk"), XSL, Accept)
+             XPath("/foo:foo/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
 
       And ("The Following counts should hold")
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
@@ -644,15 +644,15 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       Then ("The following paths should hold")
 
       assert(checker,Start, URL("y"),  Method("POST"),
-             ReqType("(application/xml)(;.*)?"), XSL, Accept)
+             ReqType("(application/xml)(;.*)?"), XSL,  SetHeaderAlways("Warning"), Accept)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"), XSL, Accept)
+             XPath("/foo:bar/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:foo"),
-             XPath("/foo:foo/@junk"), XSL, Accept)
+             XPath("/foo:foo/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
 
       And ("The Following counts should hold")
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
@@ -686,21 +686,21 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       Then ("The following paths should hold")
 
       assert(checker,Start, URL("y"),  Method("POST"),
-             ReqType("(application/xml)(;.*)?"), WellXML, XSL, Accept)
+             ReqType("(application/xml)(;.*)?"), WellXML, XSL,  SetHeaderAlways("Warning"), Accept)
 
       assert(checker,Start, URL("y"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"), XSL, Accept)
+             XPath("/foo:bar/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:foo"),
-             XPath("/foo:foo/@junk"), XSL, Accept)
+             XPath("/foo:foo/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
 
       And ("The Following counts should hold")
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerPreProcSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerPreProcSpec.scala
@@ -160,7 +160,7 @@ class WADLCheckerPreProcSpec extends BaseCheckerSpec {
         assert(checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 1")
         assert(checker, "count(/chk:checker/chk:step[@type='XSL']) = 1")
         assert(checker, Start, URL("a"), URL("b"), Method("POST"),
-               ReqType("(application/xml)(;.*)?"), WellXML, XSL, Accept)
+               ReqType("(application/xml)(;.*)?"), WellXML, XSL, SetHeaderAlways("Warning"), Accept)
       }
     }
 }


### PR DESCRIPTION
See RFC 2616 (14.46)

The preproc extension transforms a message, we should be setting an appropriate Warning header.