### PR TITLE
Param names are case sensitive

### DIFF
--- a/core/src/main/resources/xsl/builder.xsl
+++ b/core/src/main/resources/xsl/builder.xsl
@@ -588,7 +588,7 @@
         <xsl:param name="from" as="node()" select="."/>
         <xsl:param name="inRequest" as="xsd:boolean" select="false()"/>
         <xsl:variable name="headers" select="check:getHeaders($from)" as="node()*"/>
-        <xsl:variable name="names" select="distinct-values(for $h in $headers return string($h/@name))"/>
+        <xsl:variable name="names" select="distinct-values(for $h in $headers return upper-case($h/@name))"/>
         <xsl:variable name="default_headers" select="$headers[@default]" as="node()*"/>
         <xsl:variable name="header_next" as="xsd:string*">
             <xsl:choose>
@@ -601,7 +601,7 @@
             </xsl:choose>
         </xsl:variable>
         <xsl:if test="$useParamDefaults">
-          <xsl:for-each-group select="$headers" group-by="@name">
+          <xsl:for-each-group select="$headers" group-by="upper-case(@name)">
             <xsl:if test="count(current-group()[@default]) gt 1">
               <xsl:message terminate="yes">[ERROR] Multiple headers <xsl:value-of select="current-group()[1]/@name"/> have multiple @default vaules.
               Only one default value is allowed.</xsl:message>
@@ -627,8 +627,8 @@
             <xsl:variable name="pos" select="position()"/>
             <xsl:variable name="last" select="last()"/>
             <xsl:variable name="current" select="." as="xsd:string"/>
-            <xsl:variable name="multipleHeaders" as="xsd:boolean" select="count($headers[@name=$current]) gt 1" />
-            <xsl:for-each select="$headers[@name=$current]">
+            <xsl:variable name="multipleHeaders" as="xsd:boolean" select="count($headers[upper-case(@name)=$current]) gt 1" />
+            <xsl:for-each select="$headers[upper-case(@name)=$current]">
                 <xsl:variable name="isXSD" select="check:isXSDParam(.)"/>
                 <xsl:variable name="isFixed" as="xsd:boolean" select="exists(@fixed)"/>
                 <xsl:variable name="isRepeating" as="xsd:boolean" select="exists(@repeating) and xsd:boolean(@repeating)"/>
@@ -687,8 +687,8 @@
                 </xsl:choose>
             </xsl:for-each>
             <xsl:variable name="allHeaders" as="node()*" select="if ($multipleHeaders) then
-                     if ($useAnyMatchExtension) then $headers[@name=$current and not(xsd:boolean(@rax:anyMatch)) and xsd:boolean(@repeating)]
-                     else $headers[@name=$current and xsd:boolean(@repeating)]
+                     if ($useAnyMatchExtension) then $headers[upper-case(@name)=$current and not(xsd:boolean(@rax:anyMatch)) and xsd:boolean(@repeating)]
+                     else $headers[upper-case(@name)=$current and xsd:boolean(@repeating)]
                      else ()"/>
             <xsl:if test="not(empty($allHeaders))">
               <xsl:variable name="matches" as="xsd:string*">
@@ -749,7 +749,7 @@
                 </xsl:if>
               </step>
             </xsl:if>
-            <step type="CONTENT_FAIL" id="{check:HeaderFailID($headers[@name = $current][1])}"/>
+            <step type="CONTENT_FAIL" id="{check:HeaderFailID($headers[upper-case(@name) = $current][1])}"/>
         </xsl:for-each>
     </xsl:template>
     
@@ -1308,7 +1308,7 @@
     <xsl:function name="check:getNextHeaderLinksByName" as="xsd:string*">
       <xsl:param name="headers" as="node()*"/> <!-- all headers -->
       <xsl:param name="headerName" as="xsd:string"/>
-      <xsl:variable name="headersWithName" as="node()*" select="$headers[@name=$headerName]"/>
+      <xsl:variable name="headersWithName" as="node()*" select="$headers[upper-case(@name)=upper-case($headerName)]"/>
       <xsl:choose>
         <xsl:when test="empty($headersWithName)">
           <xsl:value-of select="()"/>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/BaseValidatorSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/BaseValidatorSuite.scala
