### PR TITLE
Use xsdEngine config to determine what to use to validate checker.

### DIFF
--- a/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
+++ b/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
@@ -132,6 +132,9 @@ object Wadl2Checker {
     val xslEngine = parser.option[String] (List("E", "xsl-engine"), "xsl-engine",
                                            "The name of the XSLT engine to use. Possible names are Xalan, XalanC, SaxonHE, SaxonEE.  Default: XalanC")
 
+    val xsdEngine = parser.option[String] (List("S", "xsd-engine"), "xsd-engine",
+                                           "The name of the XSD engine to use. Possible names are Xerces, SaxonEE.  Default: Xerces")
+
     val dontValidate = parser.flag[Boolean] (List("D", "dont-validate"),
                                              "Don't validate produced checker Default: false")
 
@@ -179,12 +182,15 @@ object Wadl2Checker {
         c.enableWarnHeaders = !warnHeaders.value.getOrElse(false)
         c.warnAgent = warnAgent.value.getOrElse("-")
         c.xslEngine = xslEngine.value.getOrElse("XalanC")
+        c.xsdEngine = xsdEngine.value.getOrElse("Xerces")
 
         Some((source, result, c))
       }
     } catch {
       case e: ArgotUsageException => err.println(e.message)
                                      None
+      case iae : IllegalArgumentException => err.println(iae.getMessage)
+                                             None
     }
   }
 

--- a/cli/wadl2checker/src/test/scala/com/rackspace/com/papi/components/checker/cli/Wadl2CheckerSuite.scala
+++ b/cli/wadl2checker/src/test/scala/com/rackspace/com/papi/components/checker/cli/Wadl2CheckerSuite.scala
@@ -95,6 +95,15 @@ class Wadl2CheckerSuite extends FunSuite with XPathAssertions {
       assert(out.toString().isEmpty())
   })}
 
