### PR TITLE
Updated AuthBy test to speed up build

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,7 @@
 # Releases #
+## In Progress Work ##
+1. Clean up: Optimized the configuration for one of the unit tests to improve build times.
+
 ## Release 2.0.2 (2016-10-17) ##
 1. Updated Dependencies
    1. saxon: 9.5.1-8 → 9.7.0-8

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithAuthenticatedByBase.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithAuthenticatedByBase.scala
@@ -518,7 +518,7 @@ object GivenAWadlWithAuthenticatedByBase {
     List(EnableRaxRoles),
     List(EnableCaptureHeadersExt),
     List(EnableRaxRoles, EnableCaptureHeadersExt),
-    List(EnableRaxRoles, EnableMaskRaxRoles403, EnableCaptureHeadersExt),
+    List(EnableRaxRoles, EnableMaskRaxRoles403, EnableRemoveDups, EnableCaptureHeadersExt),
     List(EnableRaxRoles, EnableMaskRaxRoles403, EnableRemoveDups, EnableJoinXPathChecks, EnableCaptureHeadersExt))
 
   // get all of the possible combinations, e.g. Set(a, b) => List(List(), List(a), List(b), List(a, b))


### PR DESCRIPTION
I noticed the new Authenticated By feature seems to have increased the build time noticeably, and I tracked it down to one of the test configurations causing the slow down when using Xerces:

```
    config.enableRaxRolesExtension        = true
    config.maskRaxRoles403                = true
    config.removeDups                     = false
    config.joinXPathChecks                = false
    config.enableCaptureHeaderExtension   = true
```

This configuration consistently took about 2 minutes longer when using Xerces compared to Saxon.  By enabling `removedDups` in the test configuration, the Xerces times improved dramatically.

```
# in the api-checker/core directory
mvn -Dtest=GivenAWadlWithAuthenticatedBySaxonEE test
mvn -Dtest=GivenAWadlWithAuthenticatedBy test
```
(times as reported by Maven for "Total Time")
Saxon Before: 29s 27s 30s
Saxon After: 28s 28s 27s
Xerces Before: 2:24m 2:28m 2:27m
Xerces After: 35s 38s 39s

I also did limited testing of running the entire build locally (i.e. `mvn install`).
Before: 9:16m
After: 7:24m 7:15m

I don't know if this is just treating the symptom or if this is a known shortcoming of Xerces, but I thought I would offer it as a solution.