### PR TITLE
Rewrite of WADLCheckerBuilder and WADLDotBuilder

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,14 @@
 ## In Progress Work ##
 1. Updated Dependencies
    1. saxon: 9.7.0-8 → 9.7.0-15
-   1. wadl-tools: 1.0.33 → 1.0.34
+   1. wadl-tools: 1.0.33 → 1.0.35
+      1. Fixed a bug where under rare circumstances a WADL was generated with two attributes with the same name.
+1. Clean up : Complete rewrite of WADLCheckerBuilder and WADLDotBuilder
+   1. We now use Saxon API instead of JAX-P XSLT API, this allows finer grained control over options and cleaner code.
+   1. Interact with wadl-tools via XSLT integration rather than Scala integration, again better options and control over execution.
+   1. Lazy XSLT / XSD compilation : We now compile a style sheet or an XSD only when it needs to be used - no startup cost for unused features.
+   1. Instrumented pipeline : Compiling the project with ```-Dchecker.timeFunctions``` will cause timing information on each step of the pipeline to print to ```stderr``` at run time.
+   1. WADLDotBuilder has always only worked with ```StreamResult```s (other ```Result``` types failed) this is now made explicit with the interface.
 
 
 ## Release 2.1.1 (2017-01-27) ##

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -33,7 +33,13 @@
         <dependency>
             <groupId>com.rackspace.papi.components.api-checker</groupId>
             <artifactId>checker-core</artifactId>
-            <version>2.1.2-SNAPSHOT</version>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.rackspace.papi.components.api-checker.macros</groupId>
+            <artifactId>checker-macros</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope> <!-- don't want macros in the jar -->
         </dependency>
         <dependency>
             <groupId>org.clapper</groupId>

