### PR TITLE
Fixed bug : Multiple <wadl:doc/> in a method would cause error.

### DIFF
--- a/core/src/main/resources/xsl/builder.xsl
+++ b/core/src/main/resources/xsl/builder.xsl
@@ -1212,7 +1212,7 @@
             <xsl:attribute name="label">
                 <xsl:choose>
                     <xsl:when test="wadl:doc/@title">
-                        <xsl:value-of select="normalize-space(wadl:doc/@title)"/>
+                        <xsl:value-of select="normalize-space(wadl:doc[1]/@title)"/>
                     </xsl:when>
                     <xsl:when test="@id">
                         <xsl:value-of select="normalize-space(@id)"/>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLSuite2.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLSuite2.scala
@@ -112,6 +112,7 @@ class ValidatorWADLSuite2 extends BaseValidatorSuite {
        </resources>
        <method name="GET" id="TestGET">
          <doc title="TestGET"/>
+         <doc title="TestGETAltDoc"/>
          <response status="200">
              <representation mediaType="application/xml"/>
          </response>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerSpec.scala
@@ -857,6 +857,57 @@ class WADLCheckerSpec extends BaseCheckerSpec with LogAssertions {
       assert (checker, "/chk:checker/chk:step[@type='METHOD' and @match='DELETE' and @label='deleteResource']")
     }
 
+    scenario("The WADL contains method ids specifed in docs") {
+      Given ("a WADL with method IDs")
+      val inWADL =
+        <application xmlns="http://wadl.dev.java.net/2009/02">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method id="getResource" name="GET">
+                      <doc title="Get My Resource"/>
+                      <response status="200 203"/>
+                   </method>
+                   <method id="deleteResource" name="DELETE">
+                      <response status="200"/>
+                   </method>
+              </resource>
+          </resources>
+        </application>
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, stdConfig)
+      Then("The method nodes should contain a resource label with the id")
+      assert (checker, "count(/chk:checker/chk:step[@type='METHOD']) = 2")
+      assert (checker, "/chk:checker/chk:step[@type='METHOD' and @match='GET' and @label='Get My Resource']")
+      assert (checker, "/chk:checker/chk:step[@type='METHOD' and @match='DELETE' and @label='deleteResource']")
+    }
+
+    scenario("The WADL contains method ids specifed in docs (multiple docs)") {
+      Given ("a WADL with method IDs")
+      val inWADL =
+        <application xmlns="http://wadl.dev.java.net/2009/02">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method id="getResource" name="GET">
+                      <doc title="Get My Resource"/>
+                      <doc title="Alt get my resource"/>
+                      <response status="200 203"/>
+                   </method>
+                   <method id="deleteResource" name="DELETE">
+                      <response status="200"/>
+                   </method>
+              </resource>
+          </resources>
+        </application>
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, stdConfig)
+      Then("The method nodes should contain a resource label with the id")
+      assert (checker, "count(/chk:checker/chk:step[@type='METHOD']) = 2")
+      assert (checker, "/chk:checker/chk:step[@type='METHOD' and @match='GET' and @label='Get My Resource']")
+      assert (checker, "/chk:checker/chk:step[@type='METHOD' and @match='DELETE' and @label='deleteResource']")
+    }
+
     scenario("The WADL contains an initial invisible node") {
       Given ("a WADL with an initial invisble node")
       val inWADL =


### PR DESCRIPTION
The issue is related to figuring out the method label from the
document titile attribute.  Only the first document label should be
used.