### PR TITLE
Fixed issue where priority of content type error states is off.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,7 @@
    1. WADLDotBuilder has always only worked with ```StreamResult```s (other ```Result``` types failed) this is now made explicit with the interface.
 1. Added support for ```rax:assert```, this allows setting XPath 3.1 assertions at the method request, representation, resource, and resources level.
    These assertions can simultaneously introspect headers, uri, methods, and body content (xml or json).
+1. Adjusted the priority of content type error steps to ensure content type errors are reported correctly.
 
 ## Release 2.1.1 (2017-01-27) ##
 1. Fixed a bug where a resource file needed by checker-util was kept in checker-core

--- a/core/src/main/resources/xsl/priority-map.xml
+++ b/core/src/main/resources/xsl/priority-map.xml
@@ -31,7 +31,6 @@
 <priority-map xmlns="http://www.rackspace.com/repose/wadl/checker/priority">
     <map type="URL_FAIL"      priority="10000" attributeMultipliers="notMatch notTypes" multValue="50"/>
     <map type="METHOD_FAIL"   priority="20000" attributeMultipliers="notMatch" multValue="50"/>
-    <map type="REQ_TYPE_FAIL" priority="30000"/>
     <map type="CONTENT_FAIL"  priority="40000"/>
     <map type="HEADER"        priority="41000"/>
     <map type="HEADERXSD"     priority="41000"/>
@@ -40,13 +39,14 @@
     <map type="HEADER_ANY"    priority="41000"/>
     <map type="HEADERXSD_ANY" priority="41000"/>
     <map type="HEADER_ALL"    priority="41000"/>
-    <map type="WELL_XML"      priority="41000"/>
-    <map type="WELL_JSON"     priority="41000"/>
-    <map type="XPATH"         priority="41000"/>
-    <map type="JSON_XPATH"    priority="41000"/>
-    <map type="XSL"           priority="41000"/>
-    <map type="ASSERT"        priority="41000"/>
-    <map type="XSD"           priority="45000"/>
-    <map type="JSON_SCHEMA"   priority="45000"/>
+    <map type="REQ_TYPE_FAIL" priority="45000"/>
+    <map type="WELL_XML"      priority="50000"/>
+    <map type="WELL_JSON"     priority="50000"/>
+    <map type="XPATH"         priority="50000"/>
+    <map type="JSON_XPATH"    priority="50000"/>
+    <map type="XSL"           priority="50000"/>
+    <map type="ASSERT"        priority="50000"/>
+    <map type="XSD"           priority="55000"/>
+    <map type="JSON_SCHEMA"   priority="55000"/>
     <map type="ACCEPT"        priority="100000"/>
 </priority-map>


### PR DESCRIPTION
Content type errors should have higher priority than header errors,
lower priority than asserts.  Without this property bad content types
may be reported as access denied if rax:roles is used.