### PR TITLE
Updated the main POM to fix release issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,18 @@
                         <target>1.7</target>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.scm</groupId>
+                            <artifactId>maven-scm-provider-gitexe</artifactId>
+                            <version>1.9.4</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Now includes a specific combination of versions for the maven-release-plugin and maven-scm-provider-gitexe.

Taken from:
> https://stackoverflow.com/questions/15166781