@@ -331,7 +331,7 @@ class BaseValidatorSuite extends FunSuite {
       throw new TestFailedException(Some("Expected error code "+code+" but got "+result.code), None, 4)
     }
     message.foreach(m => {
-      if (!result.message.contains(m)) {
+      if (!result.message.toUpperCase().contains(m.toUpperCase())) {
         throw new TestFailedException(Some("Expected error string '"+m+"' in the result message, but it didn't have one. Actual result message: '"+result.message+"'"), None, 4)
       }
     })

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLHeaderSuite2.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLHeaderSuite2.scala
@@ -190,6 +190,42 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                       </resources>
                                       </application>)
 
+  val resourceHeadersMixedCaseWADL : TestWADL = ("WADL with mixed same name headers (mixed case) at the resource level",
+                                            <application xmlns="http://wadl.dev.java.net/2009/02"
+                                              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                                              xmlns:rax="http://docs.rackspace.com/api"
+                                              xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
+                                          <resources base="https://test.api.openstack.com">
+                                      <resource path="/a/b">
+                                        <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" default="foo!" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                        <param name="X-test" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                        <param name="X-TEST" style="header" type="xsd:dateTime" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                        <param name="X-test" style="header" type="xsd:date" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                        <param name="X-TESTO" style="header" type="xsd:int" required="true" repeating="true" default="42" rax:message="Bad Testo"/>
+                                        <method name="PUT">
+                                          <request>
+                                            <representation mediaType="application/xml" element="tst:a"/>
+                                            <representation mediaType="application/json"/>
+                                          </request>
+                                        </method>
+                                        <method name="POST">
+                                          <request>
+                                            <representation mediaType="application/xml" element="tst:e"/>
+                                          </request>
+                                        </method>
+                                      </resource>
+                                      <resource path="/c">
+                                        <method name="POST">
+                                          <request>
+                                            <representation mediaType="application/json"/>
+                                          </request>
+                                        </method>
+                                        <method name="GET"/>
+                                       </resource>
+                                      </resources>
+                                      </application>)
+
+
   val resourceHeadersAllMatchWADL : TestWADL = ("WADL with mixed same name headers at the resource level anyMatch=false",
                                             <application xmlns="http://wadl.dev.java.net/2009/02"
                                               xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -281,6 +317,41 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                              <param name="X-TEST" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
                                              <param name="X-TEST" style="header" type="xsd:dateTime" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
                                              <param name="X-TEST" style="header" type="xsd:date" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                             <param name="X-TESTO" style="header" type="xsd:int" required="true" repeating="true" default="42" rax:message="Bad Testo"/>
+                                             <representation mediaType="application/xml" element="tst:e"/>
+                                          </request>
+                                        </method>
+                                      </resource>
+                                      <resource path="/c">
+                                        <method name="POST">
+                                          <request>
+                                            <representation mediaType="application/json"/>
+                                          </request>
+                                        </method>
+                                        <method name="GET"/>
+                                       </resource>
+                                      </resources>
+                                      </application>)
+
+  val requestHeadersMixedCaseWADL : TestWADL = ("WADL with mixed same name headers (mixed case) at the request level",
+                                            <application xmlns="http://wadl.dev.java.net/2009/02"
+                                              xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                                              xmlns:rax="http://docs.rackspace.com/api"
+                                              xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
+                                          <resources base="https://test.api.openstack.com">
+                                      <resource path="/a/b">
+                                        <method name="PUT">
+                                          <request>
+                                            <representation mediaType="application/xml" element="tst:a"/>
+                                            <representation mediaType="application/json"/>
+                                          </request>
+                                        </method>
+                                        <method name="POST">
+                                          <request>
+                                             <param name="X-TEST" style="header" type="xsd:string" fixed="foo!" required="true" repeating="true" default="foo!" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                             <param name="X-test" style="header" type="xsd:string" fixed="bar!" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                             <param name="X-TEST" style="header" type="xsd:dateTime" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
+                                             <param name="X-test" style="header" type="xsd:date" required="true" repeating="true" rax:code="401" rax:message="No!" rax:anyMatch="true"/>
                                              <param name="X-TESTO" style="header" type="xsd:int" required="true" repeating="true" default="42" rax:message="Bad Testo"/>
                                              <representation mediaType="application/xml" element="tst:e"/>
                                           </request>
@@ -3166,11 +3237,27 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
   run(mixedHeadersDisabledCase)
 
 
+  val mixedHeadersDisabledMixedCaseCase : TestCase = (resourceHeadersMixedCaseWADL,
+                                     List(checkHeadersDisabledConfig, checkHeadersDisabledConfigDups),
+                                     List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDisabledHeaderTests))
+
+  run(mixedHeadersDisabledMixedCaseCase)
+
+
+
   val mixedHeadersMsgDisabledCase : TestCase = (resourceHeadersWADL,
                                                 List(checkHeadersDisabledMsgConfig, checkHeadersDisabledMsgConfigDups),
                                                 List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDisabledHeaderTests))
 
   run(mixedHeadersMsgDisabledCase)
