### PR TITLE
rax:assert extension

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,8 +2,9 @@
 ## In Progress Work ##
 1. Updated Dependencies
    1. saxon: 9.7.0-8 → 9.7.0-15
-   1. wadl-tools: 1.0.33 → 1.0.35
+   1. wadl-tools: 1.0.33 → 1.0.36
       1. Fixed a bug where under rare circumstances a WADL was generated with two attributes with the same name.
+      1. Fixed a bug where extensions under the resources element were being lost
    1. io.dropwizard.metrics:metrics-core: 3.1.2 → 3.2.0
 1. Clean up : Complete rewrite of WADLCheckerBuilder and WADLDotBuilder
    1. We now use Saxon API instead of JAX-P XSLT API, this allows finer grained control over options and cleaner code.
@@ -11,7 +12,8 @@
    1. Lazy XSLT / XSD compilation : We now compile a style sheet or an XSD only when it needs to be used - no startup cost for unused features.
    1. Instrumented pipeline : Compiling the project with ```-Dchecker.timeFunctions``` will cause timing information on each step of the pipeline to print to ```stderr``` at run time.
    1. WADLDotBuilder has always only worked with ```StreamResult```s (other ```Result``` types failed) this is now made explicit with the interface.
-
+1. Added support for ```rax:assert```, this allows setting XPath 3.1 assertions at the method request, representation, resource, and resources level.
+   These assertions can simultaneously introspect headers, uri, methods, and body content (xml or json).
 
 ## Release 2.1.1 (2017-01-27) ##
 1. Fixed a bug where a resource file needed by checker-util was kept in checker-core

--- a/TODO.org
+++ b/TODO.org
@@ -848,6 +848,56 @@
        3. [X] Correct handling --version --help
        4. [X] Spot testing on setting options
    14. [X] Document.
