### PR TITLE
release note handling

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,5 @@
 # Releases #
+## In Progress Work ##
 
 ## Release 2.0.1 (2016-08-06) ##
 1. Fixed a bug where a call to getInputStream was not invalidating cached XML/JSON.


### PR DESCRIPTION
lets start tracking release notes as we go, and just give them the version number as the prep