+
+
+  val mixedHeadersMsgDisabledMixedCaseCase : TestCase = (resourceHeadersMixedCaseWADL,
+                                                List(checkHeadersDisabledMsgConfig, checkHeadersDisabledMsgConfigDups),
+                                                List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDisabledHeaderTests))
+
+  run(mixedHeadersMsgDisabledMixedCaseCase)
+
 
 
   val mixedHeadersAllMatchDisabledCase : TestCase = (resourceHeadersAllMatchWADL,
@@ -3211,6 +3298,14 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
   run(mixedHeadersCase)
 
 
+  val mixedHeadersMixedCaseCase : TestCase = (resourceHeadersMixedCaseWADL,
+                                     List(checkHeadersConfig, checkHeadersConfigDups),
+                                     List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderNegHeaderTests))
+
+  run(mixedHeadersMixedCaseCase)
+
+
+
   val mixedHeadersAllCase : TestCase = (resourceHeadersAllMatchWADL,
                                      List(checkHeadersConfig, checkHeadersConfigDups),
                                      List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderNegHeaderTestsAll))
@@ -3225,12 +3320,28 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
   run(mixedHeadersDisableAnyCase)
 
 
+  val mixedHeadersDisableAnyMixedCaseCase : TestCase = (resourceHeadersMixedCaseWADL,
+                                     List(checkHeadersConfigDisableAnyMatch, checkHeadersConfigDupsDisableAnyMatch),
+                                     List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderNegHeaderTestsAll))
+
+  run(mixedHeadersDisableAnyMixedCaseCase)
+
+
+
 
   val mixedHeadersMsgCase : TestCase = (resourceHeadersWADL,
                                      List(checkHeadersMsgConfig, checkHeadersMsgConfigDups),
                                      List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderMsgNegHeaderTests))
 
   run(mixedHeadersMsgCase)
+
+
+  val mixedHeadersMsgMixedCase : TestCase = (resourceHeadersMixedCaseWADL,
+                                     List(checkHeadersMsgConfig, checkHeadersMsgConfigDups),
+                                     List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderMsgNegHeaderTests))
+
+  run(mixedHeadersMsgMixedCase)
+
 
 
   val mixedHeadersMsgAllCase : TestCase = (resourceHeadersAllMatchWADL,
@@ -3244,6 +3355,14 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
                                      List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderMsgNegHeaderTestsAll))
 
   run(mixedHeadersMsgDisableAnyCase)
+
+
+  val mixedHeadersMsgDisableAnyMixedCase : TestCase = (resourceHeadersMixedCaseWADL,
+                                     List(checkHeadersMsgConfigDisableAnyMatch, checkHeadersMsgConfigDupsDisableAnyMatch),
+                                     List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderMsgNegHeaderTestsAll))
+
+  run(mixedHeadersMsgDisableAnyMixedCase)
+
 
 
 
@@ -3270,6 +3389,14 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
   run(mixedHeadersDefaultCase)
 
 
+  val mixedHeadersDefaultMixedCaseCase : TestCase = (resourceHeadersMixedCaseWADL,
+                                            List(checkHeadersDefaultsConfig, checkHeadersDefaultsConfigDups),
+                                            List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDefaultHeaderTests))
+
+  run(mixedHeadersDefaultMixedCaseCase)
+
+
+
   val mixedHeadersDefaultAllCase : TestCase = (resourceHeadersAllMatchWADL,
                                             List(checkHeadersDefaultsConfig, checkHeadersDefaultsConfigDups),
                                             List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderDefaultHeaderTestsAll))
