### PR TITLE
Header quality not supported

### DIFF
--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/HeaderUtil.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/HeaderUtil.scala
@@ -26,6 +26,11 @@ object HeaderUtil {
 
 
   /**
+   * Strips header parameters from a header value
+   */
+  def stripParams (headerValue : String) : String = headerValue.split(";")(0)
+
+  /**
    * Returns true if a header by the given name is available
    *
    * The context and the request are both seached.
@@ -52,7 +57,7 @@ object HeaderUtil {
 
     value match {
       case null => None
-      case _ =>  Some(value.split(",")(0).trim)
+      case _ =>  Some(stripParams(value.split(",")(0).trim))
     }
   }
 
@@ -77,7 +82,7 @@ object HeaderUtil {
 
     var list : List[String] = List()
     all_headers.foreach(i => list = list ++ i.split(",").map(j => j.trim))
-    list
+    list.map(stripParams)
   }
 
   /**
@@ -89,12 +94,12 @@ object HeaderUtil {
   def getNonSplitHeaders(context : StepContext, request : HttpServletRequest, name : String) : List[String] = {
     val req_headers = request.getHeaders(name) match {
       case null => List[String]()
-      case e : Enumeration[String] =>  e.toList
+      case e : Enumeration[String] =>  e.toList.map(stripParams)
     }
 
     context.requestHeaders.get(name) match {
       case Some(Nil) => req_headers
-      case Some(l) => l ++ req_headers
+      case Some(l) => l.map(stripParams) ++ req_headers
       case _ => req_headers
     }
   }

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLHeaderSuite2.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLHeaderSuite2.scala
@@ -508,6 +508,19 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                  Map("X-TEST"->List("foo!"), "X-TESTO"->List("23"))), response, chain)
     }
 
+
+    test(s"$desc : should allow POST on /a/b with X-TEST=foo! and X-TESTO=23 and goodXML (header param)") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("foo!;q=1.0"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST on /a/b with X-TEST=foo! and X-TESTO=23 and goodXML (multiple header param)") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("foo!;q=1.0;rockit=true"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+
+
     test(s"$desc : should allow POST on /a/b with X-TEST=bar! and X-TESTO=23 and goodXML") {
       validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
                                  Map("X-TEST"->List("bar!"), "X-TESTO"->List("23"))), response, chain)
@@ -574,6 +587,17 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                  Map("X-TEST"->List("foo!", "2001-10-26", "2001-10-26T19:32:52Z", "bar!"), "X-TESTO"->List("23"))), response, chain)
     }
 
+    test(s"$desc : should allow PUT on /a/b with X-TEST=foo!, 2001-10-26,  2001-10-26T19:32:52Z, bar! and X-TESTO=23 and goodXML (with header params)") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!;q=1.0", "2001-10-26", "2001-10-26T19:32:52Z;q=0.5", "bar!"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /a/b with X-TEST=foo!, 2001-10-26,  2001-10-26T19:32:52Z, bar! and X-TESTO=23 and goodXML (with mulitiple header params)") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
+                                 Map("X-TEST"->List("foo!;q=1.0;rockit=true", "2001-10-26;q=1", "2001-10-26T19:32:52Z;q=0.5;rockit=true", "bar!"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+
     test(s"$desc : should allow PUT on /a/b with X-TEST=bar!, 2001-10-26,  2001-10-26T19:32:52Z and X-TESTO=23 and goodXML") {
       validator.validate(request("PUT", "/a/b", "application/xml", goodXML_XSD2, false,
                                  Map("X-TEST"->List("bar!", "2001-10-26", "2001-10-26T19:32:52Z"), "X-TESTO"->List("23"))), response, chain)
@@ -604,6 +628,18 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
       validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
                                  Map("X-TEST"->List("foo!"), "X-TESTO"->List("23"))), response, chain)
     }
+
+
+    test(s"$desc : should allow POST on /a/b with X-TEST=foo! and X-TESTO=23 and goodXML (header param)") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("foo!; q=1.0"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST on /a/b with X-TEST=foo! and X-TESTO=23 and goodXML (multiple header param)") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("foo!;q=1.0 ; rockit=true"), "X-TESTO"->List("23"))), response, chain)
+    }
+
 
     test(s"$desc : should allow POST on /a/b with X-TEST=bar! and X-TESTO=23 and goodXML") {
       validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
@@ -703,6 +739,16 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
                                  Map("X-TEST"->List("2001-10-26T19:32:52Z"), "X-TESTO"->List("23"))), response, chain)
     }
 
+    test(s"$desc : should allow POST on /a/b with X-TEST=2001-10-26T19:32:52Z and X-TESTO=23 and goodXML (header param)") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("2001-10-26T19:32:52Z;q=1.0"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST on /a/b with X-TEST=2001-10-26T19:32:52Z and X-TESTO=23 and goodXML (multiple header param)") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("2001-10-26T19:32:52Z;q=1.0;rockit=true"), "X-TESTO"->List("23"))), response, chain)
+    }
+
     test(s"$desc : should allow POST on /a/b with X-TEST=foo! and X-TESTO=32 and goodXML") {
       validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
                                  Map("X-TEST"->List("foo!"), "X-TESTO"->List("32"))), response, chain)
@@ -796,6 +842,17 @@ class ValidatorWADLHeaderSuite2 extends BaseValidatorSuite {
       validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
                                  Map("X-TEST"->List("baz", "bing"), "X-TESTO"->List("23"))), response, chain)
     }
+
+    test(s"$desc : should allow POST /a/b if X-TEST=baz, bing (header param)") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("baz;q=1.0", "bing;q=0.5"), "X-TESTO"->List("23"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST /a/b if X-TEST=baz, bing (multiple header param)") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,
+                                 Map("X-TEST"->List("baz;q=1.0;rockit=true", "bing;q=0.5;rockit=false"), "X-TESTO"->List("23"))), response, chain)
+    }
+
 
     test(s"$desc : should allow POST /a/b if X-TESTO=foo") {
       validator.validate(request("POST", "/a/b", "application/xml", goodXML_XSD1, false,


### PR DESCRIPTION
An external user evaluating Repose told us about an issue where API Validation wasn't working if the header had a quality.  I did a quick test using the rax:authenticatedBy extension and observed the same behavior.

WADL:
````xml
<application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api">
    <resources base="https://test.api.openstack.com">
        <resource path="/a" rax:authenticatedBy="FEDERATED">
            <method name="GET">
                <request/>
            </method>
        </resource>
    </resources>
</application>
````

CLI Tool command:
```
java -jar ~/dev/api-checker/cli/wadltest/target/wadltest-*-jar-with-dependencies.jar \
   --console-log \
   --remove-dups \
   --well-formed \
   --header \
   --authenticated-by \
   ~/dev/logs/api-checker/quality-test.wadl
```

Testing:
```
curl -v localhost:9191/a -H 'X-Authenticated-By: FEDERATED'                  # VALID
curl -v localhost:9191/a -H 'X-Authenticated-By: FEDERATED;q=1.0'            # NOPE - 403
curl -v localhost:9191/a -H 'X-Authenticated-By: FEDERATED; q=1.0'           # NOPE - 403
curl -v localhost:9191/a -H 'X-Authenticated-By: FEDERATED;q=0.5'            # NOPE - 403
curl -v localhost:9191/a -H 'X-Authenticated-By: FEDERATED,PASSWORD;q=0.9'   # VALID
curl -v localhost:9191/a -H 'X-Authenticated-By: PASSWORD,FEDERATED;q=0.9'   # NOPE - 403
```