### PR TITLE
Fixed Bug where disconnected checker paths were not causing a fail.

### DIFF
--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerJsonSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerJsonSpec.scala
@@ -1029,7 +1029,7 @@ class WADLCheckerJsonSpec extends BaseCheckerSpec {
       assert (checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JSONSchema, Accept)
       assert (checker, Start, URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, Accept)
       assert (checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
-      assert (checker, Start, URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert (checker, Start, URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), ContentFail)
     }
 
     scenario("The WADL contains PUT and POST operations accepting JSON which must validate against an JSON Schema (with dups on)") {

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerOptSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerOptSpec.scala
@@ -64,9 +64,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"), Method("POST"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"), Method("POST"),
@@ -79,9 +79,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"), Method("POST"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"), Method("POST"),
@@ -116,9 +116,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -131,9 +131,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),
@@ -168,9 +168,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), XSL,
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -183,9 +183,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), XSL,
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),
@@ -223,9 +223,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), XSL,
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -238,9 +238,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), XSL,
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),
@@ -278,9 +278,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -293,9 +293,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),
@@ -331,9 +331,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -346,9 +346,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),
@@ -387,9 +387,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -406,9 +406,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),
@@ -453,9 +453,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -472,9 +472,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),
@@ -520,9 +520,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -535,9 +535,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),
@@ -575,9 +575,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -590,9 +590,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerOptSpecSaxonEE.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerOptSpecSaxonEE.scala
@@ -64,9 +64,9 @@ class WADLCheckerOptSpecSaxonEE extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), XSL,
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -79,9 +79,9 @@ class WADLCheckerOptSpecSaxonEE extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), XSL,
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),
@@ -118,9 +118,9 @@ class WADLCheckerOptSpecSaxonEE extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), XSL,
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -133,9 +133,9 @@ class WADLCheckerOptSpecSaxonEE extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), XSL,
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),
@@ -175,9 +175,9 @@ class WADLCheckerOptSpecSaxonEE extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -194,9 +194,9 @@ class WADLCheckerOptSpecSaxonEE extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),
@@ -241,9 +241,9 @@ class WADLCheckerOptSpecSaxonEE extends BaseCheckerSpec {
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
-             XPath("/atom:entry/w_ns16:usage"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
-             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
+             XPath("/atom:entry/w_ns17:usage"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
+             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("servers"), URL("entries"),
@@ -260,9 +260,9 @@ class WADLCheckerOptSpecSaxonEE extends BaseCheckerSpec {
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
              ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
-             XPath("/atom:entry/w_ns17:usage"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
-             XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
+             XPath("/atom:entry/w_ns16:usage"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
+             XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
              XPath("/atom:entry/@only_usage_up_down"), Accept)
 
       assert(checker,Start, URL("nova"), URL("entries"),

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerSpec.scala
@@ -5851,7 +5851,6 @@ class WADLCheckerSpec extends BaseCheckerSpec with LogAssertions {
     assert(checker, "namespace-uri-for-prefix('tst', chk:checker/chk:step[@type='XSL']/xsl:transform/xsl:template/xsl:choose/xsl:when[@test = '/tst:a/@stepType']) = 'http://www.rackspace.com/repose/wadl/checker/step/test'")
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), XSL, XSL, XSD, SetHeaderAlways("Warning"), SetHeaderAlways("Warning"), Accept)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), ContentFail)
-    assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), XSL, ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), XSL, XSL, ContentFail)
   }
 
@@ -5967,7 +5966,6 @@ class WADLCheckerSpec extends BaseCheckerSpec with LogAssertions {
            XSL, XSD, SetHeaderAlways("Warning"), SetHeaderAlways("Warning"), Accept)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), WellXML, ContentFail)
-    assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/tst:a","Expecting the root element to be: tst:a"), ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:a","Expecting the root element to be: tst:a"), ContentFail)
@@ -6034,7 +6032,6 @@ class WADLCheckerSpec extends BaseCheckerSpec with LogAssertions {
            XSL, XSD, SetHeaderAlways("Warning"), SetHeaderAlways("Warning"), Accept)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), WellXML, ContentFail)
-    assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/tst:a","Expecting the root element to be: tst:a"), ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:a","Expecting the root element to be: tst:a"), ContentFail)
@@ -6088,9 +6085,7 @@ class WADLCheckerSpec extends BaseCheckerSpec with LogAssertions {
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), XSL,
            XSL, XSD, SetHeaderAlways("Warning"), SetHeaderAlways("Warning"), Accept)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), ContentFail)
-    assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), XSL, ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), ContentFail)
-    assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), XSL, ContentFail)
   }
 
   scenario("The WADL contains a POST  operation accepting valid xml with elements specified and multiple required plain params, and a multiple XSL transforms in different reps (dups on, join on, xpath2)") {
@@ -6135,9 +6130,7 @@ class WADLCheckerSpec extends BaseCheckerSpec with LogAssertions {
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), XSL,
            XSL, XSD, SetHeaderAlways("Warning"), SetHeaderAlways("Warning"), Accept)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), ContentFail)
-    assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), XSL, ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), ContentFail)
-    assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), XSL, ContentFail)
   }
 
   scenario("The WADL contains a POST  operation accepting valid xml with elements specified and multiple required plain params, and a multiple XSL transforms in different reps (dups on 2)") {
@@ -6193,7 +6186,6 @@ class WADLCheckerSpec extends BaseCheckerSpec with LogAssertions {
            XSL, XSD, SetHeaderAlways("Warning"), SetHeaderAlways("Warning"), Accept)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), WellXML, ContentFail)
-    assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/tst:a","Expecting the root element to be: tst:a"), ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
     assert (checker, Start, URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:a","Expecting the root element to be: tst:a"), ContentFail)


### PR DESCRIPTION
The assert function which asserts that there is a path from one step
to another in a checker file was not asserting in the case where two
separate paths were missing a connection.  I must have been drunk or
tired that day in 2012 when I wrote the assertion code :-)

Luckily this did not leak any actual errors in the code, however some
assert statements in existing tests were incorrect and these have been
fixed.