@@ -3284,12 +3411,28 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
   run(mixedHeadersDefaultDisableAnyCase)
 
 
+  val mixedHeadersDefaultDisableAnyMixedCaseCase : TestCase = (resourceHeadersMixedCaseWADL,
+                                            List(checkHeadersDefaultsConfigDisableAnyMatch, checkHeadersDefaultsConfigDupsDisableAnyMatch),
+                                            List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderDefaultHeaderTestsAll))
+
+  run(mixedHeadersDefaultDisableAnyMixedCaseCase)
+
+
+
 
   val mixedHeadersMsgDefaultCase : TestCase = (resourceHeadersWADL,
                                                List(checkHeadersMsgDefaultsConfig, checkHeadersMsgDefaultsConfigDups),
                                                List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderMsgDefaultHeaderTests))
 
   run(mixedHeadersMsgDefaultCase)
+
+
+  val mixedHeadersMsgDefaultMixedCaseCase : TestCase = (resourceHeadersMixedCaseWADL,
+                                               List(checkHeadersMsgDefaultsConfig, checkHeadersMsgDefaultsConfigDups),
+                                               List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderMsgDefaultHeaderTests))
+
+  run(mixedHeadersMsgDefaultMixedCaseCase)
+
 
 
   val mixedHeadersMsgDefaultAllCase : TestCase = (resourceHeadersAllMatchWADL,
@@ -3304,6 +3447,13 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
                                                           List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderMsgDefaultHeaderTestsAll))
 
   run(mixedHeadersMsgDefaultDisabledAnyCase)
+
+
+  val mixedHeadersMsgDefaultDisabledAnyMixedCaseCase : TestCase = (resourceHeadersMixedCaseWADL,
+                                                          List(checkHeadersMsgDefaultsConfigDisableAnyMatch, checkHeadersMsgDefaultsConfigDupsDisableAnyMatch),
+                                                          List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedHeaderMsgDefaultHeaderTestsAll))
+
+  run(mixedHeadersMsgDefaultDisabledAnyMixedCaseCase)
 
 
 
@@ -3329,12 +3479,28 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
   run(mixedReqHeadersDisabledCase)
 
 
+  val mixedReqHeadersDisabledMixedCaseCase : TestCase = (requestHeadersMixedCaseWADL,
+                                                List(checkHeadersDisabledConfig, checkHeadersDisabledConfigDups),
+                                                List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDisabledHeaderTests))
+
+  run(mixedReqHeadersDisabledMixedCaseCase)
+
+
+
 
   val mixedReqHeadersMsgDisabledCase : TestCase = (requestHeadersWADL,
                                                    List(checkHeadersDisabledMsgConfig, checkHeadersDisabledMsgConfigDups),
                                                    List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDisabledHeaderTests))
 
   run(mixedReqHeadersMsgDisabledCase)
+
+
+  val mixedReqHeadersMsgDisabledMixedCaseCase : TestCase = (requestHeadersMixedCaseWADL,
+                                                   List(checkHeadersDisabledMsgConfig, checkHeadersDisabledMsgConfigDups),
+                                                   List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedHeaderDisabledHeaderTests))
+
+  run(mixedReqHeadersMsgDisabledMixedCaseCase)
+
 
 
   val mixedReqHeadersAllMatchDisabledCase : TestCase = (requestHeadersAllMatchWADL,
@@ -3375,6 +3541,13 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
   run(mixedReqHeadersCase)
 
 
+  val mixedReqHeadersMixedCaseCase : TestCase = (requestHeadersMixedCaseWADL,
+                                        List(checkHeadersConfig, checkHeadersConfigDups),
+                                        List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedReqHeaderNegHeaderTests))
+
+  run(mixedReqHeadersMixedCaseCase)
+
+
   val mixedReqHeadersAllCase : TestCase = (requestHeadersAllMatchWADL,
                                         List(checkHeadersConfig, checkHeadersConfigDups),
                                         List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests,mixedReqHeaderNegHeaderTestsAll))
@@ -3389,11 +3562,27 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
   run(mixedReqHeadersDisableAnyCase)
 
 