+** DONE Add support for assertions at resource and method level [2/2]
+   1. [X] Assertion Step [13/13]
+      1. [X] Extend XSD to support Assert Step
+      2. [X] Implement raxAssert.xsl to correctly place assertions
+      3. [X] Add config item to enable/disable rax:assert
+      4. [X] add raxAssert to checker bulider
+      5. [X] Update CLI tools to support the new step
+      6. [X] Update builder to include Assert Step [3/3]
+         1. [X] Handle in method/request
+         2. [X] In representation other than XML or JSON
+            (wadl:request/wadl:representation[@mediaType] template)
+         3. [X] In representation with XML or JSON (in
+            check:addWellForm template)
+      7. [X] Handle situation where wadl:representation has no media
+         type...by extending raxAssert.xsl to move asserts up to
+         wadl:request.
+      8. [X] Add step to priority-map
+      9. [X] Check assertions related to Assert Step
+      10. [X] Ensure optimizations work with the new step
+      11. [X] Create new step
+      12. [X] Update handler for new step
+      13. [X] Enhancements [10/10]
+          1. [X] Avoid wrapping XdmValue, DOMSource in checkStep
+          2. [X] Ensure we appropriatly cache request
+          3. [X] Submit step context and take into account
+          4. [X] Ability to specify header split in header functions
+          5. [X] Change namespace to center around request (req
+             instead of chk)
+          6. [X] Rewrite var access make prefix optional for $_ and
+             $body for compatibility with plain asserts.
+          7. [X] Cleanup assert.xq (don't do extra work)
+          8. [X] Properlly log Assert
+          9. [X] Cleanup imports!
+          10. [X] Clean up docs
+   2. [X] Testing [3/3]
+      1. [X] Step
+      2. [X] Builder
+      3. [X] Validator [10/10]
+         1. [X] At resource level
+         2. [X] At method level
+         3. [X] First assertion fail, 2nd, 3rd
+         4. [X] No representation
+         5. [X] XML / JSON Representation
+         6. [X] Media types other than XML or JSON
+         7. [X] rax:code
+         8. [X] rax:message
+         9. [X] JoinOpt
+         10. [X] RemoveDups
+** TODO Use Saxon Compile Lib feature to compile shared module.
+   - This requires Saxon-EEQ
 ** TODO Compile Performance improvements
 ** TODO Assign CONTENT_FAIL to XSL steps in builder
 ** TODO Investigate whether there is an issue with rax:roles with other headers

--- a/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
+++ b/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
@@ -123,6 +123,9 @@ object Wadl2Checker {
     val anyMatch  = parser.flag[Boolean] (List("a", "disable-any-match"),
                                           "Disable any match extension : false")
 
+    val raxAssert = parser.flag[Boolean] (List("k", "disable-rax-assert"),
+                                          "Disable Rax-Assert extension : false")
+
     val warnHeaders = parser.flag[Boolean] (List("W", "disable-warn-headers"),
                                             "Disable warn headers : false")
 
@@ -175,6 +178,7 @@ object Wadl2Checker {
         c.enableMessageExtension = !message.value.getOrElse(false)
         c.enableCaptureHeaderExtension = !captureHeader.value.getOrElse(false)
         c.enableAnyMatchExtension = !anyMatch.value.getOrElse(false)
+        c.enableAssertExtension = !raxAssert.value.getOrElse(false)
         c.xpathVersion = xpathVersion.value.getOrElse(10)
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)

--- a/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
+++ b/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
@@ -124,6 +124,9 @@ object Wadl2Dot {
     val anyMatch  = parser.flag[Boolean] (List("a", "disable-any-match"),
                                           "Disable any match extension : false")
 
+    val raxAssert = parser.flag[Boolean] (List("k", "disable-rax-assert"),
+                                          "Disable Rax-Assert extension : false")
+
     val warnHeaders = parser.flag[Boolean] (List("W", "disable-warn-headers"),
                                             "Disable warn headers : false")
 
@@ -182,6 +185,7 @@ object Wadl2Dot {
         c.enableMessageExtension = !message.value.getOrElse(false)
         c.enableCaptureHeaderExtension = !captureHeader.value.getOrElse(false)
         c.enableAnyMatchExtension = !anyMatch.value.getOrElse(false)
+        c.enableAssertExtension = !raxAssert.value.getOrElse(false)
         c.xpathVersion = xpathVersion.value.getOrElse(10)
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)

--- a/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
+++ b/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
@@ -98,6 +98,9 @@ object WadlTest {
   val anyMatch  = parser.flag[Boolean] (List("a", "disable-any-match"),
                                             "Disable any match extension : false")
 
+  val raxAssert = parser.flag[Boolean] (List("k", "disable-rax-assert"),
+                                          "Disable Rax-Assert extension : false")
+
   val warnHeaders = parser.flag[Boolean] (List("W", "disable-warn-headers"),
                                           "Disable warn headers : false")
 
@@ -282,6 +285,7 @@ object WadlTest {
         c.enableMessageExtension = !message.value.getOrElse(false)
         c.enableCaptureHeaderExtension = !captureHeader.value.getOrElse(false)
         c.enableAnyMatchExtension = !anyMatch.value.getOrElse(false)
+        c.enableAssertExtension = !raxAssert.value.getOrElse(false)
         c.xpathVersion = xpathVersion.value.getOrElse(10)
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)

--- a/core/src/main/resources/xq/assert.xq
+++ b/core/src/main/resources/xq/assert.xq
@@ -1,0 +1,54 @@
+(:
+ :   Copyright 2017 Rackspace US, Inc.
+ :
+ :   Licensed under the Apache License, Version 2.0 (the "License");
+ :   you may not use this file except in compliance with the License.
+ :   You may obtain a copy of the License at
+ :
+ :       http://www.apache.org/licenses/LICENSE-2.0
+ :
+ :   Unless required by applicable law or agreed to in writing, software
+ :   distributed under the License is distributed on an "AS IS" BASIS,
+ :   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ :   See the License for the specific language governing permissions and
+ :   limitations under the License.
+ :)
+xquery version "3.1" encoding "UTF-8";
+
+module namespace req = "http://www.rackspace.com/repose/wadl/checker/request";
+
+declare namespace map = "http://www.w3.org/2005/xpath-functions/map";
+declare namespace xs = "http://www.w3.org/2001/XMLSchema";
+
+declare %private variable $req:__JSON__    as map(*)? external;
+declare %private variable $req:__REQUEST__ as map(*) external;
+declare %private variable $req:__CONTEXT__ as map(*) external;
+
+declare variable $req:_           := if (not(empty($req:__JSON__))) then $req:__JSON__ else /;
+declare variable $req:body        := $req:_;
+declare variable $req:method      := $req:__REQUEST__?method;
+declare variable $req:uri         := $req:__REQUEST__?uri;
+declare variable $req:headerNames := distinct-values((map:keys($req:__REQUEST__?headers), map:keys($req:__CONTEXT__?headers)));
+declare variable $req:uriLevel    := $req:__CONTEXT__?uriLevel;
+
+
+declare function req:headers ($name as xs:string, $split as xs:boolean) as xs:string* {
+  if ($split) then
+    for $h in req:headers($name) return
+    for $s in tokenize($h,',') return normalize-space($s)
+  else
+    req:headers($name)
+};
+
+declare function req:headers ($name as xs:string) as xs:string* {
+  let $hn := lower-case($name)
+  return ($req:__CONTEXT__?headers($hn), $req:__REQUEST__?headers($hn))
+};
+
+declare function req:header ($name as xs:string, $split as xs:boolean) as xs:string? {
+  req:headers($name, $split)[1]
+};
+
+declare function req:header ($name as xs:string) as xs:string? {
+  req:headers($name)[1]
+};

--- a/core/src/main/resources/xsd/checker.xsd
+++ b/core/src/main/resources/xsd/checker.xsd
@@ -115,6 +115,7 @@
                 <alternative test="@type eq 'HEADER_ALL'" type="chk:HeaderAllStep"/>
                 <alternative test="@type eq 'JSON_SCHEMA'" type="chk:JsonSchemaStep"/>
                 <alternative test="@type eq 'JSON_XPATH'" type="chk:JsonXPathStep"/>
+                <alternative test="@type eq 'ASSERT'" type="chk:AssertStep"/>
             </element>
         </sequence>
         <assert test="if (count(chk:step[@type='START']) = 1) then true() else false()"
@@ -326,6 +327,77 @@
         </complexContent>
     </complexType>
 
+    <complexType name="AssertStep">
+        <annotation>
+            <documentation xmlns:html="http://www.w3.org/1999/xhtml">
+                <html:p>
+                    This is almost exactly like an XPathStep and
+                    JsonXPathStep, except that:
+                    <html:ol>
+                        <html:li>
+                            The request uri, method, and other
+                            attributes are passed as XPath parameters
+                            ($req:uri, $req:method, $req:headerNames).
+                        </html:li>
+                        <html:li>
+                            There are two xpath functions to retrive
+                            headers: req:header and req:headers.  The
+                            first call returns only the first header
+                            value, the 2nd retrives all header values.
+                            The name of available headers is stored in
+                            the sequence $req:headerNames. There is an
+                            optional boolean value to the header
+                            functions that denotes that header values
+                            should be seperated by commas, if
+                            unspecified it is assumed that the values
+                            are not comma seperated.
+                        </html:li>
+                        <html:li>
+                            The body is stored in the $req:body variable
+                            or in $req:_ (which can also be denoted as
+                            simply $body and $_).  Note that these
+                            variables may point to a map, array,
+                            xs:boolean, xs:string, xs:double, the
+                            empty sequence to denote null or a
+                            document node if the body is XML.
+                            Additionally, if the body is XML then the
+                            XPath context will also be pointing at the
+                            XML document otherwise the context will be
+                            an empty document.  Only XML and JSON is
+                            currently supported the variables will
+                            return an empty sequence if the format is
+                            not XML or JSON.
+                        </html:li>
+                        <html:li>
+                            This step does not support
+                            rax:captureHeader extension, since the
+                            intent here is only to assert a t/f XPath
+                            assertion.
+                        </html:li>
+                    </html:ol>
+                </html:p>
+                <html:p>
+                    Currentlty the XPath version is fixed to be 3.1
+                    since it's the only version that supports json.
+                </html:p>
+                <html:p>
+                    In future versions we may depricate using XPath
+                    and JsonXPath steps for performing assertions, as
+                    this step is more appropriate.  Instead, we may
+                    focus those steps to check types assocated with
+                    the body and to capture parts of the body as
+                    headers.
+                </html:p>
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="chk:GenContentFailStep">
+                <attribute name="match" type="xsd:string" use="required"/>
+                <attribute name="version" type="chk:XPathVersion" fixed="31" use="optional"/>
+                <attributeGroup ref="chk:MessageAttributes"/>
+            </extension>
+        </complexContent>
+    </complexType>
 
     <complexType name="JsonSchemaStep">
         <annotation>
@@ -847,6 +919,7 @@
             <enumeration value="HEADER_ALL"/>
             <enumeration value="JSON_SCHEMA"/>
             <enumeration value="JSON_XPATH" />
+            <enumeration value="ASSERT"/>
         </restriction>
     </simpleType>
 

--- a/core/src/main/resources/xsl/adjust-next-cont-error.xsl
+++ b/core/src/main/resources/xsl/adjust-next-cont-error.xsl
@@ -45,7 +45,7 @@
                 Only bother sorting if we have more than one
                 cont-error-type in the list.
             -->
-            <xsl:when test="count($nexts[@type=$cont-error-types]) gt 1">
+            <xsl:when test="$nexts[@type=$cont-error-types]">
                 <xsl:variable name="other" as="xs:string*" select="$nexts[not(@type = $cont-error-types) and not(@type = $sink-types)]/@id"/>
                 <xsl:variable name="sink" as="xs:string*" select="$nexts[@type=$sink-types]/@id"/>
                 <!--

--- a/core/src/main/resources/xsl/opt/removeDups-rules.xml
+++ b/core/src/main/resources/xsl/opt/removeDups-rules.xml
@@ -36,6 +36,9 @@
     <rule types="XPATH JSON_XPATH" required="next match" optional="captureHeader version code message">
         Rule for XPath states.
     </rule>
+    <rule types="ASSERT" required="next match" optional="version code message">
+        Rule for Assert state.
+    </rule>
     <rule types="HEADER HEADERXSD HEADER_ANY HEADERXSD_ANY HEADER_SINGLE HEADERXSD_SINGLE" required="next name match" optional="captureHeader code message">
         Rule for Header, HeaderXSD, HeaderAny.
     </rule>

--- a/core/src/main/resources/xsl/priority-map.xml
+++ b/core/src/main/resources/xsl/priority-map.xml
@@ -45,6 +45,7 @@
     <map type="XPATH"         priority="41000"/>
     <map type="JSON_XPATH"    priority="41000"/>
     <map type="XSL"           priority="41000"/>
+    <map type="ASSERT"        priority="41000"/>
     <map type="XSD"           priority="45000"/>
     <map type="JSON_SCHEMA"   priority="45000"/>
     <map type="ACCEPT"        priority="100000"/>

--- a/core/src/main/resources/xsl/raxAssert.xsl
+++ b/core/src/main/resources/xsl/raxAssert.xsl
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  raxAssert.xsl
+
+  The builder.xsl expects rax:assert elements to live at the method
+  request or representation level.  But the actual feature
+  allows rax:assert to appear at the resources and resource level.
+  Additionally there is a @applyToChildren attribute that is applicable
+  to rax:assert at the resource level that specifies that the assertion
+  should apply to all subresources.
+
+  This stylesheet is responsible for moving rax:assert found in
+  resources and resource level and pushing those assertions down into
+  the method level. It is also responsible for implementing the
+  @applyToChildren functionality.
+
+  Finally, the stylesheet performs error checking on rax:assert and
+  provides appropriate warnings if the assertion is misplaced.
+
+  Copyright 2017 Rackspace US, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:rax="http://docs.rackspace.com/api"
+    xmlns="http://wadl.dev.java.net/2009/02"
+    xmlns:wadl="http://wadl.dev.java.net/2009/02"
+    exclude-result-prefixes="wadl"
+    version="2.0">
+
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:template name="copy" match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!--
+        The following templates gather local and global asserts.
+        The are the source of asserts.
+    -->
+    <xsl:template match="wadl:resources[rax:assert]">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()">
+                <xsl:with-param name="globalAsserts" as="element()*" select="rax:assert" tunnel="yes"/>
+            </xsl:apply-templates>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="wadl:resource">
+        <xsl:param name="globalAsserts" as="element()*" tunnel="yes"/>
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()">
+                <xsl:with-param name="globalAsserts" as="element()*" select="($globalAsserts, rax:assert[xs:boolean(@applyToChildren)])" tunnel="yes"/>
+                <xsl:with-param name="localAsserts" as="element()*" select="rax:assert[not(@applyToChildren) or not(xs:boolean(@applyToChildren))]" tunnel="yes"/>
+            </xsl:apply-templates>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="wadl:request[rax:assert and wadl:representation]">
+        <xsl:param name="localAsserts" as="element()*" tunnel="yes"/>
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()">
+                <xsl:with-param name="localAsserts" as="element()*" select="($localAsserts, rax:assert)" tunnel="yes"/>
+            </xsl:apply-templates>
+        </xsl:copy>
+    </xsl:template>
+
+    <!--
+        The following templates select the target for global and local asserts.
+        They are the destination of asserts.
+    -->
+    <xsl:template match="wadl:request[not(wadl:representation)] |
+        wadl:representation[(local-name(..) = 'request') and (namespace-uri(..) = 'http://wadl.dev.java.net/2009/02') and @mediaType]">
+        <xsl:param name="globalAsserts" as="element()*" tunnel="yes"/>
+        <xsl:param name="localAsserts" as="element()*" tunnel="yes"/>
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+            <xsl:copy-of select="$globalAsserts | $localAsserts"/>
+            <xsl:if test="self::wadl:representation and ../wadl:representation[not(@mediaType)]">
+                <xsl:copy-of select="../wadl:representation[not(@mediaType)]/rax:assert"/>
+            </xsl:if>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="wadl:method[not(wadl:request)]">
+        <xsl:param name="globalAsserts" as="element()*" tunnel="yes"/>
+        <xsl:param name="localAsserts" as="element()*" tunnel="yes"/>
+        <xsl:copy>
+            <xsl:apply-templates select="@*"/>
+            <xsl:apply-templates select="wadl:doc"/>
+            <request>
+                <xsl:copy-of select="$globalAsserts | $localAsserts"/>
+            </request>
+            <xsl:apply-templates select="wadl:response"/>
+            <xsl:apply-templates select="node()[not(namespace-uri(.)='http://wadl.dev.java.net/2009/02')]"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!--
+        asserts on a representation that has no mediaType should be moved
+        to the request level, if there are no requests with mediaType
+    -->
+    <xsl:template match="wadl:request[wadl:representation[not(@mediaType)]]">
+        <xsl:param name="globalAsserts" as="element()*" tunnel="yes"/>
+        <xsl:param name="localAsserts" as="element()*" tunnel="yes"/>
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+            <xsl:if test="every $r in wadl:representation satisfies not($r/@mediaType)">
+                <xsl:copy-of select="$globalAsserts | $localAsserts | wadl:representation[not(@mediaType)]/rax:assert"/>
+            </xsl:if>
+        </xsl:copy>
+    </xsl:template>
+
+    <!--
+        Handle copying/removing of asserts and flag warnings if an
+        assert is in the wrong place.
+    -->
+    <xsl:template match="rax:assert">
+        <xsl:variable name="parent" as="element()" select=".."/>
+        <xsl:variable name="grandparent" as="element()" select="../.."/>
+        <xsl:choose>
+            <xsl:when test="namespace-uri($parent) = 'http://wadl.dev.java.net/2009/02'">
+                <xsl:choose>
+                    <!--
+                        In these instances we are moving assertions, so don't copy
+                        the originals.
+                    -->
+                    <xsl:when test="local-name($parent) = ('resources', 'resource')"/>
+                    <xsl:when test="(local-name($parent) = 'request') and $parent/wadl:representation[@mediaType]"/>
+                    <xsl:when test="(local-name($parent) = 'representation') and not($parent/@mediaType)"/>
+                    <!--
+                        These assertions should stay in place, so we copy them
+                    -->
+                    <xsl:when test="local-name($parent) = 'request'">
+                        <xsl:call-template name="copy"/>
+                    </xsl:when>
+                    <xsl:when test="(local-name($parent) = 'representation') and (local-name($grandparent) = 'request')
+                                    and (namespace-uri($grandparent) = 'http://wadl.dev.java.net/2009/02')">
+                        <xsl:call-template name="copy"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:call-template name="badPlacement"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="badPlacement"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template name="badPlacement">
+        <xsl:message>[WARNING] bad placement for <xsl:copy-of select="."  copy-namespaces="no"/> parent is <xsl:value-of select="name(..)"/> but</xsl:message>
+        <xsl:message>[WARNING] only allowed parents for the rax:assert extension are</xsl:message>
+        <xsl:message>[WARNING] wadl:resources, wadl:resource, wadl:request, wadl:representation (of a method request)</xsl:message>
+        <xsl:message>[WARNING] ignoring this assertion!</xsl:message>
+    </xsl:template>
+</xsl:stylesheet>

--- a/core/src/main/resources/xsl/util/funs.xsl
+++ b/core/src/main/resources/xsl/util/funs.xsl
@@ -58,7 +58,7 @@
                                                                    'XPATH', 'XSL', 'HEADER',
                                                                    'HEADERXSD', 'HEADER_ANY', 'HEADERXSD_ANY',
                                                                    'HEADER_SINGLE', 'HEADERXSD_SINGLE', 'HEADER_ALL',
-                                                                   'JSON_SCHEMA', 'JSON_XPATH')"/>
+                                                                   'JSON_SCHEMA', 'JSON_XPATH', 'ASSERT')"/>
 
     <!-- Useful matches -->
     <xsl:variable name="matchAll" select="'(?s).*'"/>

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
@@ -36,6 +36,13 @@ object Config {
     val affectsCheckerType = universe.typeOf[AffectsChecker]
     universe.typeOf[Config].members.filter(i => i.annotations.map(a => a.tree.tpe).contains(affectsCheckerType))
   }
+
+  //
+  //  The default version of XPath to use for rax:assert XPath
+  //  statements.  Currently, the version is fixed.
+  //
+  val RAX_ASSERT_XPATH_VERSION = 31
+  val RAX_ASSERT_XPATH_VERSION_STRING = "3.1"
 }
 
 /**
@@ -276,6 +283,27 @@ class Config extends LazyLogging {
   @BeanProperty
   @AffectsChecker
   var enableAuthenticatedByExtension : Boolean = false
+
+  //
+  //  Enables rax:assert extensions which allows specifying an
+  //  XPath3.1 assertion.  The assertion works similar to XSD 1.1
+  //  assertion and supports @message, @code for reporting errors.
+  //
+  //  The assertion may look at the uri ($req:uri), method ($req:method),
+  //  request body ($_ or $body), and headers (with a call to
+  //  req:header or req:headers).  The extension may be placed in a
+  //  wadl:method/wadl:request,
+  //  wadl:method/wadl:request/wadl:representation.  The extension may
+  //  also be placed in wadl:resources where it applies to all methods
+  //  globally or on wadl:resource which applies to all methods of
+  //  that resource and if @applyToChildren is set to true then it
+  //  will also apply to all subresources as well.
+  //
+  //  Note that having an assertion on a wadl:representation will
+  //  enable wellformed checks.
+  @BeanProperty
+  @AffectsChecker
+  var enableAssertExtension : Boolean = true
 
   //
   //  The XSL 1.0 engine to use.  Possible choices are Xalan, XalanC,

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/HttpServletRequestMap.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/HttpServletRequestMap.scala
@@ -1,0 +1,107 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+
+package com.rackspace.com.papi.components.checker.servlet
+
+import scala.collection.mutable.Map
+
+import java.util.Set
+import java.util.HashSet
+import java.util.Collection
+import java.util.Enumeration
+import java.util.LinkedList
+import java.util.AbstractMap.SimpleEntry
+
+import javax.servlet.http.HttpServletRequest
+
+import net.sf.saxon.om.Sequence
+
+import com.fasterxml.jackson.databind.ObjectMapper
+
+import collection.JavaConverters._
+
+import com.rackspace.com.papi.components.checker.util.JSONConverter
+
+object HttpServletRequestMap {
+  private val mapper = new ObjectMapper
+
+  //
+  // Supported Calls
+  //
+  protected val HEADERS       = "headers"
+  protected val METHOD        = "method"
+  protected val REQUEST_URI   = "uri"
+
+  //
+  //  Set of supported calls
+  //
+  protected val SUPPORTED_CALLS : Set[String] = new HashSet[String](
+    List(HEADERS, METHOD, REQUEST_URI).asJava.asInstanceOf[Collection[String]])
+}
+
+import HttpServletRequestMap._
+
+class HttpServletRequestMap(protected val request : HttpServletRequest) extends UnimplementedMap[String, Object] {
+  //
+  //  A cache from header name to array of strings to avoid converting
+  //  when a header is accessed more than once.
+  //
+  private val headerValuesCache = Map[String, java.util.List[String]]()
+  private lazy val headerNameSet : Set[String] = new HashSet[String](enumToJavaList(request.getHeaderNames()).asScala.map(_.toLowerCase).asJava)
+
+  private lazy val headers = new UnimplementedMap[String, java.util.List[String]] {
+    override def containsKey(key : Any) = request.getHeader(key.asInstanceOf[String]) != null
+    override def isEmpty = request.getHeaderNames match {
+      case null => true
+      case enum : Enumeration[String] => !enum.hasMoreElements
+    }
+    override def size = headerNameSet.size
+    override def keySet = headerNameSet
+    override def get(key : Any) : java.util.List[String] = {
+      val k = key.asInstanceOf[String]
+      headerValuesCache.getOrElseUpdate(k, enumToJavaList(request.getHeaders(k)))
+    }
+    override def entrySet() : Set[java.util.Map.Entry[String,java.util.List[String]]] = {
+      new HashSet[java.util.Map.Entry[String,java.util.List[String]]](keySet.toArray(Array[String]()).map((s : String)
+                                                                                                  => new SimpleEntry(s, get(s))).toList.asJava)
+
+    }
+  }
+
+  //
+  // Implementation of a map that gets access to request data.
+  //
+  override def containsKey(key: Any): Boolean = SUPPORTED_CALLS.contains(key.asInstanceOf[String])
+  override def isEmpty(): Boolean = false
+  override def size(): Int = SUPPORTED_CALLS.size
+  override def keySet(): java.util.Set[String] = SUPPORTED_CALLS
+  override def get(key: Any): Object = key match {
+    case METHOD       => request.getMethod
+    case REQUEST_URI  => request.getRequestURI
+    case HEADERS      => headers
+    case _ => null
+  }
+  override def entrySet(): Set[java.util.Map.Entry[String,Object]] = {
+    new HashSet[java.util.Map.Entry[String,Object]](keySet.toArray(Array[String]()).map((s : String)
+                                                                                        => new SimpleEntry(s, get(s))).toList.asJava)
+  }
+
+  private def enumToJavaList (enum : Enumeration[String]) : java.util.List[String] = enum match {
+    case null => new LinkedList()
+    case _ => enum.asScala.toList.asJava
+  }
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/RequestAttributes.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/RequestAttributes.scala
@@ -20,9 +20,12 @@ package com.rackspace.com.papi.components.checker.servlet
 //
 object RequestAttributes {
   val PARSED_XML    = "com.rackspace.com.papi.components.checker.servlet.ParsedXML"
+  val PARSED_XML_SOURCE = "com.rackspace.com.papi.components.checker.servlet.ParsedXMLSource"
   val PARSED_JSON   = "com.rackspace.com.papi.components.checker.servlet.ParsedJSONTokens"
-  val PARSED_JSON_SEQUENCE = "com.rackspace.com.papi.components.checker.servlet.ParsedJSONSequence"
+  val PARSED_JSON_SEQUENCE  = "com.rackspace.com.papi.components.checker.servlet.ParsedJSONSequence"
+  val PARSED_JSON_XDM_VALUE = "com.rackspace.com.papi.components.checker.servlet.ParsedJSONXDMValue"
   val CONTENT_ERROR = "com.rackspace.com.papi.components.checker.servlet.ContentError"
   val CONTENT_ERROR_CODE = "com.rackspace.com.papi.components.checker.servlet.ContentErrorCode"
   val CONTENT_ERROR_PRIORITY = "com.rackspace.com.papi.components.checker.servlet.ContentErrorPriority"
+  val REQUEST_XDM_VALUE = "com.rackspace.com.papi.components.checker.servlet.RequestAsXdmValue"
 }

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/UnimplementedMap.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/UnimplementedMap.scala
@@ -1,0 +1,40 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+
+package com.rackspace.com.papi.components.checker.servlet
+
+import java.util.Map
+
+/**
+ * This helper class is used as a base class for all other map clases.
+ * it is simply an unimplemented map.
+ */
+
+class UnimplementedMap[K, V] extends Map[K, V] {
+  def clear(): Unit = ???
+  def containsKey(x$1: Any): Boolean = ???
+  def containsValue(x$1: Any): Boolean = ???
+  def entrySet(): java.util.Set[java.util.Map.Entry[K,V]] = ???
+  def get(x$1: Any): V = ???
+  def isEmpty(): Boolean = ???
+  def keySet(): java.util.Set[K] = ???
+  def put(x$1: K,x$2: V): V = ???
+  def putAll(x$1: java.util.Map[_ <: K, _ <: V]): Unit = ???
+  def remove(x$1: Any): V = ???
+  def size(): Int = ???
+  def values(): java.util.Collection[V] = ???
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/Assert.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/Assert.scala
@@ -1,0 +1,293 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.step
+
+import javax.servlet.FilterChain
+
+import javax.xml.transform.Source
+import javax.xml.transform.dom.DOMSource
+import org.xml.sax.SAXParseException
+
+import com.rackspace.com.papi.components.checker.Config
+import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.step.base.{ConnectedStep, Step, StepContext}
+import com.rackspace.com.papi.components.checker.util.ImmutableNamespaceContext
+import com.rackspace.com.papi.components.checker.util.XQueryEvaluatorPool._
+import com.rackspace.com.papi.components.checker.util.XMLParserPool._
+
+import net.sf.saxon.expr.StaticProperty
+import net.sf.saxon.expr.instruct.UserFunctionParameter
+import net.sf.saxon.expr.parser.XPathParser
+
+import net.sf.saxon.sxpath.IndependentContext
+import net.sf.saxon.sxpath.XPathStaticContext
+
+import net.sf.saxon.om.StructuredQName
+import net.sf.saxon.om.GroundedValue
+import net.sf.saxon.om.Sequence
+
+import net.sf.saxon.s9api.Processor
+import net.sf.saxon.s9api.XQueryEvaluator
+import net.sf.saxon.s9api.QName
+import net.sf.saxon.s9api.XdmValue
+import net.sf.saxon.s9api.XdmEmptySequence
+
+import net.sf.saxon.query.XQueryFunctionLibrary
+import net.sf.saxon.query.XQueryFunction
+
+
+import net.sf.saxon.value.SequenceType
+import net.sf.saxon.functions.FunctionLibraryList
+import net.sf.saxon.`type`.BuiltInAtomicType
+
+import com.typesafe.scalalogging.slf4j.LazyLogging
+
+object Assert {
+  //
+  //  The saxon processor, xquery compiler
+  //
+  protected val processor = new Processor(true)
+  protected val saxonConfig = {
+    val conf = processor.getUnderlyingConfiguration
+    conf.getDynamicLoader.setClassLoader(getClass.getClassLoader)
+    conf
+  }
+  protected val compiler = {
+    val c = processor.newXQueryCompiler
+    c.setLanguageVersion(Config.RAX_ASSERT_XPATH_VERSION_STRING)
+    c
+  }
+
+  //
+  //  Our functions are always defined in the following namespace.
+  //
+  private val prefix = "req"
+  private val uri = "http://www.rackspace.com/repose/wadl/checker/request"
+
+  //
+  //  Functions take a list of sequences as input
+  //  and return a sequence as output.
+  //
+  type Fun = (String /* Function Name */,
+              List[SequenceType] /* Argument Types */,
+              SequenceType /* Return Type */)
+
+  //
+  //  Predefined Functions
+  //
+  private val functions : List[Fun] =
+    List(("header", List(SequenceType.SINGLE_STRING),
+          SequenceType.SINGLE_STRING),
+         ("header", List(SequenceType.SINGLE_STRING,
+                         SequenceType.SINGLE_BOOLEAN),
+          SequenceType.SINGLE_STRING),
+         ("headers", List(SequenceType.SINGLE_STRING),
+          SequenceType.makeSequenceType(BuiltInAtomicType.STRING,
+                                        StaticProperty.ALLOWS_ZERO_OR_MORE)),
+         ("headers", List(SequenceType.SINGLE_STRING,
+                          SequenceType.SINGLE_BOOLEAN),
+          SequenceType.makeSequenceType(BuiltInAtomicType.STRING,
+                                        StaticProperty.ALLOWS_ZERO_OR_MORE)))
+
+  //
+  //  Create an XQueryLibarary where we can declare our custom
+  //  functions.
+  //
+  private val xqlib = new XQueryFunctionLibrary(saxonConfig)
+
+  //
+  //  Declare functions
+  //
+  functions.foreach(f => {
+    val fname   = f._1
+    val argTypes = f._2
+    val retType = f._3
+
+    val fun = new XQueryFunction
+    fun.setFunctionName(new StructuredQName(prefix, uri, fname))
+    fun.setResultType(retType)
+
+    argTypes.foreach(argType => {
+      val param = new UserFunctionParameter
+      param.setVariableQName(new StructuredQName(prefix, uri, "arg"))
+      param.setRequiredType(argType)
+      fun.addArgument(param)
+    })
+
+    xqlib.declareFunction(fun)
+  })
+
+  //
+  // Predefined Variables
+  //
+  private val variables : List[String] =
+    List("_","body","method","uri","headerNames","uriLevel")
+  private val localVariables : List[String] =
+    List("_","body")
+
+
+  private def getXPathContext(nsc : ImmutableNamespaceContext) : XPathStaticContext = {
+    //
+    //  Context used when parsing XPaths
+    //
+    val ic = new IndependentContext
+
+    ic.setXPathLanguageLevel(Config.RAX_ASSERT_XPATH_VERSION)
+    ic.declareNamespace(prefix, uri)
+
+    nsc.getAllPrefixes.filter(p => {
+      (p != "xmlns") &&  (p != "xml")
+    }).foreach(p => {
+      ic.declareNamespace(p, nsc.getNamespaceURI(p))
+    })
+
+    //
+    //  Declare module and local variables, and functions
+    //
+    variables.foreach(ic.declareVariable(uri,_))
+    localVariables.foreach(ic.declareVariable("",_))
+
+    ic.getFunctionLibrary.asInstanceOf[FunctionLibraryList].addFunctionLibrary(xqlib)
+    ic
+  }
+
+  //
+  //  We are using an XQuery evaluator to execute our XPath. We do
+  //  this because it's easy to create the extensions needed for our
+  //  assertions req:headers, for example. (we define these in
+  //  xq/assert.xq.
+  //
+  //  XQuery is a superset of XPath and we don't want folks extending
+  //  beyond the capabilites of XPath, we use an XPath parser to
+  //  confirm we have valid XPath before anything else -- this will
+  //  throw an XPathException if we use capabilities in XQuery that
+  //  are not in XPath such as FLWOR expressions.
+  //
+  //  The parser is made aware of the variables / functions available
+  //  to asserts, so these are also checked.
+  //
+  def parseXPath (expression : String, nc : ImmutableNamespaceContext, version : Int) : Unit = {
+    val xpathParser = new XPathParser
+    xpathParser.setLanguage(XPathParser.XPATH, version)
+    xpathParser.parse(expression, 0, 0, getXPathContext(nc))
+  }
+
+
+  //
+  // Location of the shared XQuery module
+  //
+  private val moduleName : String = "/xq/assert.xq";
+  private val moduleLoc : String = getClass.getResource(moduleName).toString()
+
+  //
+  // XQuery prolog used in front of all XPath expressions.
+  //
+  protected val XQUERY_PROLOG = s"""
+     xquery version \"3.1\" encoding \"UTF-8\";
+
+     import module \"$uri\"
+            at \"$moduleLoc\";
+
+     declare namespace $prefix = \"$uri\";
+
+
+  """
+
+  protected val EMPTY_MAP = XdmEmptySequence.getInstance
+  protected val EMPTY_DOC = {
+    val parser = borrowParser
+    try {
+      new DOMSource(parser.newDocument)
+    } finally {
+      returnParser(parser)
+    }
+  }
+}
+
+import Assert._
+
+class Assert(id : String, label : String, val expression : String, val message : Option[String],
+             val code : Option[Int], val nc : ImmutableNamespaceContext, val version : Int,
+             val priority : Long, next : Array[Step]) extends ConnectedStep(id, label, next) with LazyLogging {
+
+  override val mismatchMessage : String = message.getOrElse (s"Expecting $expression")
+  val mismatchCode : Int = code.getOrElse(400)
+
+  private val query : String = {
+    XQUERY_PROLOG + nc.getAllPrefixes.filter(p => {
+      //
+      // These are predefined prefixes, we can't overwrite them
+      //
+      (p != "xmlns") &&  (p != "xml") && (p != "req") && (p != "")
+    }).map(p => {
+      val uri = nc.getNamespaceURI(p);
+      s"""declare namespace $p = \"$uri\";\n"""
+    }).fold("")(_ + _)+s"""
+          declare variable $$_    := $$$prefix:_;    (: For compatibility with plain params :)
+          declare variable $$body := $$$prefix:body; (: For compatibility with plain params :)
+
+    """+expression
+  }
+
+  private val exec = {
+    try {
+      logger.trace (s"compiling :\n$query")
+      val e = compiler.compile(query)
+      logger.trace ("compilation done.")
+      e
+    } catch {
+      case ex : Exception => logger.error(s"Caught exception while compiling $query",ex)
+                             throw ex
+    }
+  }
+
+  override def checkStep(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, context : StepContext) : Option[StepContext] = {
+    var ret : Option[StepContext] = None
+    var eval : XQueryEvaluator = null
+
+    val json : XdmValue = req.parsedJSONXdmValue match {
+      case null => EMPTY_MAP
+      case jv : XdmValue => jv
+    }
+
+    val xml : Source = req.parsedXMLSource match {
+      case null => EMPTY_DOC
+      case src : Source => src
+    }
+
+    try {
+      eval = borrowEvaluator(expression, exec)
+      eval.setSource(xml)
+      eval.setExternalVariable (new QName(prefix,uri,"__JSON__"), json)
+      eval.setExternalVariable (new QName(prefix,uri,"__REQUEST__"), req.asXdmValue(saxonConfig))
+      eval.setExternalVariable (new QName(prefix,uri,"__CONTEXT__"), context.asXdmValue(saxonConfig))
+      val res : Boolean = eval.evaluate.getUnderlyingValue match {
+        case groundedValue : GroundedValue => groundedValue.effectiveBooleanValue
+        case s : Sequence => s.head != null
+      }
+      if (res) {
+        ret = Some(context)
+      } else {
+        req.contentError(new SAXParseException (mismatchMessage, null), mismatchCode, priority)
+      }
+    } catch {
+      case e : Exception => req.contentError(new SAXParseException(mismatchMessage+" : "+e.getMessage, null, e), mismatchCode, priority)
+    }finally {
+      returnEvaluator (expression, eval)
+    }
+    ret
+  }
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/base/StepContext.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/base/StepContext.scala
@@ -18,7 +18,22 @@ package com.rackspace.com.papi.components.checker.step.base
 import com.rackspace.com.papi.components.checker.handler.ResultHandler
 import com.rackspace.com.papi.components.checker.util.HeaderMap
 
+import net.sf.saxon.s9api.XdmValue
+import net.sf.saxon.Configuration
+import net.sf.saxon.expr.JPConverter
+
+import collection.JavaConverters._
+
 //
 //  Used to keep context about the current request
 //
-case class StepContext(uriLevel : Int = 0, requestHeaders : HeaderMap = new HeaderMap, handler: Option[ResultHandler] = None)
+case class StepContext(uriLevel : Int = 0, requestHeaders : HeaderMap = new HeaderMap, handler: Option[ResultHandler] = None) {
+  def asXdmValue(c : Configuration) : XdmValue = {
+    val headers : java.util.Map[String, java.util.List[String]] = new java.util.HashMap[String,java.util.List[String]]()
+    requestHeaders.foreach { case (k : String, l : List[String]) =>  headers.put (k, l.asJava) }
+    val jcontext : java.util.Map[String, Object] = new java.util.HashMap[String, Object]()
+    jcontext.put("uriLevel", uriLevel.asInstanceOf[Object])
+    jcontext.put("headers", headers)
+    XdmValue.wrap(JPConverter.FromMap.INSTANCE.convert(jcontext, c.getConversionContext))
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/BaseValidatorSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/BaseValidatorSuite.scala
@@ -160,7 +160,11 @@ class BaseValidatorSuite extends FunSuite {
   def request(method : String, url : String, contentType : String, content : String) : HttpServletRequest = {
     val req = request(method, url, contentType)
 
-    when(req.getInputStream).thenReturn(new ByteArrayServletInputStream(content))
+    if (content == null) {
+      when(req.getInputStream).thenReturn(null)
+    } else {
+      when(req.getInputStream).thenReturn(new ByteArrayServletInputStream(content))
+    }
 
     req
   }

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLAssertSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLAssertSuite.scala
@@ -1,0 +1,1063 @@
+/***
+ *   Copyright 2016 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+
+import com.rackspace.com.papi.components.checker.RunAssertionsHandler._
+import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.step.results.Result
+import com.rackspace.cloud.api.wadl.Converters._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+import scala.xml.Elem
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.JsonNode
+
+@RunWith(classOf[JUnitRunner])
+class ValidatorWADLAssertSuite extends BaseValidatorSuite {
+  ///
+  ///  Configs
+  ///
+  val baseConfig = {
+    val c = TestConfig()
+    c.xpathVersion = 31
+    c.removeDups = false
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableCaptureHeaderExtension = false
+    c.enableAssertExtension = false
+    c
+  }
+
+  val baseWithAssert = {
+    val c = TestConfig()
+    c.xpathVersion = 31
+    c.removeDups = false
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c
+  }
+
+  val baseWithAssertRemoveDups = {
+    val c = TestConfig()
+    c.xpathVersion = 31
+    c.removeDups = true
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c
+  }
+
+
+  val baseWithAssertParamDefaults = {
+    val c = TestConfig()
+    c.removeDups = false
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = true
+    c.checkHeaders = true
+    c.enableAssertExtension = true
+    c
+  }
+
+  val baseWithAssertParamDefaultsRemoveDups = {
+    val c = TestConfig()
+    c.removeDups = true
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = true
+    c.checkHeaders = true
+    c.enableAssertExtension = true
+    c
+  }
+
+
+  val baseAssertWithPlainParams = {
+    val c = TestConfig()
+    c.removeDups = false
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.checkElements = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c
+  }
+
+  val baseAssertWithJoinXPaths = {
+    val c = TestConfig()
+    c.removeDups = false
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.checkElements = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c
+  }
+
+  val baseAssertWithJoinXPathsAndRemoveDups = {
+    val c = TestConfig()
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.checkElements = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c
+  }
+
+
+//  RaxRoles Configs
+
+  val baseWithPlainParamsRaxRoles = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.removeDups = false
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c
+  }
+
+
+  val baseWithRemoveDupsRaxRoles = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.removeDups = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c
+  }
+
+  val baseWithJoinXPathsRaxRoles = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.removeDups = false
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c
+  }
+
+  val baseWithJoinXPathsAndRemoveDupsRaxRoles = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c
+  }
+
+
+//  RaxRoles Configs Masked
+
+  val baseWithPlainParamsRaxRolesMask = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c.removeDups = false
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c
+  }
+
+
+  val baseWithRemoveDupsRaxRolesMask = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c.removeDups = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c
+  }
+
+  val baseWithJoinXPathsRaxRolesMask = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c.removeDups = false
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c
+  }
+
+  val baseWithJoinXPathsAndRemoveDupsRaxRolesMask = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c
+  }
+
+val WADL_withAsserts = <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:req="http://www.rackspace.com/repose/wadl/checker/request"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:tst="test.org"
+             xmlns:tst2="http://www.rackspace.com/repose/wadl/checker/step/test">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/a" rax:roles="user">
+            <method name="PUT">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml">
+                        <param name="test" style="plain" path="tst:some_xml/tst:an_element/tst:another_element" required="true"/>
+                        <rax:assert test="tst:some_xml/@att='1'" message="expect att to = 1"/>
+                        <rax:assert test="$body/tst:some_xml/tst:an_element" message="expect an_element"/>
+                    </representation>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml">
+                        <rax:assert test="false()" message="YAML makes us fail!" code="500"/>
+                    </representation>
+                    <!-- assertion should be placed in all representations -->
+                    <representation>
+                        <rax:assert test="not(empty($body))" message="There should be a body"/>
+                        <rax:assert test="not(empty($_))" message="There should be a $_"/>
+                    </representation>
+                </request>
+            </method>
+            <method name="POST">
+                <request>
+                    <representation mediaType="application/xml" element="tst2:a">
+                        <param name="test2" style="plain" path="tst2:a/@id" required="true" rax:message="Expecting an id attribute"/>
+                        <!-- This assertion applies only to POST /a when the representation is XML -->
+                        <rax:assert test="$req:method='POST' and $req:uri='/a' and /tst2:a" message="This assertion should never fire!!" code="500"/>
+                        <rax:assert test="$req:method='POST' and $req:uri='/a' and $_/tst2:a" message="This assertion should never fire!!" code="500"/>
+                    </representation>
+                    <representation mediaType="application/json">
+                        <param name="test3" style="plain" path="$_?firstName" required="true" rax:message="Need a first name" rax:code="403"/>
+                    </representation>
+                </request>
+            </method>
+            <resource path="b">
+                <method name="GET"/>
+                <method name="DELETE" rax:roles="admin Administrator">
+                  <request>
+                    <param name="X-AUTH" style="header" type="xs:string" default="foo!" required="true" repeating="true"/>
+                    <!-- Should be treated as a request assertion -->
+                    <representation>
+                        <rax:assert test="$req:method='DELETE'"/>
+                        <rax:assert test="req:header('X-AUTH') = 'foo!'"/>
+                    </representation>
+                  </request>
+                </method>
+                <method name="POST">
+                    <request>
+                        <representation mediaType="application/xml">
+                        </representation>
+                        <representation mediaType="application/json">
+                            <!-- This assertion applies only to POST /a/b if the representation is JSON -->
+                            <rax:assert test="$req:uri='/a/b' and not(empty($body))" message="The request path should be /a/b and there should be a JSON body" code="400"/>
+                            <rax:assert test="$_?stuff?string = 'A String'" message="Expect JSON to have 'A String'"/>
+                        </representation>
+                        <!-- This assertion applies only to POST /a/b request regardless of the representation-->
+                        <rax:assert test="$req:uri='/a/b'" message="The request path should be /a/b" code="400"/>
+                    </request>
+                </method>
+            </resource>
+            <!-- This assertion applies to all requests in the resource /a -->
+            <rax:assert test="$req:uri='/a'" message="The request path should be /a" code="400"/>
+            <rax:assert test="$req:uriLevel = 1" message="Bad URL Level this shouldn't happen" code="500"/>
+            <rax:assert test="some $h in $req:headerNames satisfies starts-with($h, 'a')" message="There should be a header that starts with a"/>
+            <!-- This assertion applies to all requests in the resource /a AND all subresources of a /a/b for example-->
+            <rax:assert test="some $h in $req:headerNames satisfies starts-with($h,'b')" message="There should be a header that starts with b" code="400" applyToChildren="true"/>
+        </resource>
+        <!-- This assertion applies to all requests in the WADL -->
+        <rax:assert test="'foo!' = req:headers('X-AUTH', true())" message="The X-AUTH header should always be specified and it should be foo!" code="400" />
+    </resources>
+   </application>
+
+
+val WADL_withAsserts2 = <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:req="http://www.rackspace.com/repose/wadl/checker/request"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+             xmlns:tst="test.org"
+             xmlns:tst2="http://www.rackspace.com/repose/wadl/checker/step/test"
+              >
+    <resources base="https://test.api.openstack.com">
+        <resource path="/a" rax:roles="user">
+            <method name="PUT">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml">
+                        <param name="test" style="plain" path="tst:some_xml/tst:an_element/tst:another_element" required="true"/>
+                        <rax:assert test="tst:some_xml/@att='1'" message="expect att to = 1"/>
+                        <rax:assert test="$req:body/tst:some_xml/tst:an_element" message="expect an_element"/>
+                    </representation>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml">
+                        <rax:assert test="false()" message="YAML makes us fail!" code="500"/>
+                    </representation>
+                    <!-- assertion should be placed in all representations -->
+                    <representation>
+                        <rax:assert test="not(empty($req:body))" message="There should be a body"/>
+                        <rax:assert test="not(empty($req:_))" message="There should be a $req:_"/>
+                    </representation>
+                </request>
+            </method>
+            <method name="POST">
+                <request>
+                    <representation mediaType="application/xml" element="tst2:a">
+                        <param name="test2" style="plain" path="tst2:a/@id" required="true" rax:message="Expecting an id attribute"/>
+                        <!-- This assertion applies only to POST /a when the representation is XML -->
+                        <rax:assert test="$req:method='POST' and $req:uri='/a' and /tst2:a" message="This assertion should never fire!!" code="500"/>
+                        <rax:assert test="$req:method='POST' and $req:uri='/a' and $req:_/tst2:a" message="This assertion should never fire!!" code="500"/>
+                    </representation>
+                    <representation mediaType="application/json">
+                        <param name="test3" style="plain" path="$ _?firstName" required="true" rax:message="Need a first name" rax:code="403"/>
+                    </representation>
+                </request>
+            </method>
+            <resource path="b">
+                <method name="GET"/>
+                <method name="DELETE" rax:roles="admin Administrator">
+                  <request>
+                    <param name="X-AUTH" style="header" type="xs:string" default="foo!" required="true" repeating="true"/>
+                    <!-- Should be treated as a request assertion -->
+                    <representation>
+                        <rax:assert test="$req:method='DELETE'"/>
+                        <rax:assert test="req:header('X-AUTH') = 'foo!'"/>
+                    </representation>
+                  </request>
+                </method>
+                <method name="POST">
+                    <request>
+                        <representation mediaType="application/xml">
+                        </representation>
+                        <representation mediaType="application/json">
+                            <!-- This assertion applies only to POST /a/b if the representation is JSON -->
+                            <rax:assert test="$req:uri='/a/b' and not(empty($req:body))" message="The request path should be /a/b and there should be a JSON body" code="400"/>
+                            <rax:assert test="$req:_?stuff?string = 'A String'" message="Expect JSON to have 'A String'"/>
+                        </representation>
+                        <!-- This assertion applies only to POST /a/b request regardless of the representation-->
+                        <rax:assert test="$req:uri='/a/b'" message="The request path should be /a/b" code="400"/>
+                    </request>
+                </method>
+            </resource>
+            <!-- This assertion applies to all requests in the resource /a -->
+            <rax:assert test="$req:uri='/a'" message="The request path should be /a" code="400"/>
+            <rax:assert test="$req:uriLevel = 1" message="Bad URL Level this shouldn't happen" code="500"/>
+            <rax:assert test="some $h in $req:headerNames satisfies starts-with($h, 'a')" message="There should be a header that starts with a"/>
+            <!-- This assertion applies to all requests in the resource /a AND all subresources of a /a/b for example-->
+            <rax:assert test="some $h in $req:headerNames satisfies starts-with($h,'b')" message="There should be a header that starts with b" code="400" applyToChildren="true"/>
+        </resource>
+        <!-- This assertion applies to all requests in the WADL -->
+        <rax:assert test="'foo!' = req:headers('X-AUTH', true())" message="The X-AUTH header should always be specified and it should be foo!" code="400" />
+    </resources>
+   </application>
+
+
+  //
+  // Config combinations
+  //
+  val assertDisabledConfigs = Map[String, Config]("base config with asserts disabled"->baseConfig)
+
+  val assertEnabledConfigs  = Map[String, Config]("Config with asserts enabled"->baseWithAssert,
+                                                  "Config with asserts and remove dups"->baseWithAssertRemoveDups)
+
+  val assertEnabledParamDefaultConfigs = Map[String, Config]("Config with asserts enabled, param defaults"->baseWithAssertParamDefaults,
+                                                             "Config with asserts enabled, param defaults and remove dups"->baseWithAssertParamDefaultsRemoveDups)
+
+  val assertEnabledPlainParamConfigs = Map[String, Config]("Config with asserts enabled, plain params"->baseAssertWithPlainParams,
+                                                           "Config with asserts enabled, plain params join XPath"->baseAssertWithJoinXPaths,
+                                                           "Config with asserts enabled, plain params join XPath, remove dups"->baseAssertWithJoinXPathsAndRemoveDups)
+
+  val assertEnabledPlainRaxRoles = Map[String, Config]("Config with asserts enabled, plain params, rax roles"->baseWithPlainParamsRaxRoles,
+                                                       "Config with asserts enabled, plain params, rax roles, remove dups"->baseWithRemoveDupsRaxRoles,
+                                                       "Config with asserts enabled, plain params, rax roles, join xpath"->baseWithJoinXPathsRaxRoles,
+                                                       "Config with asserts enabled, plain params, rax roles, remove dups, join xpath"->baseWithJoinXPathsAndRemoveDupsRaxRoles)
+
+  val assertEnabledPlainRaxRolesMask = Map[String, Config]("Config with asserts enabled, plain params, rax roles masked"->baseWithPlainParamsRaxRolesMask,
+                                                           "Config with asserts enabled, plain params, rax roles masked, remove dups"->baseWithRemoveDupsRaxRolesMask,
+                                                           "Config with asserts enabled, plain params, rax roles masked, join xpath"->baseWithJoinXPathsRaxRolesMask,
+                                                           "Config with asserts enabled, plain params, rax roles masked, remove dups, join xpath"->baseWithJoinXPathsAndRemoveDupsRaxRolesMask)
+
+
+  //
+  // WADL combinations
+  //
+  val assertWADLs = Map[String, Elem]("WADL with $body assertions"->WADL_withAsserts,
+                                      "WADL with $req:body assertions"->WADL_withAsserts2)
+
+
+  //
+  // Assertions!
+  //
+
+  def happyPathAssertions(validator : Validator, wadlDesc : String, configDesc : String) {
+     test (s"A PUT on /a should validate with goodXML on $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+     }
+
+    test (s"A PUT on /a should validate with goodJSON on $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json",goodJSON, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+     }
+
+
+     test (s"A POST on /a should validate with goodXML on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/xml",goodXML_XSD2, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+     }
+
+    test (s"A POST on /a should validate with goodJSON on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/json",goodJSON_Schema1, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+     }
+
+    test (s"A GET on /a/b should validate on $wadlDesc with $configDesc") {
+      validator.validate(request("GET", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+
+    test (s"A DELETE on /a/b should validate on $wadlDesc with $configDesc") {
+      validator.validate(request("DELETE", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                                          "b"->List("Dbaba"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user", "Administrator"))), response, chain)
+    }
+
+    test (s"A POST on /a/b should validate with good XML on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                                          "b"->List("Dbaba"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+
+    test (s"A POST on /a/b should validate with good JSON on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a/b", "application/json", goodJSON, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                                          "b"->List("Dbaba"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+  }
+
+
+  def happyWhenAssertionsAreDisabled(validator : Validator, wadlDesc : String, configDesc : String) {
+     test (s"A PUT on /a should validate with goodXML with an @att=2 on $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml",
+                                 <some_xml att='2' xmlns='test.org'>
+                                   <an_element>
+                                     <another_element />
+                                   </an_element>
+                                 </some_xml>
+                                 , false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+     }
+
+
+     test (s"A PUT on /a should validate with goodXML but only X-Roles headers on $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                 Map[String,List[String]]("X-Roles"->List("user"))), response, chain)
+     }
+
+
+
+     test (s"A PUT on /a should validate with goodXML that does not contain an_element $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml",
+                                 <some_xml att='1' xmlns='test.org'>
+                                   <another_element>
+                                     <yet_another_element />
+                                   </another_element>
+                                 </some_xml>
+                                 , false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+     }
+
+
+    test (s"A PUT on /a should validate with YAML  $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "text/x-yaml","""---
+- name: Hello World!
+                                 """, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+
+    test (s"A PUT on /a should validate with empty JSON body $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a/b", "application/json", "", false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                                          "b"->List("Dbaba"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+
+    test (s"A PUT on /a should validate with good JSON body and only X-Roles headers $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a/b", "application/json", goodJSON, false,
+                                 Map[String,List[String]]("X-Roles"->List("user"))), response, chain)
+    }
+
+
+    test (s"A POST on /a should validate with goodXML (wrong schema) on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/xml",goodXML, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+     }
+
+
+
+    test (s"A POST on /a should validate with goodJSON (wrong schema) on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/json","""  { "foo" : "bar" } """, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+
+    test (s"A DELETE on /a/b should validate on  with only X-ROLES headers $wadlDesc with $configDesc") {
+      validator.validate(request("DELETE", "/a/b", null, "", false,
+                                 Map[String,List[String]]("X-Roles"->List("user","admin"))), response, chain)
+    }
+
+    test (s"A POST on /a/b should validate with empty JSON body only X-ROLES headers $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a/b", "application/json", null.asInstanceOf[String], false,
+                                 Map[String,List[String]]("X-Roles"->List("user"))), response, chain)
+    }
+
+  }
+
+  //
+  //  These are just sanity checks against the WADL, they should never validate
+  //
+  def happySadPaths (validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"Plain text PUT should fail on /a $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT","/a","plain/text","hello!", false,
+                                                    Map[String,List[String]]("X-Roles"->List("user"))), response, chain),
+                         415, List("content type","application/xml","application/json","text/x\\-yaml"))
+    }
+
+    test (s"A PATCH on /a should fail with a 405 on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PATCH", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         405, List("Method", "POST", "PUT"))
+    }
+
+
+    test (s"A POST on /a/b/c should fail with a 404 on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a/b/c", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         404, List("not found","{c}"))
+    }
+
+  }
+
+  def sadWhenAssertionsAreEnabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A PUT on /a should not validate with goodXML with an @att=2 on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",
+                                                    <some_xml att='2' xmlns='test.org'>
+                                                    <an_element>
+                                                    <another_element />
+                                                    </an_element>
+                                                    </some_xml>
+                                                    , false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("expect att to = 1"))
+     }
+
+    test (s"A PUT on /a should not validate with goodXML but no headers on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("X-Roles"->List("user"))), response, chain),
+                         400, List("There should be a header that starts with a"))
+     }
+
+    test (s"A PUT on /a should not validate with goodXML but no b header on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("There should be a header that starts with b"))
+    }
+
+    test (s"A PUT on /a should not validate with goodXML but no X-AUTH header on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("abba"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("X-Auth","foo!"))
+    }
+
+    test (s"A PUT on /a should not validate with YAML  $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "text/x-yaml","""---
+- name: Hello World!
+                                 """, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         500, List("YAML makes us fail!"))
+    }
+
+    test (s"A PUT on /a should not validate with empty JSON body $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/json", "", false,
+                                                    Map[String,List[String]]("a"->List("Bbba"),
+                                                                             "b"->List("Dbaba"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("No content"))
+    }
+
+    test (s"A PUT on /a should not validate with good JSON body and no headers $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/json", goodJSON, false,
+                                 Map[String,List[String]]("X-Roles"->List("user"))), response, chain),
+                         400, List("There should be a header that starts with b"))
+    }
+
+    test (s"A PUT on /a should not validate with good JSON body and b header but no auth header $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/json", goodJSON, false,
+                                 Map[String,List[String]]("b"->List("abba"),
+                                                          "X-Roles"->List("user"))), response, chain),
+                         400, List("X-AUTH","foo!"))
+    }
+
+    test (s"A PUT on /a should not validate with good XML body and no headers on application/xml $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML, false,
+                                 Map[String,List[String]]("X-Roles"->List("user"))), response, chain),
+                         400, List("There should be a header that starts with b"))
+    }
+
+    test (s"A PUT on /a should not validate with good XML body and b header but no auth header $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/xml", goodXML, false,
+                                 Map[String,List[String]]("b"->List("abba"),
+                                                          "X-Roles"->List("user"))), response, chain),
+                         400, List("X-AUTH","foo!"))
+    }
+
+    test (s"A DELETE on /a/b should not validate on with 'foo!' is not the first value $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("DELETE", "/a/b", null, "", false,
+                                                    Map[String,List[String]]("x-auth"->List("bar","foo!"),
+                                                                             "X-Roles"->List("admin"))),
+                                            response, chain),
+                         400, List("req:header('X-AUTH') = 'foo!'"))
+    }
+
+    test (s"A POST on /a/b should not validate with empty JSON body no headers $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/json", null.asInstanceOf[String], false,
+                                                    Map[String,List[String]]("X-Roles"->List("user"))), response, chain),
+                         400, List("No content"))
+    }
+
+    test (s"A POST on /a/b should not validate with JSON with bad schema on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a/b", "application/json", goodJSON_Schema1, false,
+                                                    Map[String,List[String]]("a"->List("Bbba"),
+                                                                             "b"->List("Dbaba"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("Expect JSON to have 'A String'"))
+    }
+  }
+
+  def happyWithParamDefaultsEnabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A DELETE on /a/b should validate on when no X-Auth is specified $wadlDesc with $configDesc") {
+      validator.validate(request("DELETE", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                                          "b"->List("Dbaba"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+  }
+
+  def sadWithParamDefaultsDisabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A DELETE on /a/b should not validate on  with incorrect Auth header $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("DELETE", "/a/b", null, "", false,
+                                                    Map[String,List[String]]("X-Auth"->List("Bust"),
+                                                                             "X-Roles"->List("admin"))), response, chain),
+                         400, List("req:header('X-AUTH') = 'foo!'"))
+    }
+  }
+
+  def testsWithPlainParamsDisabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A PUT on /a should not validate with goodXML that does not contain an_element $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",
+                                                    <some_xml att='1' xmlns='test.org'>
+                                                    <another_element>
+                                                    <yet_another_element />
+                                                    </another_element>
+                                                    </some_xml>
+                                                    , false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("expect an_element"))
+    }
+
+    test (s"A POST on /a should not validate with goodXML (wrong schema) on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         500, List("This assertion should never fire!!"))
+    }
+
+    test (s"A POST on /a with tst2:a and no @id attribute should succeed on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/xml",
+                                 <a xmlns="http://www.rackspace.com/repose/wadl/checker/step/test"
+                                 stepType="ACCEPT"
+                                 even="22"/>
+                                 , false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+
+    test (s"A POST on /a with a bad schema JSON should succeed on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/json",""" { "foo" : "bar" } """,false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+  }
+
+  def testsWithPlainParamsEnabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A PUT on /a should not validate with goodXML that does not contain an_element (plain param) $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",
+                                                    <some_xml att='1' xmlns='test.org'>
+                                                    <another_element>
+                                                    <yet_another_element />
+                                                    </another_element>
+                                                    </some_xml>
+                                                    , false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("Expecting","tst:some_xml/tst:an_element/tst:another_element"))
+    }
+
+    test (s"A POST on /a should not validate with goodXML (wrong schema) on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("root", "tst2:a"))
+    }
+
+    test (s"A POST on /a with tst2:a and no @id attribute should fail with plain params enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/xml",
+                                                    <a xmlns="http://www.rackspace.com/repose/wadl/checker/step/test"
+                                                    stepType="ACCEPT"
+                                                    even="22"/>
+                                                    , false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("Expecting an id attribute"))
+    }
+
+    test (s"A POST on /a with a bad schema JSON should fail on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/json",""" { "foo" : "bar" } """,false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         403, List("Need a first name"))
+    }
+  }
+
+  def testsWithRaxRolesDisabled(validator : Validator, wadlDesc : String, configDesc : String) {
+     test (s"A PUT on /a should validate with goodXML with no roles on $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"))), response, chain)
+     }
+
+     test (s"A PUT on /a should validate with goodXML and an unknown role on $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("bizRole","admin"))), response, chain)
+     }
+
+
+    test (s"A DELETE on /a/b should validate with multiple unknown roles on $wadlDesc with $configDesc") {
+      validator.validate(request("DELETE", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                                          "b"->List("Dbaba"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("bizBuz", "Wooga"))), response, chain)
+    }
+
+
+    test (s"A DELETE on /a/b should validate with no roles $wadlDesc with $configDesc") {
+      validator.validate(request("DELETE", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                                          "b"->List("Dbaba"),
+                                                          "X-Auth"->List("foo!"))), response, chain)
+    }
+  }
+
+  def testsWithRaxRolesEnabled(validator : Validator, wadlDesc : String, configDesc : String) {
+     test (s"A PUT on /a should validate with goodXML with no roles on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"))), response, chain),
+                         403, List("You are forbidden"))
+     }
+
+     test (s"A PUT on /a should validate with goodXML and an unknown role on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                                   Map[String,List[String]]("a"->List("abba"),
+                                                                            "b"->List("ababa"),
+                                                                            "X-Auth"->List("foo!"),
+                                                                            "X-Roles"->List("bizRole","admin"))), response, chain),
+                         403, List("You are forbidden"))
+     }
+
+
+    test (s"A DELETE on /a/b should validate with multiple unknown roles on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("DELETE", "/a/b", null, "", false,
+                                                    Map[String,List[String]]("a"->List("Bbba"),
+                                                                             "b"->List("Dbaba"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("bizBuz", "Wooga"))), response, chain),
+                         403, List("You are forbidden"))
+    }
+
+
+    test (s"A DELETE on /a/b should validate with no roles $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("DELETE", "/a/b", null, "", false,
+                                                    Map[String,List[String]]("a"->List("Bbba"),
+                                                                             "b"->List("Dbaba"),
+                                                                             "X-Auth"->List("foo!"))), response, chain),
+                         403, List("You are forbidden"))
+    }
+  }
+
+  def testsWithRaxRolesMaskEnabled(validator : Validator, wadlDesc : String, configDesc : String) {
+     test (s"A PUT on /a should validate with goodXML with no roles on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"))), response, chain),
+                         404, List("Resource not found"))
+     }
+
+     test (s"A PUT on /a should validate with goodXML and an unknown role on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                                   Map[String,List[String]]("a"->List("abba"),
+                                                                            "b"->List("ababa"),
+                                                                            "X-Auth"->List("foo!"),
+                                                                            "X-Roles"->List("bizRole","admin"))), response, chain),
+                         405, List("PUT"))
+     }
+
+
+    test (s"A DELETE on /a/b should validate with multiple unknown roles on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("DELETE", "/a/b", null, "", false,
+                                                    Map[String,List[String]]("a"->List("Bbba"),
+                                                                             "b"->List("Dbaba"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("bizBuz", "Wooga"))), response, chain),
+                         404, List("Resource not found"))
+    }
+
+
+    test (s"A DELETE on /a/b should validate with no roles $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("DELETE", "/a/b", null, "", false,
+                                                    Map[String,List[String]]("a"->List("Bbba"),
+                                                                             "b"->List("Dbaba"),
+                                                                             "X-Auth"->List("foo!"))), response, chain),
+                         404, List("Resource not found"))
+    }
+  }
+
+  //
+  // With assertions disabled
+  //
+
+  for ((wadlDesc, wadl) <- assertWADLs) {
+    for ((configDesc, config) <- assertDisabledConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happyWhenAssertionsAreDisabled(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+    }
+  }
+
+  //
+  //  With asserts enabled
+  //
+  for ((wadlDesc, wadl) <- assertWADLs) {
+    for ((configDesc, config) <- assertEnabledConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      sadWhenAssertionsAreEnabled(validator, wadlDesc, configDesc)
+      sadWithParamDefaultsDisabled(validator, wadlDesc, configDesc)
+      testsWithPlainParamsDisabled(validator, wadlDesc, configDesc)
+      testsWithRaxRolesDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+  //
+  // With param defaults and assert enabled configs
+  //
+  for ((wadlDesc, wadl) <- assertWADLs) {
+    for ((configDesc, config) <- assertEnabledParamDefaultConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      sadWhenAssertionsAreEnabled(validator, wadlDesc, configDesc)
+      happyWithParamDefaultsEnabled (validator, wadlDesc, configDesc)
+      testsWithPlainParamsDisabled(validator, wadlDesc, configDesc)
+      testsWithRaxRolesDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+  //
+  //  With plain params and asserts enabled
+  //
+  for ((wadlDesc, wadl) <- assertWADLs) {
+    for ((configDesc, config) <- assertEnabledPlainParamConfigs) {
+      val validator = Validator(wadl, config)
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      sadWhenAssertionsAreEnabled(validator, wadlDesc, configDesc)
+      sadWithParamDefaultsDisabled(validator, wadlDesc, configDesc)
+      testsWithPlainParamsEnabled(validator, wadlDesc, configDesc)
+      testsWithRaxRolesDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+  //
+  //  With plain params and rax:roles and asserts enabled
+  //
+  for ((wadlDesc, wadl) <- assertWADLs) {
+    for ((configDesc, config) <- assertEnabledPlainRaxRoles) {
+      val validator = Validator(wadl, config)
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      sadWhenAssertionsAreEnabled(validator, wadlDesc, configDesc)
+      sadWithParamDefaultsDisabled(validator, wadlDesc, configDesc)
+      testsWithPlainParamsEnabled(validator, wadlDesc, configDesc)
+      testsWithRaxRolesEnabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+
+  //
+  //  With plain params and rax:roles Masked and asserts enabled
+  //
+  for ((wadlDesc, wadl) <- assertWADLs) {
+    for ((configDesc, config) <- assertEnabledPlainRaxRolesMask) {
+      val validator = Validator(wadl, config)
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      sadWhenAssertionsAreEnabled(validator, wadlDesc, configDesc)
+      sadWithParamDefaultsDisabled(validator, wadlDesc, configDesc)
+      testsWithPlainParamsEnabled(validator, wadlDesc, configDesc)
+      testsWithRaxRolesMaskEnabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/servlet/HttpServletRequestMapSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/servlet/HttpServletRequestMapSuite.scala
@@ -1,0 +1,204 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.com.papi.components.checker.servlet.HttpServletRequestMap
+import com.rackspace.com.papi.components.checker.util.VarXPathExpression
+import com.rackspace.com.papi.components.checker.util.XPathExpressionPool._
+import com.rackspace.com.papi.components.checker.util.XMLParserPool._
+import com.rackspace.com.papi.components.checker.util.ImmutableNamespaceContext
+
+import org.junit.runner.RunWith
+import org.mockito.Mockito.when
+import org.scalatest.junit.JUnitRunner
+
+import java.io.InputStreamReader
+import java.io.BufferedReader
+
+import javax.xml.namespace.QName
+import javax.xml.xpath.XPathConstants
+
+import scala.collection.JavaConverters._
+
+@RunWith(classOf[JUnitRunner])
+class HttpServletRequestMapSuite extends BaseValidatorSuite {
+  val XPATH_VERSION = 31
+  val REQUEST_VAR = new QName("request")
+  val defaultContext = ImmutableNamespaceContext(Map[String,String]())
+  val emptyDoc = {
+    val parser = borrowParser
+    try {
+      parser.newDocument
+    } finally {
+      if (parser != null) returnParser(parser)
+    }
+  }
+
+
+  test("Method should be accesible in XPath") {
+    val req1 = new HttpServletRequestMap(request("GET","/"))
+    val req2 = new HttpServletRequestMap(request("DELETE","/"))
+    val req3 = new HttpServletRequestMap(request("PUT", "/"))
+
+    val xpath1 = borrowExpression("$request?method='GET'", defaultContext, XPATH_VERSION).asInstanceOf[VarXPathExpression]
+    val xpath2 = borrowExpression("$request?method='DELETE'", defaultContext, XPATH_VERSION).asInstanceOf[VarXPathExpression]
+    val xpath3 = borrowExpression("$request?method='PUT'", defaultContext, XPATH_VERSION).asInstanceOf[VarXPathExpression]
+
+    try {
+      //
+      //  Only GET is set in request 1
+      //
+      assert(xpath1.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req1)).asInstanceOf[Boolean])
+      assert(!xpath1.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req2)).asInstanceOf[Boolean])
+      assert(!xpath1.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req3)).asInstanceOf[Boolean])
+
+
+      //
+      //  Only DELETE is set in request 2
+      //
+      assert(xpath2.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req2)).asInstanceOf[Boolean])
+      assert(!xpath2.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req1)).asInstanceOf[Boolean])
+      assert(!xpath2.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req3)).asInstanceOf[Boolean])
+
+
+      //
+      //  Only PUT is set in request 3
+      //
+      assert(xpath3.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req3)).asInstanceOf[Boolean])
+      assert(!xpath3.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req1)).asInstanceOf[Boolean])
+      assert(!xpath3.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req2)).asInstanceOf[Boolean])
+
+    } finally {
+      if (xpath1 != null) returnExpression("$request?method='GET'", defaultContext, XPATH_VERSION, xpath1)
+      if (xpath2 != null) returnExpression("$request?method='DELETE'", defaultContext, XPATH_VERSION, xpath2)
+      if (xpath3 != null) returnExpression("$request?method='PUT'", defaultContext, XPATH_VERSION, xpath3)
+    }
+  }
+
+  test("URI should be accessible in XPath") {
+    val req1 = new HttpServletRequestMap(request("GET","/path/to/foo"))
+    val req2 = new HttpServletRequestMap(request("DELETE","/path/to/bar"))
+    val req3 = new HttpServletRequestMap(request("PUT", "/yet/another/path.txt"))
+
+
+    val xpath1 = borrowExpression("$request?uri='/path/to/foo'", defaultContext, XPATH_VERSION).asInstanceOf[VarXPathExpression]
+    val xpath2 = borrowExpression("$request?uri='/path/to/bar'", defaultContext, XPATH_VERSION).asInstanceOf[VarXPathExpression]
+    val xpath3 = borrowExpression("$request?uri='/yet/another/path.txt'", defaultContext, XPATH_VERSION).asInstanceOf[VarXPathExpression]
+
+    try {
+      //
+      //  URI shoud be /path/to/foo only in req1
+      //
+      assert(xpath1.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req1)).asInstanceOf[Boolean])
+      assert(!xpath1.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req2)).asInstanceOf[Boolean])
+      assert(!xpath1.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req3)).asInstanceOf[Boolean])
+
+
+      //
+      //  URI should be /path/to/bar only in req 2
+      //
+      assert(xpath2.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req2)).asInstanceOf[Boolean])
+      assert(!xpath2.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req1)).asInstanceOf[Boolean])
+      assert(!xpath2.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req3)).asInstanceOf[Boolean])
+
+
+      //
+      // URI should be /yet/another/path.txt only in req 3
+      //
+      assert(xpath3.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req3)).asInstanceOf[Boolean])
+      assert(!xpath3.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req1)).asInstanceOf[Boolean])
+      assert(!xpath3.evaluate (emptyDoc, XPathConstants.BOOLEAN,Map(REQUEST_VAR->req2)).asInstanceOf[Boolean])
+
+    } finally {
+      if (xpath1 != null) returnExpression("$request?uri='/path/to/foo'", defaultContext, XPATH_VERSION, xpath1)
+      if (xpath2 != null) returnExpression("$request?uri='/path/to/bar'", defaultContext, XPATH_VERSION, xpath2)
+      if (xpath3 != null) returnExpression("$request?uri='/yet/another/path.txt'", defaultContext, XPATH_VERSION, xpath3)
+    }
+  }
+
+  def getVarPath (xpath : String, retType : QName, vars : Map[QName,Object]) : Object = {
+    val xpathExp = borrowExpression(xpath, defaultContext, XPATH_VERSION).asInstanceOf[VarXPathExpression]
+    try {
+      xpathExp.evaluate (emptyDoc, retType, vars)
+    } finally {
+      if (xpathExp != null) returnExpression(xpath, defaultContext, XPATH_VERSION, xpathExp)
+    }
+  }
+
+  test("Headers should be accessible, though in a (lower) case sensitive manner") {
+    var req1 = new HttpServletRequestMap(request("GET", "/path/to/foo", "application/json", "null", false,
+                                                 Map[String,List[String]]("foo"->List("bar"),
+                                                                          "bIz"->List("baz","boom","bit"),
+                                                                          "x"->List("y"))))
+    var req2 = new HttpServletRequestMap(request("DELETE", "/path/to/bar", "application/json", "null", false,
+                                                 Map[String,List[String]]("FoO"->List("baz"))))
+
+    var req3 = new HttpServletRequestMap(request("PUT", "/yet/another/path.txt", "application/json", "null", false,
+                                                 Map[String,List[String]]()))
+
+    var req4 = new HttpServletRequestMap(request("POST", "/no/headers/allowed"))
+
+
+    assert (getVarPath ("""
+                         (count($request?headers?foo) = 1) and
+                         (count($request?headers?biz) = 3) and
+                         (count($request?headers?x) = 1)
+                        """, XPathConstants.BOOLEAN, Map(REQUEST_VAR->req1)).asInstanceOf[Boolean])
+
+    assert (getVarPath ("""
+                         (every $v in $request?headers?foo satisfies $v='bar') and
+                         (every $v in $request?headers?biz satisfies $v=('baz','boom','bit')) and
+                         (every $v in $request?headers?x satisfies $v='y')
+                        """, XPathConstants.BOOLEAN, Map(REQUEST_VAR->req1)).asInstanceOf[Boolean])
+
+    assert(getVarPath("count($request?headers?foo) = 1",
+                      XPathConstants.BOOLEAN, Map(REQUEST_VAR->req2)).asInstanceOf[Boolean])
+
+    assert(getVarPath("$request?headers?foo = 'baz'",
+                      XPathConstants.BOOLEAN, Map(REQUEST_VAR->req2)).asInstanceOf[Boolean])
+
+    assert(getVarPath("empty($request?headers?*)",
+                       XPathConstants.BOOLEAN, Map(REQUEST_VAR->req3)).asInstanceOf[Boolean])
+
+    assert(getVarPath("empty($request?headers?*)",
+                       XPathConstants.BOOLEAN, Map(REQUEST_VAR->req4)).asInstanceOf[Boolean])
+
+
+  }
+
+  test("Mix access method, uri, headers") {
+    var req1 = new HttpServletRequestMap(request("GET", "/path/to/foo", "application/json", "null", false,
+                                                 Map[String,List[String]]("foo"->List("bar"),
+                                                                          "bIz"->List("baz","boom","bit"),
+                                                                          "x"->List("y"))))
+    var req2 = new HttpServletRequestMap(request("DELETE", "/path/to/bar", "application/json", "null", false,
+                                                 Map[String,List[String]]("FoO"->List("baz"))))
+
+    var req3 = new HttpServletRequestMap(request("PUT", "/yet/another/path.txt", "application/json", "null", false,
+                                                 Map[String,List[String]]()))
+
+    assert(getVarPath("""($request?method='GET') and ($request?uri='/path/to/foo') and ($request?headers?x = 'y')""",
+                      XPathConstants.BOOLEAN, Map(REQUEST_VAR->req1)).asInstanceOf[Boolean])
+
+    assert(getVarPath("""($request?method='DELETE') and ($request?uri='/path/to/bar') and ($request?headers?foo = 'baz')""",
+                      XPathConstants.BOOLEAN, Map(REQUEST_VAR->req2)).asInstanceOf[Boolean])
+
+    assert(getVarPath("""($request?method='PUT') and ($request?uri='/yet/another/path.txt') and (empty($request?headers?*))""",
+                      XPathConstants.BOOLEAN, Map(REQUEST_VAR->req3)).asInstanceOf[Boolean])
+
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/servlet/RequestResponseSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/servlet/RequestResponseSuite.scala
@@ -136,8 +136,8 @@ class RequestResponseSuite extends BaseValidatorSuite {
     wrapper.addHeader("Foo", "Baz")
     wrapper.addHeader("Moo", "Baz")
     val headers = wrapper.getHeaderNames
-    assert(headers.nextElement() == "Foo")
-    assert(headers.nextElement() == "Moo")
+    assert(headers.nextElement() == "foo")
+    assert(headers.nextElement() == "moo")
   }
 
   test("Ensure getHeaderNames continues to send null if the original request sends null because of security") {

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/step/StepSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/step/StepSuite.scala
@@ -6815,4 +6815,179 @@ class StepSuite extends BaseStepSuite with MockitoSugar {
     assert (!req2.contentError.getMessage.contains("\n"))
   }
 
+  test ("In an Assert test if an XPath validates then a step context should be returned (checking method)") {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val assertStep = new Assert("Assert","Assert", "$req:method = 'GET'", None, None, nsContext, 31, 10, Array[Step]())
+    val req1 = request("GET", "/a/b")
+    val req2 = request("GET", "/a/c")
+
+    assert(assertStep.checkStep(req1, response, chain, StepContext()).isDefined)
+    assert(assertStep.checkStep(req2, response, chain, StepContext(1)).isDefined)
+  }
+
+  test ("In an Assert test if an XPath validates then a the content error priorisy should be -1") {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val assertStep = new Assert("Assert","Assert", "$req:method = 'GET'", None, None, nsContext, 31, 10, Array[Step]())
+    val req1 = request("GET", "/a/b")
+    val req2 = request("GET", "/a/c")
+
+    assertStep.checkStep(req1, response, chain, StepContext())
+    assertStep.checkStep(req2, response, chain, StepContext(1))
+
+    assert (req1.contentErrorPriority == -1)
+    assert (req2.contentErrorPriority == -1)
+  }
+
+  test ("In an Assert test if an XPath does not validates then a step context should be empty (checking method)") {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val assertStep = new Assert("Assert","Assert", "$req:method = 'GET'", None, None, nsContext, 31, 10, Array[Step]())
+    val req1 = request("DELETE", "/a/b")
+    val req2 = request("PUT", "/a/c")
+
+    assert(assertStep.checkStep(req1, response, chain, StepContext()).isEmpty)
+    assert(assertStep.checkStep(req2, response, chain, StepContext(1)).isEmpty)
+  }
+
+  test ("In an Assert test if an XPath does not validates then the error priority should be set (checking method)") {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val assertStep = new Assert("Assert","Assert", "$req:method = 'GET'", None, None, nsContext, 31, 10, Array[Step]())
+    val req1 = request("DELETE", "/a/b")
+    val req2 = request("PUT", "/a/c")
+
+    assertStep.checkStep(req1, response, chain, StepContext())
+    assertStep.checkStep(req2, response, chain, StepContext(1))
+
+    assert (req1.contentErrorPriority == 10)
+    assert (req2.contentErrorPriority == 10)
+  }
+
+  test ("In an Assert test if an XPath does not validate then the request should contain a SAXParseException") {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val assertStep = new Assert("Assert","Assert", "$req:method = 'GET'", None, None, nsContext, 31, 10, Array[Step]())
+    val req1 = request("DELETE", "/a/b")
+    val req2 = request("PUT", "/a/c")
+
+    assertStep.checkStep(req1, response, chain, StepContext())
+    assertStep.checkStep(req2, response, chain, StepContext(1))
+
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[SAXParseException])
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[SAXParseException])
+  }
+
+
+  test ("In an Assert test if an XPath does not validate then the request should contain a SAXParseException with message of 'Expecting '+XPath") {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val assertStep = new Assert("Assert","Assert", "$req:method = 'GET'", None, None, nsContext, 31, 10, Array[Step]())
+    val req1 = request("DELETE", "/a/b")
+    val req2 = request("PUT", "/a/c")
+
+    assertStep.checkStep(req1, response, chain, StepContext())
+    assertStep.checkStep(req2, response, chain, StepContext(1))
+
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[SAXParseException])
+    assert (req1.contentError.getMessage.contains("Expecting $req:method = 'GET'"))
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[SAXParseException])
+    assert (req2.contentError.getMessage.contains("Expecting $req:method = 'GET'"))
+  }
+
+  test ("In an Assert test if an XPath does not validate then the request should contain an error code = 400") {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val assertStep = new Assert("Assert","Assert", "$req:method = 'GET'", None, None, nsContext, 31, 10, Array[Step]())
+    val req1 = request("DELETE", "/a/b")
+    val req2 = request("PUT", "/a/c")
+
+    assertStep.checkStep(req1, response, chain, StepContext())
+    assertStep.checkStep(req2, response, chain, StepContext(1))
+
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[SAXParseException])
+    assert (req1.contentError.getMessage.contains("Expecting $req:method = 'GET'"))
+    assert (req1.contentErrorCode == 400)
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[SAXParseException])
+    assert (req2.contentError.getMessage.contains("Expecting $req:method = 'GET'"))
+    assert (req2.contentErrorCode == 400)
+  }
+
+  test ("In an Assert test if an XPath does not validate then the request should contain a SAXParseException with message of setMessage") {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val assertStep = new Assert("Assert","Assert", "$req:method = 'GET'", Some("Expecting a GET Method"), None, nsContext, 31, 10, Array[Step]())
+    val req1 = request("DELETE", "/a/b")
+    val req2 = request("PUT", "/a/c")
+
+    assertStep.checkStep(req1, response, chain, StepContext())
+    assertStep.checkStep(req2, response, chain, StepContext(1))
+
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[SAXParseException])
+    assert (req1.contentError.getMessage.contains("Expecting a GET Method"))
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[SAXParseException])
+    assert (req2.contentError.getMessage.contains("Expecting a GET Method"))
+  }
+
+
+  test ("In an Assert test if an XPath does not validate then the request should contain an error code of setError Code") {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val assertStep = new Assert("Assert","Assert", "$req:method = 'GET'", None, Some(401), nsContext, 31, 10, Array[Step]())
+    val req1 = request("DELETE", "/a/b")
+    val req2 = request("PUT", "/a/c")
+
+    assertStep.checkStep(req1, response, chain, StepContext())
+    assertStep.checkStep(req2, response, chain, StepContext(1))
+
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[SAXParseException])
+    assert (req1.contentError.getMessage.contains("Expecting $req:method = 'GET'"))
+    assert (req1.contentErrorCode == 401)
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[SAXParseException])
+    assert (req2.contentError.getMessage.contains("Expecting $req:method = 'GET'"))
+    assert (req2.contentErrorCode == 401)
+  }
+
+
+  test ("In an Assert test if an XPath does not validate then the request should contain an error message of setMessage  and an code of setError Code") {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val assertStep = new Assert("Assert","Assert", "$req:method = 'GET'", Some("Expecting GET Method"), Some(401), nsContext, 31, 10, Array[Step]())
+    val req1 = request("DELETE", "/a/b")
+    val req2 = request("PUT", "/a/c")
+
+    assertStep.checkStep(req1, response, chain, StepContext())
+    assertStep.checkStep(req2, response, chain, StepContext(1))
+
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[SAXParseException])
+    assert (req1.contentError.getMessage.contains("Expecting GET Method"))
+    assert (req1.contentErrorCode == 401)
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[SAXParseException])
+    assert (req2.contentError.getMessage.contains("Expecting GET Method"))
+    assert (req2.contentErrorCode == 401)
+  }
+
+  test ("In an Assert test if an XPath does not validate then the request should contain an error message of setMessage  and an code of setError Code,  setPriority") {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val assertStep = new Assert("Assert","Assert", "$req:method = 'GET'", Some("Expecting GET Method"), Some(401), nsContext, 31, 50, Array[Step]())
+    val req1 = request("DELETE", "/a/b")
+    val req2 = request("PUT", "/a/c")
+
+    assertStep.checkStep(req1, response, chain, StepContext())
+    assertStep.checkStep(req2, response, chain, StepContext(1))
+
+    assert (req1.contentError != null)
+    assert (req1.contentError.isInstanceOf[SAXParseException])
+    assert (req1.contentError.getMessage.contains("Expecting GET Method"))
+    assert (req1.contentErrorCode == 401)
+    assert (req1.contentErrorPriority == 50)
+    assert (req2.contentError != null)
+    assert (req2.contentError.isInstanceOf[SAXParseException])
+    assert (req2.contentError.getMessage.contains("Expecting GET Method"))
+    assert (req2.contentErrorCode == 401)
+    assert (req2.contentErrorPriority == 50)
+  }
 }

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
@@ -142,6 +142,22 @@ class BaseCheckerSpec extends BaseWADLSpec with LazyLogging {
     stepsWithJsonXPathMessageMatch(checker, xpathMatch, message).filter (n => (n \ "@code").text == code.toString)
   }
 
+  def stepsWithAssertMatch (checker : NodeSeq, xpathMatch : String) : NodeSeq = {
+    stepsWithMatch (checker, xpathMatch).filter(n => (n \ "@type").text == "ASSERT")
+  }
+
+  def stepsWithAssertMessageMatch (checker : NodeSeq, xpathMatch : String, message : String) : NodeSeq = {
+    stepsWithAssertMatch(checker, xpathMatch).filter (n => (n \ "@message").text == message)
+  }
+
+  def stepsWithAssertCodeMatch (checker : NodeSeq, xpathMatch : String, code : Int) : NodeSeq = {
+    stepsWithAssertMatch(checker, xpathMatch).filter (n => (n \ "@code").text == code.toString)
+  }
+
+  def stepsWithAssertMessageCodeMatch (checker : NodeSeq, xpathMatch : String, message : String, code : Int) : NodeSeq = {
+    stepsWithAssertMessageMatch(checker, xpathMatch, message).filter (n => (n \ "@code").text == code.toString)
+  }
+
   def stepsWithMethodMatch (checker : NodeSeq, methodMatch  : String) : NodeSeq = {
     stepsWithMatch (checker, methodMatch).filter(n => (n \ "@type").text == "METHOD")
   }
@@ -374,6 +390,10 @@ class BaseCheckerSpec extends BaseWADLSpec with LazyLogging {
   def JsonXPath(expression: String, message : String) : (NodeSeq) => NodeSeq = stepsWithJsonXPathMessageMatch(_, expression, message)
   def JsonXPath(expression: String, code : Int) : (NodeSeq) => NodeSeq = stepsWithJsonXPathCodeMatch(_, expression, code)
   def JsonXPath(expression: String, message : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithJsonXPathMessageCodeMatch(_, expression, message, code)
+  def RaxAssert(expression : String) : (NodeSeq) => NodeSeq = stepsWithAssertMatch(_, expression)
+  def RaxAssert(expression : String, message : String) : (NodeSeq) => NodeSeq = stepsWithAssertMessageMatch(_, expression, message)
+  def RaxAssert(expression : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithAssertCodeMatch(_, expression, code)
+  def RaxAssert(expression : String, message : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithAssertMessageCodeMatch(_, expression, message, code)
   def ReqType(reqType : String) : (NodeSeq) => NodeSeq = stepsWithReqTypeMatch (_, "(?i)"+reqType)
   def AnyReqType : (NodeSeq) => NodeSeq = stepsWithReqTypeMatch (_, "(.*)()")
   def HeaderWithCapture(name : String, headerMatch : String, captureHeader : String) : (NodeSeq) => NodeSeq = stepsWithHeaderMatchCapture(_, name, headerMatch, captureHeader)

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerAssertStepSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerAssertStepSpec.scala
@@ -1,0 +1,964 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import com.rackspace.com.papi.components.checker.{LogAssertions, TestConfig}
+import org.apache.logging.log4j.Level
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml._
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerAssertStepSpec extends BaseCheckerSpec with LogAssertions {
+  //
+  //  Register some common prefixes, you'll need the for XPath
+  //  assertions.
+  //
+  register ("xsd", "http://www.w3.org/2001/XMLSchema")
+  register ("wadl","http://wadl.dev.java.net/2009/02")
+  register ("xsl","http://www.w3.org/1999/XSL/Transform")
+  register ("chk","http://www.rackspace.com/repose/wadl/checker")
+  register ("tst","http://www.rackspace.com/repose/wadl/checker/step/test")
+
+
+  //
+  //  Configs...
+  //
+
+  val assertDisabled = {
+    val tc = TestConfig()
+    tc.enableAssertExtension = false
+    tc.removeDups = false
+    tc
+  }
+
+  val assertEnabled = {
+    val tc = TestConfig()
+    tc.enableAssertExtension = true
+    tc.removeDups = false
+    tc
+  }
+
+  val assertEnabledRemoveDups = {
+    val tc = TestConfig()
+    tc.enableAssertExtension = true
+    tc.removeDups = true
+    tc
+  }
+
+  //
+  // WADLs...
+  //
+  val assertAtMethodLevel =
+            <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <rax:assert test="req:header('X-AUTH') = 'foo!'"/>
+                  </request>
+               </method>
+            </resource>
+           </resources>
+          </application>
+
+  val assertAtMethodMultiRep =
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                    <rax:assert test="req:header('X-AUTH') = 'foo!'"/>
+                  </request>
+               </method>
+            </resource>
+           </resources>
+          </application>
+
+  val assertAtResourceLevel =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                    <rax:assert test="req:header('X-AUTH') = 'foo!'"/>
+                  </request>
+               </method>
+               <method name="PUT">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                  </request>
+               </method>
+               <resource path="c">
+                   <method name="GET">
+                   </method>
+                   <method name="POST">
+                    <request>
+                      <representation mediaType="application/xml"/>
+                      <representation mediaType="application/json"/>
+                      <representation mediaType="text/x-yaml"/>
+                    </request>
+                   </method>
+                   <method name="PUT">
+                     <request>
+                       <representation mediaType="application/xml"/>
+                       <representation mediaType="application/json"/>
+                       <representation mediaType="text/x-yaml"/>
+                     </request>
+                   </method>
+               </resource>
+               <rax:assert test="contains($req:uri,'/a')"/>
+            </resource>
+           </resources>
+          </application>
+
+  val assertAtResourceLevelApplyChildrenFalse =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                    <rax:assert test="req:header('X-AUTH') = 'foo!'"/>
+                  </request>
+               </method>
+               <method name="PUT">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                  </request>
+               </method>
+               <resource path="c">
+                   <method name="GET">
+                   </method>
+                   <method name="POST">
+                    <request>
+                      <representation mediaType="application/xml"/>
+                      <representation mediaType="application/json"/>
+                      <representation mediaType="text/x-yaml"/>
+                    </request>
+                   </method>
+                   <method name="PUT">
+                     <request>
+                       <representation mediaType="application/xml"/>
+                       <representation mediaType="application/json"/>
+                       <representation mediaType="text/x-yaml"/>
+                     </request>
+                   </method>
+               </resource>
+               <rax:assert test="contains($req:uri,'/a')" applyToChildren="false"/>
+            </resource>
+           </resources>
+          </application>
+
+  val assertAtResourceLevelApplyChildrenTrue =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                    <rax:assert test="req:header('X-AUTH') = 'foo!'"/>
+                  </request>
+               </method>
+               <method name="PUT">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                  </request>
+               </method>
+               <resource path="c">
+                   <method name="GET">
+                   </method>
+                   <method name="POST">
+                    <request>
+                      <representation mediaType="application/xml"/>
+                      <representation mediaType="application/json"/>
+                      <representation mediaType="text/x-yaml"/>
+                    </request>
+                   </method>
+                   <method name="PUT">
+                     <request>
+                       <representation mediaType="application/xml"/>
+                       <representation mediaType="application/json"/>
+                       <representation mediaType="text/x-yaml"/>
+                     </request>
+                   </method>
+               </resource>
+               <rax:assert test="contains($req:uri,'/a')" applyToChildren="true"/>
+            </resource>
+           </resources>
+          </application>
+
+
+  val assertAtResourceLevelApplyChildrenTrueRepAsserts =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml">
+                      <rax:assert test="'text/x-yaml' = req:headers('Accept', true())"/>
+                    </representation>
+                    <rax:assert test="req:header('X-AUTH') = 'foo!'"/>
+                  </request>
+               </method>
+               <method name="PUT">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                  </request>
+               </method>
+               <resource path="c">
+                   <method name="GET">
+                   </method>
+                   <method name="POST">
+                    <request>
+                      <representation mediaType="application/xml"/>
+                      <representation mediaType="application/json"/>
+                      <representation mediaType="text/x-yaml"/>
+                    </request>
+                   </method>
+                   <method name="PUT">
+                     <request>
+                       <representation mediaType="application/xml"/>
+                       <representation mediaType="application/json">
+                            <rax:assert test="'application/json' = req:headers('Accept', true())"/>
+                       </representation>
+                       <representation mediaType="text/x-yaml"/>
+                     </request>
+                   </method>
+               </resource>
+               <rax:assert test="contains($req:uri,'/a')" applyToChildren="true"/>
+            </resource>
+           </resources>
+          </application>
+
+  val assertAtResourceLevelApplyChildrenTrueRepResourcesAsserts =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml">
+                      <rax:assert test="'text/x-yaml' = req:headers('Accept', true())"/>
+                    </representation>
+                    <rax:assert test="req:header('X-AUTH') = 'foo!'"  message="Not auth to send X-AUTH unless it's 'foo!'" code="403"/>
+                  </request>
+               </method>
+               <method name="PUT">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                  </request>
+               </method>
+               <resource path="c">
+                   <method name="GET">
+                   </method>
+                   <method name="POST">
+                    <request>
+                      <representation mediaType="application/xml"/>
+                      <representation mediaType="application/json"/>
+                      <representation mediaType="text/x-yaml"/>
+                    </request>
+                   </method>
+                   <method name="PUT">
+                     <request>
+                       <representation mediaType="application/xml"/>
+                       <representation mediaType="application/json">
+                            <rax:assert test="'application/json' = req:headers('Accept', true())" message="You should specify JSON!"/>
+                       </representation>
+                       <representation mediaType="text/x-yaml"/>
+                     </request>
+                   </method>
+               </resource>
+               <rax:assert test="contains($req:uri,'/a')" applyToChildren="true"/>
+            </resource>
+            <rax:assert test="not(empty($req:uri))"/>
+           </resources>
+          </application>
+
+  feature ("The WADLCheckerBuilder can correctly transforma a WADL into checker format") {
+
+    info ("As a developer")
+    info ("I want to be able to transform a WADL which references rax:assert extensions into a ")
+    info ("a description of a machine that can validate the API in checker format")
+    info ("so that an API validator can process the checker format to validate the API")
+
+    scenario ("The WADL contains a misplaced rax:assert") {
+      Given("A WADL with a misplaced rax:assert")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                  </request>
+                  <!-- Notice accert at method level, but not request level -->
+                  <rax:assert test="req:header('X-AUTH') = 'foo!'"/>
+               </method>
+            </resource>
+           </resources>
+          </application>
+
+      When("the wadl is translated")
+      val checkerLog = log (Level.WARN) {
+        val checker = builder.build (inWADL, assertEnabled)
+        Then("No asserts should exist in the checker format")
+        assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 0")
+      }
+      And ("There should be a warning in the log that denotes that denotes the bad placement")
+      assert(checkerLog, "bad placement for <rax:assert")
+      assert(checkerLog, "req:header('X-AUTH') = 'foo!'")
+    }
+
+    scenario ("The WADL contains a method with a rax:assert at the request level (rax:assert disabled)") {
+      Given("A WADL with a GET operation with a rax:assert at the request level, but rax:assert disabled")
+      val inWADL = assertAtMethodLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), Accept)
+    }
+
+    scenario ("The WADL contains a method with a rax:assert at the request level (rax:assert enabled)") {
+      Given("A WADL with a GET operation with a rax:assert at the request level, but rax:assert enabled")
+      val inWADL = assertAtMethodLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 1")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), RaxAssert("req:header('X-AUTH') = 'foo!'"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ContentFail)
+    }
+
+    scenario ("The WADL contains a method with a rax:assert at the request level, XML, JSON, and YAML representations (rax:assert disabled)") {
+      Given("A WADL with a GET operation with a rax:assert at the request level, but rax:assert disabled")
+      val inWADL = assertAtMethodMultiRep
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a method with a rax:assert at the request level, XML, JSON, and YAML representations (rax:assert enabled)") {
+      Given("A WADL with a GET operation with a rax:assert at the request level, but rax:assert enabled")
+      val inWADL = assertAtMethodMultiRep
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 3")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("req:header('X-AUTH') = 'foo!'"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("req:header('X-AUTH') = 'foo!'"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("req:header('X-AUTH') = 'foo!'"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+    }
+
+    scenario ("The WADL contains a method with a rax:assert at the request level, XML, JSON, and YAML representations (rax:assert enabled, remove dups)") {
+      Given("A WADL with a GET operation with a rax:assert at the request level, but rax:assert enabled, remove dups")
+      val inWADL = assertAtMethodMultiRep
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 1")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("req:header('X-AUTH') = 'foo!'"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("req:header('X-AUTH') = 'foo!'"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("req:header('X-AUTH') = 'foo!'"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert disabled)") {
+      Given("A WADL with a rax:assert at the resource level, but rax:assert disabled")
+      val inWADL = assertAtResourceLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert enabled)") {
+      Given("A WADL with a with a rax:assert at the resource level, but rax:assert enabled")
+      val inWADL = assertAtResourceLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 9")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert enabled, removedups)") {
+      Given("A WADL with a rax:assert at the resource level, but rax:assert enabled, removedups")
+      val inWADL = assertAtResourceLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 2")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert disabled, applyChildrenFalse)") {
+      Given("A WADL with a rax:assert at the request level, but rax:assert disabled, applyChildrenFalse")
+      val inWADL = assertAtResourceLevelApplyChildrenFalse
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert enabled, applyChildrenFalse)") {
+      Given("A WADL with a rax:assert at the resource level, but rax:assert enabled applyChldernFalse")
+      val inWADL = assertAtResourceLevelApplyChildrenFalse
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 9")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert enabled, removedups, applyChildrenFalse)") {
+      Given("A WADL with a rax:assert at the resource level, but rax:assert enabled applyChldrenFalse")
+      val inWADL = assertAtResourceLevelApplyChildrenFalse
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 2")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert disabled, applyChildrenTrue)") {
+      Given("A WADL with a rax:assert at the resource level, but rax:assert disabled applyChlidrenTrue")
+      val inWADL = assertAtResourceLevelApplyChildrenTrue
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert enabled, applyChildrenTrue)") {
+      Given("A WADL with a rax:assert at the resource level applyChildernTrue")
+      val inWADL = assertAtResourceLevelApplyChildrenTrue
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 16")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxAssert("contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert enabled, removedups, applyChildrenTrue)") {
+      Given("A WADL with a rax:assert at the request level, but rax:assert enabled, removeDups, and applyChlidrenTrue")
+      val inWADL = assertAtResourceLevelApplyChildrenTrue
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 2")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxAssert("contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert disabled, applyChildrenTrue, asserts at representation)") {
+      Given("A WADL with a rax:assert at the resource level, but rax:assert disabled applyChlidrenTrue, and asserts at representation")
+      val inWADL = assertAtResourceLevelApplyChildrenTrueRepAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert enabled, applyChildrenTrue, asserts at representation)") {
+      Given("A WADL with a rax:assert at the resource level, but rax:assert enabled applyChlidrenTrue, and asserts at representation")
+      val inWADL = assertAtResourceLevelApplyChildrenTrueRepAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 18")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("'text/x-yaml' = req:headers('Accept', true())"),
+             RaxAssert("req:header('X-AUTH') = 'foo!'"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxAssert("contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxAssert("'application/json' = req:headers('Accept', true())"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert enabled, applyChildrenTrue, asserts at representation, removeDups)") {
+      Given("A WADL with a rax:assert at the resource level, but rax:assert enabled applyChlidrenTrue, and asserts at representation with removeDups")
+      val inWADL = assertAtResourceLevelApplyChildrenTrueRepAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 4")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("req:header('X-AUTH') = 'foo!'"),
+             RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("'text/x-yaml' = req:headers('Accept', true())"),
+             RaxAssert("req:header('X-AUTH') = 'foo!'"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxAssert("contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxAssert("'application/json' = req:headers('Accept', true())"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert disabled, applyChildrenTrue, asserts at representation and resources level)") {
+      Given("A WADL with a rax:assert at the resource level, but rax:assert disabled applyChlidrenTrue, and asserts at representation and resources level")
+      val inWADL = assertAtResourceLevelApplyChildrenTrueRepResourcesAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert enabled, applyChildrenTrue, asserts at representation and resources level)") {
+      Given("A WADL with a rax:assert at the resource level, but rax:assert enabled applyChlidrenTrue, and asserts at representation and resources level")
+      val inWADL = assertAtResourceLevelApplyChildrenTrueRepResourcesAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 31")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML,
+             RaxAssert("req:header('X-AUTH') = 'foo!'","Not auth to send X-AUTH unless it's 'foo!'", 403),
+             RaxAssert("contains($req:uri,'/a')"), RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxAssert("req:header('X-AUTH') = 'foo!'","Not auth to send X-AUTH unless it's 'foo!'", 403),
+             RaxAssert("contains($req:uri,'/a')"), RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("'text/x-yaml' = req:headers('Accept', true())"),
+             RaxAssert("req:header('X-AUTH') = 'foo!'","Not auth to send X-AUTH unless it's 'foo!'", 403),
+             RaxAssert("contains($req:uri,'/a')"), RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxAssert("contains($req:uri,'/a')"), RaxAssert("not(empty($req:uri))"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxAssert("'application/json' = req:headers('Accept', true())","You should specify JSON!"),
+             RaxAssert("contains($req:uri,'/a')"), RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+    }
+
+    scenario ("The WADL contains a resource with a rax:assert at the resource level, XML, JSON, and YAML representations in methods (rax:assert enabled, applyChildrenTrue, asserts at representation and resources level, remove Dups on)") {
+      Given("A WADL with a rax:assert at the resource level, but rax:assert enabled applyChlidrenTrue, and asserts at representation and resources level remove Dups on")
+      val inWADL = assertAtResourceLevelApplyChildrenTrueRepResourcesAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, assertEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='ASSERT']) = 5")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML,
+             RaxAssert("req:header('X-AUTH') = 'foo!'","Not auth to send X-AUTH unless it's 'foo!'", 403),
+             RaxAssert("contains($req:uri,'/a')"), RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxAssert("req:header('X-AUTH') = 'foo!'","Not auth to send X-AUTH unless it's 'foo!'", 403),
+             RaxAssert("contains($req:uri,'/a')"), RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("'text/x-yaml' = req:headers('Accept', true())"),
+             RaxAssert("req:header('X-AUTH') = 'foo!'","Not auth to send X-AUTH unless it's 'foo!'", 403),
+             RaxAssert("contains($req:uri,'/a')"), RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxAssert("contains($req:uri,'/a')"), RaxAssert("not(empty($req:uri))"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxAssert("'application/json' = req:headers('Accept', true())","You should specify JSON!"),
+             RaxAssert("contains($req:uri,'/a')"), RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, ContentFail)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxAssert("contains($req:uri,'/a')"),
+             RaxAssert("not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), ContentFail)
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <scala.test.version>2.2.6</scala.test.version>
         <scala.uri.version>0.4.2</scala.uri.version>
         <junit.version>4.10</junit.version>
-        <wadl-tools.version>1.0.35</wadl-tools.version>
+        <wadl-tools.version>1.0.36</wadl-tools.version>
         <xmlsec.version>1.4.6</xmlsec.version>
         <xerces.version>2.12.1-rax</xerces.version>
         <servlet.version>3.1</servlet.version>

--- a/util/src/main/scala/com/rackspace/com/papi/compenents/checker/util/HeaderMap.scala
+++ b/util/src/main/scala/com/rackspace/com/papi/compenents/checker/util/HeaderMap.scala
@@ -27,7 +27,7 @@ class HeaderMap private (val headers : TreeMap[String, List[String]])
   def this() = this(new TreeMap[String, List[String]]()(CaseInsensitiveStringOrdering))
 
   def addHeader (name : String, value : String) : HeaderMap = {
-    new HeaderMap(headers + (name -> (headers.getOrElse(name, List()) :+ value)))
+    new HeaderMap(headers + (name.toLowerCase -> (headers.getOrElse(name, List()) :+ value)))
   }
 
   def removeHeader (name : String, value : String) : HeaderMap = {
@@ -41,7 +41,7 @@ class HeaderMap private (val headers : TreeMap[String, List[String]])
   }
 
   def addHeaders (name : String, values : List[String]) : HeaderMap = {
-    new HeaderMap(headers + (name -> (headers.getOrElse(name, List()) ::: values)))
+    new HeaderMap(headers + (name.toLowerCase -> (headers.getOrElse(name, List()) ::: values)))
   }
 
   def addHeaders (otherHeaders : HeaderMap) : HeaderMap = {

--- a/util/src/main/scala/com/rackspace/com/papi/compenents/checker/util/ImmutableNamespaceContext.scala
+++ b/util/src/main/scala/com/rackspace/com/papi/compenents/checker/util/ImmutableNamespaceContext.scala
@@ -89,6 +89,8 @@ class ImmutableNamespaceContext private (private val inputNS : scala.collection.
     }
   }
 
+  def getAllPrefixes = prefixToURI.keySet
+
   //
   //  Borrow toString, hashCode, and equals from our immutable
   //  namespace map.

--- a/util/src/main/scala/com/rackspace/com/papi/compenents/checker/util/XQueryEvaluatorPool.scala
+++ b/util/src/main/scala/com/rackspace/com/papi/compenents/checker/util/XQueryEvaluatorPool.scala
@@ -1,0 +1,66 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.util
+
+import com.codahale.metrics.{Gauge, MetricRegistry}
+import org.apache.commons.pool.PoolableObjectFactory
+import org.apache.commons.pool.impl.SoftReferenceObjectPool
+
+import scala.collection.mutable.{HashMap, MutableList, Map}
+
+import net.sf.saxon.s9api.XQueryExecutable
+import net.sf.saxon.s9api.XQueryEvaluator
+
+object XQueryEvaluatorPool extends Instrumented {
+
+  private val evaluators : Map[String, SoftReferenceObjectPool[XQueryEvaluator]] = new HashMap[String,
+                                                                                               SoftReferenceObjectPool[XQueryEvaluator]]
+
+  private val activeGauges = new MutableList[Gauge[Int]]
+  private val idleGauges = new MutableList[Gauge[Int]]
+
+  private def addXQueryEvaluatorPool(expression : String, exec : XQueryExecutable) : SoftReferenceObjectPool[XQueryEvaluator] = {
+    val pool = new SoftReferenceObjectPool[XQueryEvaluator](new XQueryEvaluatorFactory(exec))
+    val registryClassName = getRegistryClassName(getClass)
+    activeGauges :+ gaugeOrAdd(MetricRegistry.name(registryClassName, "Active", expression))(pool.getNumActive)
+    idleGauges :+ gaugeOrAdd(MetricRegistry.name(registryClassName, "Idle", expression))(pool.getNumIdle)
+    pool
+  }
+
+  def borrowEvaluator (expression : String, exec : XQueryExecutable) : XQueryEvaluator = {
+    evaluators.getOrElseUpdate(expression, addXQueryEvaluatorPool(expression, exec)).borrowObject
+  }
+
+  def returnEvaluator(expression : String, evaluator : XQueryEvaluator) : Unit = {
+    evaluators(expression).returnObject(evaluator)
+  }
+
+  def numActive (expression : String) : Int = {
+    evaluators(expression).getNumActive
+  }
+
+  def numIdle (expression : String) : Int = {
+    evaluators(expression).getNumIdle
+  }
+}
+
+private class XQueryEvaluatorFactory (val exec : XQueryExecutable) extends PoolableObjectFactory[XQueryEvaluator] {
+  def makeObject = exec.load()
+  def validateObject  (xe : XQueryEvaluator) : Boolean = xe != null
+  def passivateObject (xe : XQueryEvaluator) : Unit = { /* Ignore */ }
+  def activateObject (xe : XQueryEvaluator) : Unit = { /* Ignore */ }
+  def destroyObject (xe : XQueryEvaluator) : Unit = { /* Ignore */ }
+}

--- a/util/src/test/scala/com/rackspace/com/papi/components/checker/util/XQueryEvaluatorPoolSuite.scala
+++ b/util/src/test/scala/com/rackspace/com/papi/components/checker/util/XQueryEvaluatorPoolSuite.scala
@@ -1,0 +1,81 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.util
+
+import net.sf.saxon.s9api.Processor
+import net.sf.saxon.s9api.XQueryEvaluator
+import net.sf.saxon.s9api.XQueryExecutable
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class XQueryEvaluatorPoolSuite extends FunSuite {
+
+  private val processor   = new Processor(false)
+  private val compiler    = {
+    val c = processor.newXQueryCompiler()
+    c.setLanguageVersion("3.1")
+    c
+  }
+  private val query = "/xq/load-json.xq"
+  private val executable  = compiler.compile(getClass.getResourceAsStream(query))
+
+
+  test("The xquery pool should successfully create an xquery evaluator") {
+    var evaluator : XQueryEvaluator = null
+    try {
+      evaluator = XQueryEvaluatorPool.borrowEvaluator(query, executable)
+      assert (evaluator != null)
+    }finally {
+      if (evaluator != null) XQueryEvaluatorPool.returnEvaluator(query, evaluator)
+    }
+  }
+
+  test("NumIdle should not be zero soon after returning an evaluator") {
+    var evaluator : XQueryEvaluator = null
+    try {
+      evaluator = XQueryEvaluatorPool.borrowEvaluator(query, executable)
+      assert (evaluator != null)
+    }finally {
+      if (evaluator != null) XQueryEvaluatorPool.returnEvaluator(query, evaluator)
+      assert(XQueryEvaluatorPool.numIdle(query) != 0)
+    }
+  }
+
+  test("NumActive should increase/decrease as we borrow/return new evaluators") {
+    val NUM_INCREASE = 5
+
+    val initActive = XQueryEvaluatorPool.numActive(query)
+    val initIdle   = XQueryEvaluatorPool.numIdle(query)
+
+    val evaluators = new Array[XQueryEvaluator](NUM_INCREASE)
+    for (i <- 0 to NUM_INCREASE-1) {
+      evaluators(i) = XQueryEvaluatorPool.borrowEvaluator(query, executable)
+    }
+
+    assert (XQueryEvaluatorPool.numActive(query) >= initActive+NUM_INCREASE)
+
+    val fullActive = XQueryEvaluatorPool.numActive(query)
+
+    for (i <- 0 to NUM_INCREASE-1) {
+      XQueryEvaluatorPool.returnEvaluator (query, evaluators(i))
+    }
+
+    assert (XQueryEvaluatorPool.numActive(query) <= fullActive-NUM_INCREASE)
+  }
+}


### PR DESCRIPTION
...works like XSD assert.  At the resource level and method level. Use XPath 3.1, pass request as input parameter map...

Ideas : use scala magic to create a proxy that looks like a map but dynamically reaches into the HTTP Servlet Request
