### PR TITLE
Expose xsdEngine in wadlTest utility.

### DIFF
--- a/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
+++ b/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
@@ -104,6 +104,10 @@ object WadlTest {
   val xslEngine = parser.option[String] (List("E", "xsl-engine"), "xsl-engine",
                                             "The name of the XSLT engine to use. Possible names are Xalan, XalanC, SaxonHE, SaxonEE.  Default: XalanC")
 
+
+  val xsdEngine = parser.option[String] (List("S", "xsd-engine"), "xsd-engine",
+                                            "The name of the XSD engine to use. Possible names are Xerces, SaxonEE.  Default: Xerces")
+
   val dontValidate = parser.flag[Boolean] (List("D", "dont-validate"),
                                        "Don't validate produced checker Default: false")
 
@@ -281,6 +285,7 @@ object WadlTest {
         c.enableWarnHeaders = !warnHeaders.value.getOrElse(false)
         c.warnAgent = warnAgent.value.getOrElse("-")
         c.xslEngine = xslEngine.value.getOrElse("XalanC")
+        c.xsdEngine = xsdEngine.value.getOrElse("Xerces")
 
 
         val dot = File.createTempFile("chk", ".dot")


### PR DESCRIPTION
This was a bit of an oversight since xsdEngine doesn't affect checker format it's not a command line option in wadl2dot and wadl2checker -- but it should be an option here.