+  val mixedReqHeadersDisableAnyMixedCaseCase : TestCase = (requestHeadersMixedCaseWADL,
+                                        List(checkHeadersConfigDisableAnyMatch, checkHeadersConfigDupsDisableAnyMatch),
+                                        List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderNegHeaderTestsAll))
+
+  run(mixedReqHeadersDisableAnyMixedCaseCase)
+
+
+
   val mixedReqHeadersMsgCase : TestCase = (requestHeadersWADL,
                                            List(checkHeadersMsgConfig, checkHeadersMsgConfigDups),
                                            List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedReqHeaderMsgNegHeaderTests))
 
   run(mixedReqHeadersMsgCase)
+
+
+  val mixedReqHeadersMsgMixedCaseCase : TestCase = (requestHeadersMixedCaseWADL,
+                                           List(checkHeadersMsgConfig, checkHeadersMsgConfigDups),
+                                           List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedReqHeaderMsgNegHeaderTests))
+
+  run(mixedReqHeadersMsgMixedCaseCase)
+
 
 
   val mixedReqHeadersMsgAllCase : TestCase = (requestHeadersAllMatchWADL,
@@ -3407,6 +3596,13 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
                                            List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderMsgNegHeaderTestsAll))
 
   run(mixedReqHeadersMsgDisableAnyCase)
+
+
+  val mixedReqHeadersMsgDisableAnyMixedCaseCase : TestCase = (requestHeadersMixedCaseWADL,
+                                           List(checkHeadersMsgConfigDisableAnyMatch, checkHeadersMsgConfigDupsDisableAnyMatch),
+                                           List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderMsgNegHeaderTestsAll))
+
+  run(mixedReqHeadersMsgDisableAnyMixedCaseCase)
 
 
 
@@ -3433,6 +3629,14 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
   run(mixedReqHeadersDefaultCase)
 
 
+  val mixedReqHeadersDefaultMixedCaseCase : TestCase = (requestHeadersMixedCaseWADL,
+                                               List(checkHeadersDefaultsConfig, checkHeadersDefaultsConfigDups),
+                                               List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedReqHeaderDefaultHeaderTests))
+
+  run(mixedReqHeadersDefaultMixedCaseCase)
+
+
+
   val mixedReqHeadersDefaultAllCase : TestCase = (requestHeadersAllMatchWADL,
                                                List(checkHeadersDefaultsConfig, checkHeadersDefaultsConfigDups),
                                                List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderDefaultHeaderTestsAll))
@@ -3448,11 +3652,25 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
 
 
 
+  val mixedReqHeadersDefaultAnyMixedCaseCase : TestCase = (requestHeadersMixedCaseWADL,
+                                               List(checkHeadersDefaultsConfigDisableAnyMatch, checkHeadersDefaultsConfigDupsDisableAnyMatch),
+                                               List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderDefaultHeaderTestsAll))
+
+  run(mixedReqHeadersDefaultAnyMixedCaseCase)
+
+
   val mixedReqHeadersMsgDefaultCase : TestCase = (requestHeadersWADL,
                                                   List(checkHeadersMsgDefaultsConfig, checkHeadersMsgDefaultsConfigDups),
                                                   List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedReqHeaderMsgDefaultHeaderTests))
 
   run(mixedReqHeadersMsgDefaultCase)
+
+
+  val mixedReqHeadersMsgDefaultMixedCaseCase : TestCase = (requestHeadersMixedCaseWADL,
+                                                  List(checkHeadersMsgDefaultsConfig, checkHeadersMsgDefaultsConfigDups),
+                                                  List(mixedHeaderHappyPathTests, mixedHeaderHappyNegTests, mixedReqHeaderMsgDefaultHeaderTests))
+
+  run(mixedReqHeadersMsgDefaultMixedCaseCase)
 
 
   val mixedReqHeadersMsgDefaultAllCase : TestCase = (requestHeadersAllMatchWADL,
@@ -3467,6 +3685,14 @@ def mixedHeaderMsgNegHeaderTestsAll (desc : String, validator : Validator) : Uni
                                                   List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderMsgDefaultHeaderTestsAll))
 
   run(mixedReqHeadersMsgDefaultAnyCase)