--- a/cli/wadl2checker/src/test/scala/com/rackspace/com/papi/components/checker/cli/Wadl2CheckerSuite.scala
+++ b/cli/wadl2checker/src/test/scala/com/rackspace/com/papi/components/checker/cli/Wadl2CheckerSuite.scala
@@ -108,9 +108,6 @@ class Wadl2CheckerSuite extends FunSuite with XPathAssertions {
     withOutput ( (out, error) => {
       Wadl2Checker.main(Array("src/test/resources/wadl/sharedXPath.wadl"))
 
-      //  No err
-      assert(error.toString().isEmpty())
-
       val outXML = XML.loadString(out.toString())
 
       //  Just some basic asserts to make sure we're working, we'd
@@ -125,9 +122,6 @@ class Wadl2CheckerSuite extends FunSuite with XPathAssertions {
   test ("Should generate checker xml to stdout (xsd engine)") {
     withOutput ( (out, error) => {
       Wadl2Checker.main(Array("--xsd-engine","Xerces","src/test/resources/wadl/sharedXPath.wadl"))
-
-      //  No err
-      assert(error.toString().isEmpty())
 
       val outXML = XML.loadString(out.toString())
 
@@ -147,8 +141,6 @@ class Wadl2CheckerSuite extends FunSuite with XPathAssertions {
 
       Wadl2Checker.main(Array("src/test/resources/wadl/sharedXPath.wadl", outFile))
 
-      //  No err, noout
-      assert(error.toString().isEmpty())
       assert(out.toString().isEmpty())
 
       val outXML = XML.loadFile(outFile)
@@ -194,8 +186,6 @@ class Wadl2CheckerSuite extends FunSuite with XPathAssertions {
           } else {
             Wadl2Checker.main(Array(arg,"src/test/resources/wadl/sharedXPath.wadl"))
           }
-          //  No err
-          assert(error.toString().isEmpty())
 
           val outXML = XML.loadString(out.toString())
 

--- a/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
+++ b/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
@@ -37,7 +37,7 @@ object Wadl2Dot {
   val version = getClass.getPackage.getImplementationVersion
 
   def parseArgs(args: Array[String], base : String,
-                in : InputStream, out : PrintStream, err : PrintStream) : Option[(Source, Result, Config, Boolean, Boolean)] = {
+                in : InputStream, out : PrintStream, err : PrintStream) : Option[(Source, StreamResult, Config, Boolean, Boolean)] = {
 
     val parser = new ArgotParser("wadl2dot", preUsage=Some(s"$title v$version"))
 
@@ -54,8 +54,8 @@ object Wadl2Dot {
 
     def source: Source = new StreamSource(URLResolver.toAbsoluteSystemId(input.value.get, base))
 
-    def result: Result = {
-      var r: Result = null
+    def result: StreamResult = {
+      var r: StreamResult = null
       if (output.value.isEmpty) {
         r = new StreamResult(out)
       } else {
@@ -211,7 +211,7 @@ object Wadl2Dot {
   def main(args : Array[String]) = {
     parseArgs (args, getBaseFromWorkingDir(System.getProperty("user.dir")),
                System.in, System.out, System.err) match {
-      case Some((source : Source, result : Result, config : Config,
+      case Some((source : Source, result : StreamResult, config : Config,
                  ignoreSinks : Boolean, nfaMode : Boolean)) =>
                    new WADLDotBuilder().build(source, result,
                                               config, ignoreSinks, nfaMode)
@@ -225,7 +225,7 @@ object Wadl2Dot {
   def nailMain(context : NGContext) = {
     parseArgs (context.getArgs, getBaseFromWorkingDir(context.getWorkingDirectory),
                context.in, context.out, context.err) match {
-      case Some((source : Source, result : Result, config : Config,
+      case Some((source : Source, result : StreamResult, config : Config,
                  ignoreSinks : Boolean, nfaMode : Boolean)) =>
                    new WADLDotBuilder().build(source, result,
                                               config, ignoreSinks, nfaMode)

--- a/cli/wadl2dot/src/test/scala/com/rackspace/com/papi/components/checker/cli/Wadl2DotSuite.scala
+++ b/cli/wadl2dot/src/test/scala/com/rackspace/com/papi/components/checker/cli/Wadl2DotSuite.scala
@@ -100,9 +100,6 @@ class Wadl2DotSuite extends FunSuite {
     withOutput( (outStream, errStream) => {
       Wadl2Dot.main(Array("src/test/resources/wadl/sharedXPath.wadl"))
 
-      //  No err
-      assert(errStream.toString().isEmpty())
-
       val out = outStream.toString()
 
       //  Just some basic asserts to make sure we're working, we'd
@@ -116,9 +113,6 @@ class Wadl2DotSuite extends FunSuite {
   test ("Should generate dot to stdout (xsdEngine)") {
     withOutput( (outStream, errStream) => {
       Wadl2Dot.main(Array("--xsd-engine","Xerces","src/test/resources/wadl/sharedXPath.wadl"))
-
-      //  No err
-      assert(errStream.toString().isEmpty())
 
       val out = outStream.toString()
 
@@ -136,8 +130,6 @@ class Wadl2DotSuite extends FunSuite {
 
       Wadl2Dot.main(Array("src/test/resources/wadl/sharedXPath.wadl", outDot))
 
-      //  No err
-      assert(errStream.toString().isEmpty())
       assert(outStream.toString().isEmpty())
 
       val source = scala.io.Source.fromFile(outDot)
@@ -159,8 +151,6 @@ class Wadl2DotSuite extends FunSuite {
   test ("Should generate dot to stdout : test -n arg (nfa mode)") {
     withOutput( (outStream, errStream) => {
       Wadl2Dot.main(Array("-n","src/test/resources/wadl/sharedXPath.wadl"))
-      //  No err
-      assert(errStream.toString().isEmpty())
 
       val out = outStream.toString()
 
@@ -175,9 +165,6 @@ class Wadl2DotSuite extends FunSuite {
   test ("Should generate dot to stdout : test -e arg (show error states)") {
     withOutput( (outStream, errStream) => {
       Wadl2Dot.main(Array("-e","src/test/resources/wadl/sharedXPath.wadl"))
-
-      //  No err
-      assert(errStream.toString().isEmpty())
 
       val out = outStream.toString()
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,13 @@
         <dependency>
             <groupId>com.rackspace.papi.components.api-checker</groupId>
             <artifactId>checker-util</artifactId>
-            <version>2.1.2-SNAPSHOT</version>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.rackspace.papi.components.api-checker.macros</groupId>
+            <artifactId>checker-macros</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope> <!-- don't want macros in the jar -->
         </dependency>
     </dependencies>
 

--- a/core/src/main/resources/xsl/builder.xsl
+++ b/core/src/main/resources/xsl/builder.xsl
@@ -52,6 +52,7 @@
     <!-- Paramenters -->
     <xsl:param name="user" as="xsd:string" select="'unknown'" />
     <xsl:param name="creator" as="xsd:string" select="'unknown'"/>
+    <xsl:param name="schematronOutput" as="node()"/>
     <xsl:param name="configMetadata" as="node()">
         <params>
           <meta>
@@ -290,7 +291,7 @@
 
     <xsl:template name="check:addMetadata">
         <xsl:variable name="created-from" as="node()*">
-            <xsl:apply-templates mode="addCreatedFrom"/>
+            <xsl:apply-templates mode="addCreatedFrom" select="$schematronOutput"/>
         </xsl:variable>
         <meta>
             <xsl:if test="$user"><built-by><xsl:value-of select="$user"/></built-by></xsl:if>

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/wadl/BuilderHelper.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/wadl/BuilderHelper.scala
@@ -1,0 +1,123 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import scala.annotation.tailrec
+
+import javax.xml.transform.Source
+import javax.xml.transform.sax.SAXSource
+import javax.xml.transform.URIResolver
+
+import org.xml.sax.XMLReader
+import org.xml.sax.EntityResolver
+import org.xml.sax.SAXException
+
+import org.xml.sax.helpers.XMLReaderFactory
+
+import com.rackspace.cloud.api.wadl.util.LogErrorListener
+
+import com.rackspace.com.papi.components.checker.Config
+
+import com.typesafe.scalalogging.slf4j.LazyLogging
+
+import net.sf.saxon.s9api.Processor
+import net.sf.saxon.s9api.XsltExecutable
+import net.sf.saxon.s9api.XsltTransformer
+import net.sf.saxon.s9api.QName
+import net.sf.saxon.s9api.XdmValue
+
+import net.sf.saxon.serialize.MessageWarner
+
+/**
+ * Common functionality shared by builders
+ */
+
+protected object BuilderHelper extends LazyLogging {
+
+  val processor = new Processor(true)
+  val compiler = processor.newXsltCompiler
+
+  compiler.setErrorListener(new LogErrorListener)
+
+
+  private val transformerFactory = new net.sf.saxon.TransformerFactoryImpl
+  def idTransform = {
+    val idt = transformerFactory.newTransformer()
+    idt.setErrorListener (new LogErrorListener)
+    idt
+  }
+
+  //
+  //  Given XSLTExect and an optional set of XSLT parameters, creates an XsltTransformer
+  //
+  def getXsltTransformer (xsltExec : XsltExecutable, resolver : URIResolver, params : Map[QName, XdmValue]=Map[QName, XdmValue]()) : XsltTransformer = {
+    val t = xsltExec.load
+    t.setErrorListener (new LogErrorListener)
+    t.getUnderlyingController.setMessageEmitter(new MessageWarner)
+    t.setURIResolver(resolver)
+    for ((param, value) <- params) {
+      t.setParameter(param, value)
+    }
+    t
+  }
+
+  //
+  //  Create a reader with xinclude if possible
+  //
+  def XMLReader(resolver : Option[EntityResolver] = None) : XMLReader = {
+    val reader = XMLReaderFactory.createXMLReader()
+    if (resolver != None) {
+      reader.setEntityResolver(resolver.get)
+    }
+    try {
+      reader.setFeature ("http://apache.org/xml/features/xinclude", true)
+    } catch {
+      case se: SAXException => logger.warn ("The XML parser does not seem to support XInclude! XIncludes will not be resolved!")
+    }
+    reader
+  }
+
+  //
+  // Given a source, returns a source with the appropriate
+  // EntityResolver.
+  //
+  def Source(in : Source, resolver : Option[EntityResolver] = None) : Source = {
+    val inputSource = SAXSource.sourceToInputSource(in)
+    if (inputSource == null) {
+      logger.warn (
+        "I couldn't convert the source to a SAX stream, that means that if you used externaly defined "+
+        "DTDs or entities I can't reliably report them as dependecies. Continuing to normalize WADL...")
+      in
+    } else {
+      val ss = new SAXSource(inputSource)
+      ss.setXMLReader(XMLReader(resolver))
+      ss
+    }
+  }
+
+  //
+  //  Checker transform functions take a source and validator config
+  //  and produce a source for the next part in the chain -- which is
+  //  the result of trannsform.
+  //
+  type CheckerTransform = (Source, Config) => Source
+
+  @tailrec
+  def applyBuildSteps(steps : List[CheckerTransform], current : Source, config : Config) : Source = steps match {
+    case transform :: transforms => applyBuildSteps(transforms, transform(current, config), config)
+    case _ => current
+  }
+}

--- a/macros/pom.xml
+++ b/macros/pom.xml
@@ -1,0 +1,88 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.rackspace.papi.components</groupId>
+        <artifactId>api-checker</artifactId>
+        <version>2.1.2-SNAPSHOT</version>
+    </parent>
+
+    <groupId>com.rackspace.papi.components.api-checker.macros</groupId>
+    <artifactId>checker-macros</artifactId>
+    <packaging>jar</packaging>
+
+    <name>API Checker Macros</name>
+    <description>API Checker Macros</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <version>${scala.major}.${scala.minor}.${scala.patch}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <args>
+                        <arg>-unchecked</arg>
+                        <arg>-deprecation</arg>
+                        <arg>-explaintypes</arg>
+                        <arg>-feature</arg>
+                    </args>
+                    <recompileMode>incremental</recompileMode>
+                    <jvmArgs>
+                        <jvmArg>-Xms64m</jvmArg>
+                        <jvmArg>-Xmx1024m</jvmArg>
+                    </jvmArgs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.10</version>
+                <configuration>
+                    <includes>
+                        <include>**/*.class</include>
+                    </includes>
+                    <enableAssertions>false</enableAssertions>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/macros/src/main/scala/com/rackspace/com/papi/components/checker/macros/TimeFunction.scala
+++ b/macros/src/main/scala/com/rackspace/com/papi/components/checker/macros/TimeFunction.scala
@@ -1,0 +1,53 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.macros
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+object TimeFunction {
+  val TIME_PROP = "checker.timeFunctions"
+  val TIME_WARN = 650
+  def timeFunction[T](desc : String, f : => T) : T = macro timeFunctionImpl[T]
+
+  def timeFunctionImpl[T] (c : blackbox.Context)(desc : c.Tree, f : c.Tree) : c.Expr[T] = {
+    import c.universe._
+
+    if (!doTimeFunction) {
+      c.Expr(f)
+    } else {
+      val start = c.freshName("start")
+      val end   = c.freshName("end")
+      val tt    = c.freshName("tt")
+      val ret   = c.freshName("ret")
+
+      c.Expr(q"""
+             Console.err.print("["+$desc+" : ")
+                                 val $$start = System.currentTimeMillis
+                                 val $$ret = $f
+                                 val $$end = System.currentTimeMillis
+                                 val $$tt  = $$end - $$start
+                                 if ($$tt > $TIME_WARN) Console.err.print(Console.RED)
+                                 Console.err.print($$tt)
+                                 if ($$tt > $TIME_WARN) Console.err.print(Console.RESET)
+                                 Console.err.println(" Millis]")
+             $$ret
+             """)
+    }
+  }
+
+  def doTimeFunction : Boolean = Option(System.getProperty(TIME_PROP)).isDefined
+}

--- a/macros/src/test/scala/com/rackspace/com/papi/components/checker/macros/TimeFunctionSuite.scala
+++ b/macros/src/test/scala/com/rackspace/com/papi/components/checker/macros/TimeFunctionSuite.scala
@@ -1,0 +1,116 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.macros
+
+import scala.tools.reflect.ToolBox
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.junit.JUnitRunner
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+import scala.reflect.runtime.universe._
+
+import scala.reflect.runtime.currentMirror
+import scala.tools.reflect.ToolBox
+
+import TimeFunction._
+
+@RunWith(classOf[JUnitRunner])
+class TimeFunctionSuite extends FunSuite with BeforeAndAfterAll {
+
+  val toolbox = currentMirror.mkToolBox()
+  var currentProp : Option[String] = None
+
+  override def beforeAll = currentProp = Option(System.getProperty(TIME_PROP))
+  override def afterAll = {
+    if (currentProp.isEmpty) {
+      System.clearProperty(TIME_PROP)
+    } else {
+      System.setProperty(TIME_PROP, currentProp.get)
+    }
+  }
+
+  test ("If the system property is set then the output should contain some millis"){
+    val outStream = new ByteArrayOutputStream()
+    val printOutStream = new PrintStream(outStream)
+
+    Console.withErr(printOutStream) {
+      System.setProperty(TIME_PROP, "")
+      toolbox.eval(toolbox.parse("""com.rackspace.com.papi.components.checker.macros.TimeFunction.timeFunction("print", {Console.err.println("hello!")})"""))
+    }
+    val outString = outStream.toString
+    assert(outString.contains("hello!\n"))
+    assert(outString.contains("print :"))
+    assert(outString.contains("Millis"))
+  }
+
+  test ("If the system property is not set then the output should match exactly"){
+    val outStream = new ByteArrayOutputStream()
+    val printOutStream = new PrintStream(outStream)
+
+    Console.withErr(printOutStream) {
+      System.clearProperty(TIME_PROP)
+      toolbox.eval(toolbox.parse("""com.rackspace.com.papi.components.checker.macros.TimeFunction.timeFunction("foo", {Console.err.println("foo!")})"""))
+    }
+    assert(outStream.toString == "foo!\n")
+  }
+
+  test ("If the system property is set then the output should contain some millis (should evaluate)"){
+    val outStream = new ByteArrayOutputStream()
+    val printOutStream = new PrintStream(outStream)
+    var res : Int = 0
+    Console.withErr(printOutStream) {
+      System.setProperty(TIME_PROP, "")
+      res = toolbox.eval(toolbox.parse("""com.rackspace.com.papi.components.checker.macros.TimeFunction.timeFunction("add", {7+2})""")).asInstanceOf[Int]
+    }
+    val outString = outStream.toString
+    assert(res == 9)
+    assert(outString.contains("add :"))
+    assert(outString.contains("Millis"))
+  }
+
+  test ("If the system property is not set then there should be no output but should evaluate"){
+    val outStream = new ByteArrayOutputStream()
+    val printOutStream = new PrintStream(outStream)
+    var res : Int = 0
+
+    Console.withErr(printOutStream) {
+      System.clearProperty(TIME_PROP)
+      res = toolbox.eval(toolbox.parse("""com.rackspace.com.papi.components.checker.macros.TimeFunction.timeFunction("add", {10+5})""")).asInstanceOf[Int]
+    }
+    assert(res == 15)
+    assert(outStream.toString.isEmpty)
+  }
+
+  test ("If the system property is set then the output should contain some millis that matches time elapsed"){
+    val outStream = new ByteArrayOutputStream()
+    val printOutStream = new PrintStream(outStream)
+    Console.withErr(printOutStream) {
+      System.setProperty(TIME_PROP, "")
+      toolbox.eval(toolbox.parse("""com.rackspace.com.papi.components.checker.macros.TimeFunction.timeFunction("sleep", {Thread.sleep(500)})"""))
+    }
+    val parts = outStream.toString.split(" ")
+    assert(parts(0) == "[sleep")
+    assert(parts(1) == ":")
+    assert(parts(2).toInt >= 500) // Make sure we capture time elapse
+    assert(parts(3) == "Millis]\n")
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 
     <modules>
         <module>util</module>
+        <module>macros</module>
         <module>core</module>
         <module>cli</module>
     </modules>
@@ -53,7 +54,7 @@
         <scala.test.version>2.2.6</scala.test.version>
         <scala.uri.version>0.4.2</scala.uri.version>
         <junit.version>4.10</junit.version>
-        <wadl-tools.version>1.0.34</wadl-tools.version>
+        <wadl-tools.version>1.0.35</wadl-tools.version>
         <xmlsec.version>1.4.6</xmlsec.version>
         <xerces.version>2.12.1-rax</xerces.version>
         <servlet.version>3.1</servlet.version>


### PR DESCRIPTION
 1. We now use Saxon API instead of JAX-P XSLT API, this allows finer grained control over options and cleaner code.
 1. Interact with wadl-tools via XSLT integration rather than Scala integration, again better options and control over execution.
 1. Lazy XSLT / XSD compilation : We now compile a style sheet or an XSD only when it needs to be used - no startup cost for unused features.
 1. Instrumented pipeline : Compiling the project with ```-Dchecker.timeFunctions``` will cause timing information on each step of the pipeline to print to ```stderr``` at run time.
 1. WADLDotBuilder has always only worked with ```StreamResult```s (other ```Result``` types failed) this is now made explicit with the interface.