### PR TITLE
Fixed metadata ext issue where a bad WADL was being produced.

### DIFF
--- a/core/src/main/resources/xsl/meta-transform.xsl
+++ b/core/src/main/resources/xsl/meta-transform.xsl
@@ -2,7 +2,8 @@
 <!--
    meta-transform.xsl
 
-   This stylesheet ...
+   This stylesheet rax:metadata into metadata resources with
+   appropriate rax:roles attributes.
 
    Copyright 2015 Rackspace US, Inc.
 
@@ -106,20 +107,19 @@
     </xsl:template>
     <xsl:template match="wadl:grammars">
         <xsl:copy>
-            <xsl:apply-templates select="@*"/>
+            <xsl:apply-templates select="@* | node()"/>
             <xsl:call-template name="addMetadataSchema">
                 <xsl:with-param name="metadata" select="../rax:metadata"/>
             </xsl:call-template>
-            <xsl:apply-templates/>
         </xsl:copy>
     </xsl:template>
     <xsl:template match="wadl:resource[@rax:useMetadata]">
         <xsl:copy>
             <xsl:apply-templates select="@*[not(name() = 'rax:useMetadata')]"/>
+            <xsl:apply-templates select="node()"/>
             <xsl:call-template name="addMetadataAPI">
                 <xsl:with-param name="useMetadata" select="@rax:useMetadata"/>
             </xsl:call-template>
-            <xsl:apply-templates select="node()"/>
         </xsl:copy>
     </xsl:template>
     <xsl:template match="rax:metadata"/>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithMetaTransformsBase.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithMetaTransformsBase.scala
@@ -26,9 +26,15 @@ abstract class GivenAWadlWithMetaTransformsBase extends FlatSpec with RaxRolesBe
   val descriptionWithRaxRoles = description + " and RAX-Roles"
   val descriptionWithRaxRolesMasked = descriptionWithRaxRoles + " Masked"
 
-  val metadataWadl = <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api">
+  val metadataWadl = <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api"
+    xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test">
+    <grammars>
+       <include href="src/test/resources/xsd/test-urlxsd.xsd"/>
+    </grammars>
     <resources base="https://resource.api.rackspace.com">
-      <resource id="standardResource" path="standard" rax:useMetadata="standardMeta"/>
+      <resource id="standardResource" path="standard/{id}" rax:useMetadata="standardMeta">
+            <param name="id" style="template" type="tst:UUID" required="true"/>
+      </resource>
       <resource id="customResource" path="custom" rax:useMetadata="customMeta"/>
     </resources>
     <rax:metadata id="standardMeta">
@@ -84,7 +90,7 @@ abstract class GivenAWadlWithMetaTransformsBase extends FlatSpec with RaxRolesBe
 
     // Standard/Custom GET's, PUT's, DELETE's, and POST's are forbidden when RAX-Roles are not enabled.
     val validator = Validator((localWADLURI, metadataWadl), createConfigWithRaxRoles(false, false, useSaxon))