+
+
+
+  val mixedReqHeadersMsgDefaultAnyMixedCaseCase : TestCase = (requestHeadersMixedCaseWADL,
+                                                  List(checkHeadersMsgDefaultsConfigDisableAnyMatch, checkHeadersMsgDefaultsConfigDupsDisableAnyMatch),
+                                                  List(mixedHeaderHappyPathTestsAllMatch, mixedHeaderHappyNegTests, mixedReqHeaderMsgDefaultHeaderTestsAll))
+
+  run(mixedReqHeadersMsgDefaultAnyMixedCaseCase)
 
 
 


### PR DESCRIPTION
While adding the rax:authenticatedBy extension, I noticed that providing a rax:authenticatedBy value and a param header value with a param name whose casing did not match the `authenticated-by.xsl`, requests were always rejected.

I was able to recreate the issue using just params and not using the rax:authenticatedBy extension.  For the rax:authenticatedBy tests included below, I removed the param check for "X-AUTHENTICATED-BY" at the top of the `authenticated-by.xsl`.

Of note, I ran the CLI Tool with and without the `--remove-dups` option and got slightly different errors for a few cases.  These differences are noted in the results below.

WADL with various tests:
````xml
<application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api" xmlns:xs="http://www.w3.org/2001/XMLSchema">
    <resources base="https://test.api.openstack.com">
        <resource path="/justParams">
            <method name="GET">
                <request>
                    <param fixed="IMPERSONATION" name="X-AUTHENTICATED-BY" required="true" style="header"/>
                    <param fixed="PASSWORD" name="x-authenticated-by" required="true" style="header"/>
                </request>
            </method>
        </resource>
        <resource path="/allCaps" rax:authenticatedBy="FEDERATED">
            <method name="GET">
                <request>
                    <param fixed="PASSWORD" name="X-AUTHENTICATED-BY" required="true" style="header"/>
                </request>
            </method>
        </resource>
        <resource path="/allLowerCase" rax:authenticatedBy="RSAKEY">
            <method name="GET">
                <request>
                    <param fixed="PASSWORD" name="x-authenticated-by" required="true" style="header"/>
                </request>
            </method>
        </resource>
        <resource path="/resourceLevel" rax:authenticatedBy="APIKEY">
            <method name="GET">
                <request>
                    <param fixed="PASSWORD" name="X-Authenticated-By" required="true" style="header"/>
                </request>
            </method>
        </resource>
        <resource path="/methodLevel">
            <method name="GET" rax:authenticatedBy="PASSCODE">
                <request>
                    <param fixed="PASSWORD" name="X-Authenticated-By" required="true" style="header"/>
                </request>
            </method>
        </resource>
        <resource path="/resourceAndMethodLevel" rax:authenticatedBy="RSAKEY">
            <method name="GET" rax:authenticatedBy="IMPERSONATION">
                <request>
                    <param fixed="PASSWORD" name="X-Authenticated-By" required="true" style="header"/>
                </request>
            </method>
        </resource>
        <resource path="/parentResourceLevel" rax:authenticatedBy="PASSCODE">
            <resource path="/childResourceLevel" rax:authenticatedBy="RSAKEY">
                <method name="GET">
                    <request>
                        <param fixed="PASSWORD" name="X-Authenticated-By" required="true" style="header"/>
                    </request>
                </method>
            </resource>
        </resource>
    </resources>
</application>
````

CLI Tool command (shown with `--remove-dups`, but it was also run without it for each test):
```
java -jar ~/dev/api-checker/cli/wadltest/target/wadltest-*-jar-with-dependencies.jar \
   --console-log \
   --remove-dups \
   --well-formed \
   --header \
   --authenticated-by \
   ~/dev/logs/api-checker/param-test.wadl
```