+  test ("Bad XSD engine should generate an error") {
+    withOutput ( (out, error) => {
+      Wadl2Checker.main(Array("-S", "foo", "src/test/resources/wadl/sharedXPath.wadl"))
+      assert(error.toString().contains("Unrecognized XSL engine"))
+      assert(error.toString().contains("foo"))
+      assert(error.toString().contains("Xerces, SaxonEE"))
+      assert(out.toString().isEmpty())
+  })}
+
   test ("Should generate checker xml to stdout") {
     withOutput ( (out, error) => {
       Wadl2Checker.main(Array("src/test/resources/wadl/sharedXPath.wadl"))
@@ -106,6 +115,25 @@ class Wadl2CheckerSuite extends FunSuite with XPathAssertions {
 
       //  Just some basic asserts to make sure we're working, we'd
       //  expect to see all of these things in the output
+      assert(outXML, "/chk:checker")
+      assert(outXML, "starts-with(/chk:checker/chk:meta/chk:created-by,'API Checker')")
+      assert(outXML, "/chk:checker/chk:meta/chk:config")
+      assert(outXML, "/chk:checker/chk:step[@type='START']")
+      assert(outXML, "/chk:checker/chk:step[@type='ACCEPT']")
+  })}
+
+  test ("Should generate checker xml to stdout (xsd engine)") {
+    withOutput ( (out, error) => {
+      Wadl2Checker.main(Array("--xsd-engine","Xerces","src/test/resources/wadl/sharedXPath.wadl"))
+
+      //  No err
+      assert(error.toString().isEmpty())
+
+      val outXML = XML.loadString(out.toString())
+
+      //  Just some basic asserts to make sure we're working, we'd
+      //  expect to see all of these things in the output
+      //
       assert(outXML, "/chk:checker")
       assert(outXML, "starts-with(/chk:checker/chk:meta/chk:created-by,'API Checker')")
       assert(outXML, "/chk:checker/chk:meta/chk:config")

--- a/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
+++ b/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
@@ -133,6 +133,8 @@ object Wadl2Dot {
     val xslEngine = parser.option[String] (List("E", "xsl-engine"), "xsl-engine",
                                            "The name of the XSLT engine to use. Possible names are Xalan, XalanC, SaxonHE, SaxonEE.  Default: XalanC")
 
+    val xsdEngine = parser.option[String] (List("S", "xsd-engine"), "xsd-engine",
+                                           "The name of the XSD engine to use. Possible names are Xerces, SaxonEE.  Default: Xerces")
 
     val dontValidate = parser.flag[Boolean] (List("D", "dont-validate"),
                                              "Don't validate produced checker Default: false")
@@ -187,12 +189,15 @@ object Wadl2Dot {
         c.enableWarnHeaders = !warnHeaders.value.getOrElse(false)
         c.warnAgent = warnAgent.value.getOrElse("-")
         c.xslEngine = xslEngine.value.getOrElse("XalanC")
+        c.xsdEngine = xsdEngine.value.getOrElse("Xerces")
 
         Some((source, result, c, !showErrors.value.getOrElse(false), nfaMode.value.getOrElse(false)))
       }
     } catch {
       case e: ArgotUsageException => err.println(e.message)
                                      None
+      case iae : IllegalArgumentException => err.println(iae.getMessage)
+                                             None
     }
   }
 

--- a/cli/wadl2dot/src/test/scala/com/rackspace/com/papi/components/checker/cli/Wadl2DotSuite.scala
+++ b/cli/wadl2dot/src/test/scala/com/rackspace/com/papi/components/checker/cli/Wadl2DotSuite.scala
@@ -87,9 +87,35 @@ class Wadl2DotSuite extends FunSuite {
       assert(outStream.toString().isEmpty())
   })}
 
+  test ("Bad XSD engine s hould generate an error") {
+    withOutput( (outStream, errStream) => {
+      Wadl2Dot.main(Array("-S", "foo", "src/test/resources/wadl/sharedXPath.wadl"))
+      assert(errStream.toString().contains("Unrecognized XSL engine"))
+      assert(errStream.toString().contains("foo"))
+      assert(errStream.toString().contains("Xerces, SaxonEE"))
+      assert(outStream.toString().isEmpty())
+  })}
+
   test ("Should generate dot to stdout") {
     withOutput( (outStream, errStream) => {
       Wadl2Dot.main(Array("src/test/resources/wadl/sharedXPath.wadl"))
+
+      //  No err
+      assert(errStream.toString().isEmpty())
+
+      val out = outStream.toString()
+
+      //  Just some basic asserts to make sure we're working, we'd
+      //  expect to see all of these things in the output
+      assert(out.contains("digraph Checker"))
+      assert(out.contains("rank=source"))
+      assert(out.contains("->"))
+      assert(!out.contains("SE0"))
+  })}
+
+  test ("Should generate dot to stdout (xsdEngine)") {
+    withOutput( (outStream, errStream) => {
+      Wadl2Dot.main(Array("--xsd-engine","Xerces","src/test/resources/wadl/sharedXPath.wadl"))
 
       //  No err
       assert(errStream.toString().isEmpty())

--- a/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
+++ b/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
@@ -107,6 +107,10 @@ object WadlTest {
   val xslEngine = parser.option[String] (List("E", "xsl-engine"), "xsl-engine",
                                             "The name of the XSLT engine to use. Possible names are Xalan, XalanC, SaxonHE, SaxonEE.  Default: XalanC")
 
+
+  val xsdEngine = parser.option[String] (List("S", "xsd-engine"), "xsd-engine",
+                                            "The name of the XSD engine to use. Possible names are Xerces, SaxonEE.  Default: Xerces")
+
   val dontValidate = parser.flag[Boolean] (List("D", "dont-validate"),
                                        "Don't validate produced checker Default: false")
 
@@ -285,6 +289,7 @@ object WadlTest {
         c.enableWarnHeaders = !warnHeaders.value.getOrElse(false)
         c.warnAgent = warnAgent.value.getOrElse("-")
         c.xslEngine = xslEngine.value.getOrElse("XalanC")
+        c.xsdEngine = xsdEngine.value.getOrElse("Xerces")
 
 
         val dot = File.createTempFile("chk", ".dot")
@@ -311,6 +316,7 @@ object WadlTest {
       }
     } catch {
       case e: ArgotUsageException => println(e.message)
+      case iae : IllegalArgumentException => println(iae.getMessage)
     }
   }
 }

--- a/core/src/test/resources/log4j2-test.xml
+++ b/core/src/test/resources/log4j2-test.xml
@@ -7,6 +7,9 @@
         <List name="api-coverage-listAppender"/>
     </Appenders>
     <Loggers>
+        <Logger name="com.rackspace.com.papi.components.checker.wadl" level="debug">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
         <Root level="info">
             <AppenderRef ref="STDOUT"/>
         </Root>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerCheckXSDEngineSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerCheckXSDEngineSuite.scala
@@ -1,0 +1,55 @@
+/***
+ *   Copyright 2016 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import com.rackspace.com.papi.components.checker.{LogAssertions, TestConfig}
+import org.apache.logging.log4j.Level
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml._
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerCheckXSDEngineSuite extends BaseCheckerSpec with LogAssertions {
+  val config = {
+    val c = TestConfig()
+    c.validateChecker = true
+    c.xsdEngine="Xerces"
+    c
+  }
+
+  scenario ("Load a WADL document check XSDEngine") {
+    Given("a WADL document that ends in")
+    val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="/">
+                <resource path="element">
+                    <method name="GET">
+                        <response status="200"/>
+                    </method>
+                </resource>
+              </resource>
+           </resources>
+        </application>
+    When("the document is loaded...")
+    val goodCheckerLog = log (Level.DEBUG) {
+      val checker = builder.build (inWADL,config)
+    }
+    Then ("An appropriate DEBUG messages should be emmited.")
+    assert(goodCheckerLog,"Using Xerces for checker validation")
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerCheckXSDEngineSuiteSaxonEE.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerCheckXSDEngineSuiteSaxonEE.scala
@@ -1,0 +1,55 @@
+/***
+ *   Copyright 2016 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import com.rackspace.com.papi.components.checker.{LogAssertions, TestConfig}
+import org.apache.logging.log4j.Level
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml._
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerCheckXSDEngineSuiteSaxonEE extends BaseCheckerSpec with LogAssertions {
+  val config = {
+    val c = TestConfig()
+    c.validateChecker = true
+    c.xsdEngine="SaxonEE"
+    c
+  }
+
+  scenario ("Load a WADL document check XSDEngine") {
+    Given("a WADL document that ends in")
+    val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="/">
+                <resource path="element">
+                    <method name="GET">
+                        <response status="200"/>
+                    </method>
+                </resource>
+              </resource>
+           </resources>
+        </application>
+    When("the document is loaded...")
+    val goodCheckerLog = log (Level.DEBUG) {
+      val checker = builder.build (inWADL,config)
+    }
+    Then ("An appropriate DEBUG messages should be emmited.")
+    assert(goodCheckerLog,"Using SaxonEE for checker validation")
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerCompSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerCompSpec.scala
@@ -97,6 +97,27 @@ class WADLCheckerCompSpec extends BaseCheckerSpec with LogAssertions {
        assertEmpty(goodCheckerLog)
      }
 
+     scenario ("Load a plain checker document that ends with .checker extension (check XSDEngine)") {
+       Given("a plain checker document that ends in .checker")
+       val in = ("foo.checker", fooGETChecker)
+       When("the document is loaded...")
+       val goodCheckerLog = log (Level.DEBUG) {
+         val checker = builder.build (in,config)
+         assert(checker, "/chk:checker/chk:step[@type='START']/@next = 'F1 notFoo noMETHOD'")
+         assert(checker, "/chk:checker/chk:step[@type='URL']/@match = 'foo'")
+         assert(checker, "/chk:checker/chk:step[@type='URL']/@next = 'G1 noURL notGET'")
+         assert(checker, "/chk:checker/chk:step[@type='METHOD']/@next = 'A'")
+         assert(checker, "/chk:checker/chk:step[@type='METHOD']/@match = 'GET'")
+         assert(checker, "/chk:checker/chk:step[@type='ACCEPT']")
+         assert(checker, "/chk:checker/chk:step[@type='URL_FAIL']/@notMatch='foo'")
+         assert(checker, "/chk:checker/chk:step[@type='URL_FAIL' and not(@notMatch)]")
+         assert(checker, "/chk:checker/chk:step[@type='METHOD_FAIL']/@notMatch='GET'")
+         assert(checker, "/chk:checker/chk:step[@type='METHOD_FAIL' and not(@notMatch)]")
+       }
+       Then ("An appropriate DEBUG messages should be emmited.")
+       assert(goodCheckerLog,"Using Xerces for checker validation")
+     }
+
     scenario ("Should fail to load a plain checker document that *does not* end with a .checker extension") {
       Given ("a plain checker document that does not end in .checker")
       val in = ("foo.xml", fooGETChecker)

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerCompSpecSaxonEE.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerCompSpecSaxonEE.scala
@@ -1,0 +1,88 @@
+/***
+ *   Copyright 2016 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import com.rackspace.com.papi.components.checker.{LogAssertions, TestConfig}
+import org.apache.logging.log4j.Level
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerCompSpecSaxonEE extends BaseCheckerSpec with LogAssertions {
+  //
+  //  Register some common prefixes, you'll need the for XPath
+  //  assertions.
+  //
+  register ("xsd", "http://www.w3.org/2001/XMLSchema")
+  register ("wadl","http://wadl.dev.java.net/2009/02")
+  register ("chk","http://www.rackspace.com/repose/wadl/checker")
+
+  val creatorString = {
+    val title = getClass.getPackage.getImplementationTitle
+    val version = getClass.getPackage.getImplementationVersion
+    s"$title ($version)"
+  }
+
+  val config = {
+    val c = TestConfig()
+    c.validateChecker = true
+    c.xsdEngine="SaxonEE"
+    c
+  }
+
+  //
+  //  A simple checker that accepts a GET on /foo
+  //
+  val fooGETChecker =  <checker xmlns="http://www.rackspace.com/repose/wadl/checker">
+                             <meta>
+                                <built-by>Test</built-by>
+                                <created-by>{creatorString}</created-by>
+                                <created-on>2014-11-10T10:00:07.811-06:00</created-on>
+                                {
+                                  config.checkerMetaMap.map(c => <config option={c._1} value={c._2.toString} />)
+                                }
+                             </meta>
+                             <step id="S0" type="START" next="F1 notFoo noMETHOD"/>
+                             <step id="F1" type="URL" match="foo" next="G1 noURL notGET"/>
+                             <step id="G1" type="METHOD" match="GET" label="GET Foo" next="A"/>
+                             <step id="A" type="ACCEPT" priority="19999"/>
+                             <step id="notFoo" type="URL_FAIL" notMatch="foo" />
+                             <step id="notGET" type="METHOD_FAIL" notMatch="GET" />
+                             <step id="noMETHOD" type="METHOD_FAIL" />
+                             <step id="noURL" type="URL_FAIL" />
+                         </checker>
+
+  scenario ("Load a plain checker document that ends with .checker extension (check SaxonEE)") {
+    Given("a plain checker document that ends in .checker")
+    val in = ("foo.checker", fooGETChecker)
+      When("the document is loaded...")
+    val goodCheckerLog = log (Level.DEBUG) {
+      val checker = builder.build (in,config)
+      assert(checker, "/chk:checker/chk:step[@type='START']/@next = 'F1 notFoo noMETHOD'")
+      assert(checker, "/chk:checker/chk:step[@type='URL']/@match = 'foo'")
+      assert(checker, "/chk:checker/chk:step[@type='URL']/@next = 'G1 noURL notGET'")
+      assert(checker, "/chk:checker/chk:step[@type='METHOD']/@next = 'A'")
+      assert(checker, "/chk:checker/chk:step[@type='METHOD']/@match = 'GET'")
+      assert(checker, "/chk:checker/chk:step[@type='ACCEPT']")
+      assert(checker, "/chk:checker/chk:step[@type='URL_FAIL']/@notMatch='foo'")
+      assert(checker, "/chk:checker/chk:step[@type='URL_FAIL' and not(@notMatch)]")
+      assert(checker, "/chk:checker/chk:step[@type='METHOD_FAIL']/@notMatch='GET'")
+      assert(checker, "/chk:checker/chk:step[@type='METHOD_FAIL' and not(@notMatch)]")
+    }
+    Then ("An appropriate DEBUG messages should be emmited.")
+    assert(goodCheckerLog,"Using SaxonEE for checker validation")
+  }
+}


### PR DESCRIPTION
XSD engine was honored only at runtime, at compile time we always used
Xerces to ensure the generated checker file validated. Turns out Saxon
is alot faster then Xerces so if we have saxon specified then use
that to validate the checker.

Also, new CLI option to specify the xsdEngine as well.

<img width="870" alt="checker_val" src="https://cloud.githubusercontent.com/assets/348314/19216343/49f8cd02-8d7d-11e6-8d58-ce9dd7ecc532.png">

Notice that SaxonEE is 27 times faster!