-    List(("standard", targetsStandard), ("custom", targetsCustom)).foreach { case (style, targets) =>
+    List(("standard/55679674-8e21-11e6-bf0c-28cfe92134e7", targetsStandard), ("custom", targetsCustom)).foreach { case (style, targets) =>
       List(methodGet, methodPut, methodDel, methodPst).foreach { method =>
         targets.foreach { target =>
           rolesList.foreach { roles =>
@@ -103,7 +109,7 @@ abstract class GivenAWadlWithMetaTransformsBase extends FlatSpec with RaxRolesBe
       } else {
         descriptionWithRaxRoles
       }
-      List(("standard", targetsStandard), ("custom", targetsCustom)).foreach { case (style, targets) =>
+      List(("standard/1a34564a-8e22-11e6-8e61-28cfe92134e7", targetsStandard), ("custom", targetsCustom)).foreach { case (style, targets) =>
         // Standard/Custom GET's are allowed regardless of roles.
         targets.foreach { target =>
           rolesList.foreach { roles =>
@@ -130,17 +136,17 @@ abstract class GivenAWadlWithMetaTransformsBase extends FlatSpec with RaxRolesBe
             // THEN access should be allowed;
             // ELSE access should be not allowed/forbidden.
             if (targetInRoles(target, roles, List("admin"))) {
-              it should behave like accessIsAllowed(validator, method, s"/standard/metadata/${target}foo", roles, desc)
+              it should behave like accessIsAllowed(validator, method, s"/standard/2cb1be7a-8e22-11e6-a152-28cfe92134e7/metadata/${target}foo", roles, desc)
             } else if (masked) {
-              it should behave like methodNotAllowed(validator, method, s"/standard/metadata/${target}foo", roles, desc)
+              it should behave like methodNotAllowed(validator, method, s"/standard/2cb1be7a-8e22-11e6-a152-28cfe92134e7/metadata/${target}foo", roles, desc)
             } else {
-              it should behave like accessIsForbidden(validator, method, s"/standard/metadata/${target}foo", roles, desc)
+              it should behave like accessIsForbidden(validator, method, s"/standard/2cb1be7a-8e22-11e6-a152-28cfe92134e7/metadata/${target}foo", roles, desc)
             }
           }
           if (masked) {
-            it should behave like methodNotAllowedWhenNoXRoles(validator, method, s"/standard/metadata/${target}foo", desc)
+            it should behave like methodNotAllowedWhenNoXRoles(validator, method, s"/standard/2cb1be7a-8e22-11e6-a152-28cfe92134e7/metadata/${target}foo", desc)
           } else {
-            it should behave like accessIsForbiddenWhenNoXRoles(validator, method, s"/standard/metadata/${target}foo", desc)
+            it should behave like accessIsForbiddenWhenNoXRoles(validator, method, s"/standard/2cb1be7a-8e22-11e6-a152-28cfe92134e7/metadata/${target}foo", desc)
           }
         }
       }

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerMetaExtSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerMetaExtSpec.scala
@@ -1,0 +1,87 @@
+/***
+ *   Copyright 2016 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import javax.xml.transform.Templates
+import javax.xml.transform.dom.{DOMResult, DOMSource}
+import javax.xml.transform.stream.StreamSource
+
+import com.rackspace.cloud.api.wadl.Converters._
+import com.rackspace.cloud.api.wadl.WADLNormalizer
+import com.rackspace.com.papi.components.checker.{Config, LogAssertions}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerMetaExtSpec extends BaseCheckerSpec with LogAssertions {
+  scenario("A WADL with metadata extension enabled should produce a valid WADL, even in the presens of existing schemas") {
+    Given("A WADL with existing schemas an template params")
+    val inWADL =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:meta="http://docs.rackspace.com/metadata/api"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:tst="test://schema/a">
+           <grammars>
+              <include href="xsd/simple.xsd"/>
+           </grammars>
+           <resources base="https://test.api.openstack.com">
+              <resource id="yn" path="path/to/my/resource/{yn}" rax:useMetadata="myMetadata">
+                   <param name="yn" style="template" type="tst:yesno"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+           <rax:metadata id="myMetadata">
+               <rax:metaRole name="admin" pattern="*"/>
+               <rax:metaRole name="billing:role" pattern="billing:"/>
+           </rax:metadata>
+        </application>
+    register("test://app/xsd/simple.xsd",
+             <schema elementFormDefault="qualified"
+                        attributeFormDefault="unqualified"
+                        xmlns="http://www.w3.org/2001/XMLSchema"
+                        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                        targetNamespace="test://schema/a">
+                   <simpleType name="yesno">
+                       <restriction base="xsd:string">
+                           <enumeration value="yes"/>
+                           <enumeration value="no"/>
+                       </restriction>
+                   </simpleType>
+                </schema>)
+    When("The WADL is ran by the Metadata extension XSL")
+    val wadl = new WADLNormalizer
+    val raxMetaTransformTemplates: Templates =
+      wadl.saxTransformerFactory.newTemplates(new StreamSource(getClass.getResource("/xsl/meta-transform.xsl").toString))
+    val handler = wadl.saxTransformerFactory.newTransformerHandler(raxMetaTransformTemplates)
+    val transformer = handler.getTransformer
+    val res = new DOMResult
+    val src = new StreamSource(inWADL)
+    src.setSystemId("test://app/myWADL.wadl")
+    transformer.transform (src, res)
+    Then("The WADL should be one that is loaded correctly by API checker")
+    val result2 = new DOMResult
+    val src2 = new DOMSource(res.getNode)
+    src2.setSystemId("test://app/myWADL.wadl")
+
+    val config = new Config
+    config.enableRaxRolesExtension=true
+    config.maskRaxRoles403=true
+    builder.build(src2, result2, config)
+  }
+}


### PR DESCRIPTION
The extension was placing WADL elements in the wrong location under
some circumstances.

New WADL and Schema elements should be placed *after* existing ones -- instead they were placed *before* existing ones which caused failures.