CURL commands and test results:
```
# * if remove-dups is enabled

curl -v localhost:9191/justParams -H 'X-Authenticated-By: IMPERSONATION'  # 400 Bad Content: Expecting an HTTP header x-authenticated-by to have a value matching PASSWORD
curl -v localhost:9191/justParams -H 'X-Authenticated-By: PASSWORD'       # 400 Bad Content: Expecting an HTTP header X-AUTHENTICATED-BY to have a value matching IMPERSONATION
curl -v localhost:9191/justParams -H 'X-Authenticated-By: BACON'          # 400 Bad Content: Expecting an HTTP header X-AUTHENTICATED-BY to have a value matching IMPERSONATION
curl -v localhost:9191/justParams -H 'X-AUTHENTICATED-BY: IMPERSONATION'  # 400 Bad Content: Expecting an HTTP header x-authenticated-by to have a value matching PASSWORD
curl -v localhost:9191/justParams -H 'x-authenticated-by: PASSWORD'       # 400 Bad Content: Expecting an HTTP header X-AUTHENTICATED-BY to have a value matching IMPERSONATION
curl -v localhost:9191/justParams -H 'X-AUTHENTICATED-BY: IMPERSONATION' -H 'x-authenticated-by: PASSWORD'  # 400 Bad Content: Expecting 1 and only 1 instance of Header X-AUTHENTICATED-BY

curl -v localhost:9191/allCaps -H 'X-Authenticated-By: FEDERATED'  # VALID - 200
curl -v localhost:9191/allCaps -H 'X-Authenticated-By: PASSWORD'   # VALID - 200
curl -v localhost:9191/allCaps -H 'X-Authenticated-By: BACON'      # NOPE - 403 / 400*
curl -v localhost:9191/allCaps -H 'X-Authenticated-By: FEDERATED' -H 'X-Authenticated-By: PASSWORD'   # VALID - 200
curl -v localhost:9191/allCaps -H 'X-Authenticated-By: FEDERATED' -H 'X-Authenticated-By: BACON'      # VALID - 200
curl -v localhost:9191/allCaps -H 'X-Authenticated-By: BACON' -H 'X-Authenticated-By: FEDERATED'      # VALID - 200
curl -v localhost:9191/allCaps -H 'X-Authenticated-By: PASSWORD' -H 'X-Authenticated-By: FEDERATED'   # VALID - 200
curl -v localhost:9191/allCaps -H 'X-Authenticated-By: PASSWORD' -H 'X-Authenticated-By: BACON'       # NOPE - 403 / 400* -- unexpected
curl -v localhost:9191/allCaps -H 'X-Authenticated-By: BACON' -H 'X-Authenticated-By: PASSWORD'       # NOPE - 403 / 400* -- unexpected
curl -v localhost:9191/allCaps -H 'X-Authenticated-By: BACON' -H 'X-Authenticated-By: POTATO'         # NOPE - 403 / 400*

curl -v localhost:9191/allLowerCase -H 'X-Authenticated-By: RSAKEY'     # NOPE - 400 -- unexpected
curl -v localhost:9191/allLowerCase -H 'X-Authenticated-By: PASSWORD'   # NOPE - 403 -- unexpected
curl -v localhost:9191/allLowerCase -H 'X-Authenticated-By: BACON'      # NOPE - 403
curl -v localhost:9191/allLowerCase -H 'X-Authenticated-By: RSAKEY' -H 'X-Authenticated-By: PASSWORD'   # NOPE - 400 -- unexpected
curl -v localhost:9191/allLowerCase -H 'X-Authenticated-By: PASSWORD' -H 'X-Authenticated-By: RSAKEY'   # NOPE - 400 -- unexpected

curl -v localhost:9191/resourceLevel -H 'X-Authenticated-By: APIKEY'     # NOPE - 400 -- unexpected
curl -v localhost:9191/resourceLevel -H 'X-Authenticated-By: PASSWORD'   # NOPE - 403 -- unexpected
curl -v localhost:9191/resourceLevel -H 'X-Authenticated-By: BACON'      # NOPE - 403
curl -v localhost:9191/resourceLevel -H 'X-Authenticated-By: APIKEY' -H 'X-Authenticated-By: PASSWORD'   # NOPE - 400 -- unexpected
curl -v localhost:9191/resourceLevel -H 'X-Authenticated-By: PASSWORD' -H 'X-Authenticated-By: APIKEY'   # NOPE - 400 -- unexpected

curl -v localhost:9191/methodLevel -H 'X-Authenticated-By: PASSCODE'   # NOPE - 400 -- unexpected
curl -v localhost:9191/methodLevel -H 'X-Authenticated-By: PASSWORD'   # NOPE - 403 -- unexpected
curl -v localhost:9191/methodLevel -H 'X-Authenticated-By: BACON'      # NOPE - 403
curl -v localhost:9191/methodLevel -H 'X-Authenticated-By: PASSCODE' -H 'X-Authenticated-By: PASSWORD'   # NOPE - 400 -- unexpected
curl -v localhost:9191/methodLevel -H 'X-Authenticated-By: PASSWORD' -H 'X-Authenticated-By: PASSCODE'   # NOPE - 400 -- unexpected

curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: RSAKEY'          # NOPE - 400 -- unexpected
curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: IMPERSONATION'   # NOPE - 400 -- unexpected
curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: PASSWORD'        # NOPE - 403 -- unexpected
curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: BACON'           # NOPE - 403
curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: RSAKEY' -H 'X-Authenticated-By: PASSWORD'          # NOPE - 400 -- unexpected
curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: RSAKEY' -H 'X-Authenticated-By: IMPERSONATION'     # NOPE - 400 -- unexpected
curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: PASSWORD' -H 'X-Authenticated-By: RSAKEY'          # NOPE - 400 -- unexpected
curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: PASSWORD' -H 'X-Authenticated-By: IMPERSONATION'   # NOPE - 400 -- unexpected
curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: IMPERSONATION' -H 'X-Authenticated-By: RSAKEY'     # NOPE - 400 -- unexpected
curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: IMPERSONATION' -H 'X-Authenticated-By: PASSWORD'   # NOPE - 400 -- unexpected
curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: RSAKEY' -H 'X-Authenticated-By: IMPERSONATION' -H 'X-Authenticated-By: PASSWORD'  # NOPE - 400 -- unexpected
curl -v localhost:9191/resourceAndMethodLevel -H 'X-Authenticated-By: PASSWORD' -H 'X-Authenticated-By: RSAKEY' -H 'X-Authenticated-By: IMPERSONATION'  # NOPE - 400 -- unexpected

curl -v localhost:9191/parentResourceLevel/childResourceLevel -H 'X-Authenticated-By: PASSCODE'   # NOPE - 400 -- unexpected
curl -v localhost:9191/parentResourceLevel/childResourceLevel -H 'X-Authenticated-By: RSAKEY'     # NOPE - 400 -- unexpected
curl -v localhost:9191/parentResourceLevel/childResourceLevel -H 'X-Authenticated-By: PASSWORD'   # NOPE - 403 -- unexpected
curl -v localhost:9191/parentResourceLevel/childResourceLevel -H 'X-Authenticated-By: PASSCODE' -H 'X-Authenticated-By: RSAKEY'     # NOPE - 400 -- unexpected
curl -v localhost:9191/parentResourceLevel/childResourceLevel -H 'X-Authenticated-By: PASSCODE' -H 'X-Authenticated-By: PASSWORD'   # NOPE - 400 -- unexpected
curl -v localhost:9191/parentResourceLevel/childResourceLevel -H 'X-Authenticated-By: RSAKEY' -H 'X-Authenticated-By: PASSCODE'     # NOPE - 400 -- unexpected
curl -v localhost:9191/parentResourceLevel/childResourceLevel -H 'X-Authenticated-By: RSAKEY' -H 'X-Authenticated-By: PASSWORD'     # NOPE - 400 -- unexpected
curl -v localhost:9191/parentResourceLevel/childResourceLevel -H 'X-Authenticated-By: PASSWORD' -H 'X-Authenticated-By: PASSCODE'   # NOPE - 400 -- unexpected
curl -v localhost:9191/parentResourceLevel/childResourceLevel -H 'X-Authenticated-By: PASSWORD' -H 'X-Authenticated-By: RSAKEY'     # NOPE - 400 -- unexpected
curl -v localhost:9191/parentResourceLevel/childResourceLevel -H 'X-Authenticated-By: PASSCODE' -H 'X-Authenticated-By: RSAKEY' -H 'X-Authenticated-By: PASSWORD'   # NOPE - 400 -- unexpected
curl -v localhost:9191/parentResourceLevel/childResourceLevel -H 'X-Authenticated-By: PASSWORD' -H 'X-Authenticated-By: PASSCODE' -H 'X-Authenticated-By: RSAKEY'   # NOPE - 400 -- unexpected
```

I could dream up a ton of more scenarios to test, but running them would have taken a while.  If there are any other tests you would like me to check out, let me know.