### PR TITLE
Extend Capture Header extension so that it can stand alone

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,8 @@
 # Releases #
 ## In Progress Work ##
 1. Fixed a bug where rax:roles were not masked correctly if default headers were set.
+1. Added support for ```rax:captureHeader```, this allows setting XPath 3.1 paths at the method request, representation, resource, and resources
+   level to allow capturing a header with the result of the XPath. The XPaths can simultaneously introspect headers, uri, methods, and body content (xml or json).
 
 ## Release 2.2.1 (2017-05-24) ##
 1. Fixed a bug where we were not correctly setting the classloader.

--- a/TODO.org
+++ b/TODO.org
@@ -896,6 +896,34 @@
          8. [X] rax:message
          9. [X] JoinOpt
          10. [X] RemoveDups
+** TODO Extend Support for Capture Header to support standalone element [2/2]
+   1. [X] Add CaptureHeader Step [10/10]
+      1. [X] Extend XSD to support New Capture Header Step
+      2. [X] Extend / Generalize raxAssert.xsl to handle new Capture
+         Header Step
+      3. [X] Updated raxAssert call in checker builder
+      4. [X] Update builder to include Capture Header Step [3/3]
+         1. [X] Handle in method / request
+         2. [X] In representation other than XML or JSON :
+            (wadl:request/wadl:representation[@mediaType] template)
+         3. [X] In representation with XML or JSON (in
+            check:addWellForm template)
+      5. [X] Add step to priority map
+      6. [X] Check assertions related to capture header step
+      7. [X] Update WADL2Dot to display steps correctly
+      8. [X] Ensure optimizations work with the new step
+      9. [X] Create new step
+      10. [X] Update handler for new step
+   2. [X] Testing [3/3]
+      1. [X] Step
+      2. [X] Bulider
+      3. [X] Validator [6/6]
+         1. [X] At resources level
+         2. [X] At resource level
+         3. [X] At method level
+         4. [X] No representation
+         5. [X] XML / JSON representation
+         6. [X] Media types other than XML or JSON
 ** TODO Use Saxon Compile Lib feature to compile shared module.
    - This requires Saxon-EEQ
 ** TODO Compile Performance improvements

--- a/core/src/main/resources/xsd/checker.xsd
+++ b/core/src/main/resources/xsd/checker.xsd
@@ -116,6 +116,7 @@
                 <alternative test="@type eq 'JSON_SCHEMA'" type="chk:JsonSchemaStep"/>
                 <alternative test="@type eq 'JSON_XPATH'" type="chk:JsonXPathStep"/>
                 <alternative test="@type eq 'ASSERT'" type="chk:AssertStep"/>
+                <alternative test="@type eq 'CAPTURE_HEADER'" type="chk:CaptureHeaderStep"/>
             </element>
         </sequence>
         <assert test="if (count(chk:step[@type='START']) = 1) then true() else false()"
@@ -372,7 +373,11 @@
                             This step does not support
                             rax:captureHeader extension, since the
                             intent here is only to assert a t/f XPath
-                            assertion.
+                            assertion.  That said, there is a separate
+                            capture header step that provides a method
+                            for capturing a header and allows for
+                            XPaths as described in this step. See
+                            CaptureHeaderStep.
                         </html:li>
                     </html:ol>
                 </html:p>
@@ -395,6 +400,39 @@
                 <attribute name="match" type="xsd:string" use="required"/>
                 <attribute name="version" type="chk:XPathVersion" fixed="31" use="optional"/>
                 <attributeGroup ref="chk:MessageAttributes"/>
+            </extension>
+        </complexContent>
+    </complexType>
+
+    <complexType name="CaptureHeaderStep">
+        <annotation>
+            <documentation xmlns:html="http://www.w3.org/1999/xhtml">
+                <html:p>
+                    This step behaves almost exactly like AssertStep,
+                    but the key difference is that instead of
+                    expecting an XPath that returns an xsd:booleon,
+                    this XPath should return a collection of
+                    xs:strings. The strings are captured in a header
+                    denoted by the name attribute. The functions and
+                    variables available in this step are described
+                    in AssertStep.
+                </html:p>
+                <html:p>
+                    As with AssertStep the XPath version is fixed to
+                    be 3.1 since it's the only version that supports
+                    json.
+                </html:p>
+                <html:p>
+                    Since this step is not executing an assertion
+                    rax:message and rax:code extensions do not apply.
+                </html:p>
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="chk:ConnectedStep">
+                <attribute name="name" type="xsd:string" use="required"/>
+                <attribute name="path" type="xsd:string" use="required"/>
+                <attribute name="version" type="chk:XPathVersion" fixed="31" use="optional"/>
             </extension>
         </complexContent>
     </complexType>
@@ -920,6 +958,7 @@
             <enumeration value="JSON_SCHEMA"/>
             <enumeration value="JSON_XPATH" />
             <enumeration value="ASSERT"/>
+            <enumeration value="CAPTURE_HEADER"/>
         </restriction>
     </simpleType>
 

--- a/core/src/main/resources/xsl/checker2dot.xsl
+++ b/core/src/main/resources/xsl/checker2dot.xsl
@@ -175,6 +175,18 @@
                                                  </xsl:choose>
                                                  <xsl:text>)</xsl:text>
                                                </xsl:when>
+                                               <xsl:when test="$nextStep/@path">
+                                                 <xsl:text>ε (</xsl:text>
+                                                 <xsl:choose>
+                                                     <xsl:when test="$nextStep/@path">
+                                                         <xsl:value-of select="concat($nextStep/@name,':&#x2190; ',check:escapeRegex($nextStep/@path))"/>
+                                                     </xsl:when>
+                                                     <xsl:otherwise>
+                                                         <xsl:value-of select="check:matchValue($nextStep)"/>
+                                                     </xsl:otherwise>
+                                                 </xsl:choose>
+                                                 <xsl:text>)</xsl:text>
+                                               </xsl:when>
                                                <xsl:otherwise>
                                                    <xsl:call-template name="check:getErrorRegex">
                                                        <xsl:with-param name="nextStep" select="$nextStep"/>
@@ -213,6 +225,9 @@
                      </xsl:when>
                      <xsl:when test="@name and @value">
                          <xsl:value-of select="concat(@name,':&#x2190;? ',check:escapeRegex(@value))"/>
+                     </xsl:when>
+                     <xsl:when test="@name and @path">
+                         <xsl:value-of select="concat(@name,':&#x2190; ',check:escapeRegex(@path))"/>
                      </xsl:when>
                      <xsl:when test="@match or @matchRegEx">
                          <xsl:value-of select="check:matchValue(.)"/>

--- a/core/src/main/resources/xsl/opt/removeDups-rules.xml
+++ b/core/src/main/resources/xsl/opt/removeDups-rules.xml
@@ -39,6 +39,9 @@
     <rule types="ASSERT" required="next match" optional="version code message">
         Rule for Assert state.
     </rule>
+    <rule types="CAPTURE_HEADER" required="next name path" optional="version">
+        Rule for the capture header extension.
+    </rule>
     <rule types="HEADER HEADERXSD HEADER_ANY HEADERXSD_ANY HEADER_SINGLE HEADERXSD_SINGLE" required="next name match" optional="captureHeader code message">
         Rule for Header, HeaderXSD, HeaderAny.
     </rule>

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
@@ -265,10 +265,17 @@ class Config extends LazyLogging {
   var maskRaxRoles403 : Boolean = false
 
   //
-  //  Enable capture header extension.  This extension allows
-  //  capturing the contents of a WADL parameter to a request
-  //  header. Currently works with template, header, and XML plain
-  //  parameters.
+  //  Enable rax:captureHeader extension attribute.  This extension
+  //  allows capturing the contents of a WADL parameter to a request
+  //  header. Currently works with template, header, XML, and JSON
+  //  plain parameters.
+  //
+  //  Additionally, this enables the <rax:captureHeader/> element
+  //  which allows capturing a header based on an XPath 3.1. The XPath
+  //  follows the same rules as Assert XPath (see
+  //  enableAssertExtension), but expects a sequence of strings (which
+  //  are stored as header values) rather than a boolean.
+  //
   @BeanProperty
   @AffectsChecker
   var enableCaptureHeaderExtension : Boolean = true

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/XPathStepUtil.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/XPathStepUtil.scala
@@ -1,0 +1,287 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.step
+
+import javax.xml.transform.Source
+import javax.xml.transform.dom.DOMSource
+
+import com.rackspace.com.papi.components.checker.Config
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest
+import com.rackspace.com.papi.components.checker.step.base.StepContext
+
+import com.rackspace.com.papi.components.checker.util.ImmutableNamespaceContext
+import com.rackspace.com.papi.components.checker.util.XMLParserPool._
+
+import net.sf.saxon.expr.StaticProperty
+import net.sf.saxon.expr.instruct.UserFunctionParameter
+import net.sf.saxon.expr.parser.XPathParser
+
+import net.sf.saxon.sxpath.IndependentContext
+import net.sf.saxon.sxpath.XPathStaticContext
+
+import net.sf.saxon.om.StructuredQName
+import net.sf.saxon.om.GroundedValue
+import net.sf.saxon.om.Sequence
+
+import net.sf.saxon.s9api.Processor
+import net.sf.saxon.s9api.XQueryExecutable
+import net.sf.saxon.s9api.XQueryEvaluator
+import net.sf.saxon.s9api.QName
+import net.sf.saxon.s9api.XdmValue
+import net.sf.saxon.s9api.XdmEmptySequence
+
+import net.sf.saxon.query.XQueryFunctionLibrary
+import net.sf.saxon.query.XQueryFunction
+
+import net.sf.saxon.value.SequenceType
+import net.sf.saxon.functions.FunctionLibraryList
+import net.sf.saxon.`type`.BuiltInAtomicType
+
+import com.typesafe.scalalogging.slf4j.LazyLogging
+
+//
+//  This utility is used to execute XPaths on steps which have access
+//  to the current Request and the StepContext. Currently this
+//  includes the Assert step which is used to make XPath assertions
+//  and the CaptureHeader step which is used to introspect the request
+//  to capture one or more header values.
+//
+
+object XPathStepUtil extends LazyLogging {
+  //
+  //  The saxon processor, xquery compiler
+  //
+  protected val processor = {
+    val p = new Processor(true)
+    val dynLoader = p.getUnderlyingConfiguration.getDynamicLoader
+    dynLoader.setClassLoader(getClass.getClassLoader)
+    p
+  }
+
+  protected val saxonConfig = {
+    val conf = processor.getUnderlyingConfiguration
+    conf.getDynamicLoader.setClassLoader(getClass.getClassLoader)
+    conf
+  }
+  protected val compiler = {
+    val c = processor.newXQueryCompiler
+    c.setLanguageVersion(Config.RAX_ASSERT_XPATH_VERSION_STRING)
+    c
+  }
+
+  //
+  //  Our functions are always defined in the following namespace.
+  //
+  private val prefix = "req"
+  private val uri = "http://www.rackspace.com/repose/wadl/checker/request"
+
+  //
+  //  Functions take a list of sequences as input
+  //  and return a sequence as output.
+  //
+  type Fun = (String /* Function Name */,
+              List[SequenceType] /* Argument Types */,
+              SequenceType /* Return Type */)
+
+  //
+  //  Predefined Functions
+  //
+  private val functions : List[Fun] =
+    List(("header", List(SequenceType.SINGLE_STRING),
+          SequenceType.SINGLE_STRING),
+         ("header", List(SequenceType.SINGLE_STRING,
+                         SequenceType.SINGLE_BOOLEAN),
+          SequenceType.SINGLE_STRING),
+         ("headers", List(SequenceType.SINGLE_STRING),
+          SequenceType.makeSequenceType(BuiltInAtomicType.STRING,
+                                        StaticProperty.ALLOWS_ZERO_OR_MORE)),
+         ("headers", List(SequenceType.SINGLE_STRING,
+                          SequenceType.SINGLE_BOOLEAN),
+          SequenceType.makeSequenceType(BuiltInAtomicType.STRING,
+                                        StaticProperty.ALLOWS_ZERO_OR_MORE)))
+
+  //
+  //  Create an XQueryLibarary where we can declare our custom
+  //  functions.
+  //
+  private val xqlib = new XQueryFunctionLibrary(saxonConfig)
+
+  //
+  //  Declare functions
+  //
+  functions.foreach(f => {
+    val fname   = f._1
+    val argTypes = f._2
+    val retType = f._3
+
+    val fun = new XQueryFunction
+    fun.setFunctionName(new StructuredQName(prefix, uri, fname))
+    fun.setResultType(retType)
+
+    argTypes.foreach(argType => {
+      val param = new UserFunctionParameter
+      param.setVariableQName(new StructuredQName(prefix, uri, "arg"))
+      param.setRequiredType(argType)
+      fun.addArgument(param)
+    })
+
+    xqlib.declareFunction(fun)
+  })
+
+  //
+  // Predefined Variables
+  //
+  private val variables : List[String] =
+    List("_","body","method","uri","headerNames","uriLevel")
+  private val localVariables : List[String] =
+    List("_","body")
+
+
+  private def getXPathContext(nsc : ImmutableNamespaceContext) : XPathStaticContext = {
+    //
+    //  Context used when parsing XPaths
+    //
+    val ic = new IndependentContext
+
+    ic.setXPathLanguageLevel(Config.RAX_ASSERT_XPATH_VERSION)
+    ic.declareNamespace(prefix, uri)
+
+    nsc.getAllPrefixes.filter(p => {
+      (p != "xmlns") &&  (p != "xml")
+    }).foreach(p => {
+      ic.declareNamespace(p, nsc.getNamespaceURI(p))
+    })
+
+    //
+    //  Declare module and local variables, and functions
+    //
+    variables.foreach(ic.declareVariable(uri,_))
+    localVariables.foreach(ic.declareVariable("",_))
+
+    ic.getFunctionLibrary.asInstanceOf[FunctionLibraryList].addFunctionLibrary(xqlib)
+    ic
+  }
+
+  //
+  //  We are using an XQuery evaluator to execute our XPath. We do
+  //  this because it's easy to create the extensions needed for our
+  //  assertions req:headers, for example. (we define these in
+  //  xq/assert.xq.
+  //
+  //  XQuery is a superset of XPath and we don't want folks extending
+  //  beyond the capabilites of XPath, we use an XPath parser to
+  //  confirm we have valid XPath before anything else -- this will
+  //  throw an XPathException if we use capabilities in XQuery that
+  //  are not in XPath such as FLWOR expressions.
+  //
+  //  The parser is made aware of the variables / functions available
+  //  to asserts, so these are also checked.
+  //
+  protected[step] def parseXPath (expression : String, nc : ImmutableNamespaceContext, version : Int) : Unit = {
+    val xpathParser = new XPathParser
+    xpathParser.setLanguage(XPathParser.XPATH, version)
+    xpathParser.parse(expression, 0, 0, getXPathContext(nc))
+  }
+
+
+  //
+  // Location of the shared XQuery module
+  //
+  private val moduleName : String = "/xq/assert.xq";
+  private val moduleLoc : String = getClass.getResource(moduleName).toString()
+
+  //
+  // XQuery prolog used in front of all XPath expressions.
+  //
+  protected val XQUERY_PROLOG = s"""
+     xquery version \"3.1\" encoding \"UTF-8\";
+
+     import module \"$uri\"
+            at \"$moduleLoc\";
+
+     declare namespace $prefix = \"$uri\";
+
+
+  """
+
+  protected val EMPTY_MAP = XdmEmptySequence.getInstance
+  protected val EMPTY_DOC = {
+    val parser = borrowParser
+    try {
+      new DOMSource(parser.newDocument)
+    } finally {
+      returnParser(parser)
+    }
+  }
+
+  //
+  //  Create a valid XQuery for the given expression given the
+  //  namespace context.
+  //
+  protected def xqueryStringForExpression(expression : String, nc : ImmutableNamespaceContext) : String = {
+    XQUERY_PROLOG + nc.getAllPrefixes.filter(p => {
+      //
+      // These are predefined prefixes, we can't overwrite them
+      //
+      (p != "xmlns") &&  (p != "xml") && (p != "req") && (p != "")
+    }).map(p => {
+      val uri = nc.getNamespaceURI(p);
+      s"""declare namespace $p = \"$uri\";\n"""
+    }).fold("")(_ + _)+s"""
+          declare variable $$_    := $$$prefix:_;    (: For compatibility with plain params :)
+          declare variable $$body := $$$prefix:body; (: For compatibility with plain params :)
+
+    """+expression
+  }
+
+  //
+  //  Compile an XQuery Executable for the given XPath expression,
+  //  taking into account extended functions, etc.
+  //
+  protected[step] def xqueryExecutableForExpression(expression : String, nc : ImmutableNamespaceContext) : XQueryExecutable = {
+    val query = xqueryStringForExpression(expression, nc)
+    try {
+      logger.trace (s"compiling :\n$query")
+      val e = compiler.compile(query)
+      logger.trace ("compilation done.")
+      e
+    } catch {
+      case ex : Exception => logger.error(s"Caught exception while compiling $query",ex)
+                             throw ex
+    }
+  }
+
+  //
+  //  Given a Checker Request and a StepContext, this function sets up
+  //  an XQuery evaluator for execution.
+  //
+  protected[step] def setupXQueryEvaluator (eval : XQueryEvaluator, req : CheckerServletRequest, context : StepContext) : Unit = {
+    val json : XdmValue = req.parsedJSONXdmValue match {
+      case null => EMPTY_MAP
+      case jv : XdmValue => jv
+    }
+
+    val xml : Source = req.parsedXMLSource match {
+      case null => EMPTY_DOC
+      case src : Source => src
+    }
+
+    eval.setSource(xml)
+    eval.setExternalVariable (new QName(prefix,uri,"__JSON__"), json)
+    eval.setExternalVariable (new QName(prefix,uri,"__REQUEST__"), req.asXdmValue(saxonConfig))
+    eval.setExternalVariable (new QName(prefix,uri,"__CONTEXT__"), context.asXdmValue(saxonConfig)) 
+  }
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerBuilder.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerBuilder.scala
@@ -90,8 +90,8 @@ object WADLCheckerBuilder {
   private lazy val raxMetaTransformXsltExec: XsltExecutable = timeFunction ("compile /xsl/meta-transform.xsl",
                                                                             compiler.compile(new StreamSource(getClass.getResource("/xsl/meta-transform.xsl").toString)))
 
-  private lazy val raxAssertXsltExec : XsltExecutable = timeFunction ("compile /xsl/raxAssert.xsl",
-                                                                      compiler.compile(new StreamSource(getClass.getResource("/xsl/raxAssert.xsl").toString)))
+  private lazy val raxGlobalExtnXsltExec : XsltExecutable = timeFunction ("compile /xsl/raxGlobalExtn.xsl",
+                                                                      compiler.compile(new StreamSource(getClass.getResource("/xsl/raxGlobalExtn.xsl").toString)))
 
 
   private lazy val raxRolesXsltExec : XsltExecutable = timeFunction ("compile /xsl/raxRoles.xsl",
@@ -384,15 +384,15 @@ class WADLCheckerBuilder(protected[wadl] var wadl : WADLNormalizer) extends Lazy
   })
 
   //
-  // Handles the rax:assert extension
+  // Handles global element extensions (rax:assert, rax:captureHeader) extension
   //
-  private def raxAssert(in : Source, c : Config) : Source = timeFunction("raxAssert", {
-    if (c.enableAssertExtension) {
-      val raxAssertTransform = getXsltTransformer(raxAssertXsltExec)
+  private def raxGlobalExtn(in : Source, c : Config) : Source = timeFunction("raxGlobalExtn", {
+    if (c.enableAssertExtension | c.enableCaptureHeaderExtension) {
+      val raxExtnTransform = getXsltTransformer(raxGlobalExtnXsltExec)
       val out = new XdmDestination
-      raxAssertTransform.setSource(in)
-      raxAssertTransform.setDestination(out)
-      raxAssertTransform.transform
+      raxExtnTransform.setSource(in)
+      raxExtnTransform.setDestination(out)
+      raxExtnTransform.transform
       out.getXdmNode.asSource
     } else {
       in
@@ -637,7 +637,7 @@ class WADLCheckerBuilder(protected[wadl] var wadl : WADLNormalizer) extends Lazy
         //  be applied.
         //
         val buildSteps : List[CheckerTransform] =
-          List(raxAssert, authenticatedBy, raxRoles,
+          List(raxGlobalExtn, authenticatedBy, raxRoles,
                buildChecker(entityDoc, _, _),
                raxRolesMask, joinOpt, dupsOpt,
                joinHeaderOpt, joinXPathOpt, adjustNext, validateChecker)

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/BaseValidatorSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/BaseValidatorSuite.scala
@@ -74,7 +74,7 @@ class BaseValidatorSuite extends FunSuite {
                         <even>22</even>
                      </e>
 
-  val goodXML_XSD2 = <a xmlns="http://www.rackspace.com/repose/wadl/checker/step/test"
+  val goodXML_XSD2 = <tst:a xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
                         id="21f1fcf6-bf38-11e1-878e-133ab65fcec3"
                         stepType="ACCEPT"
                         even="22"/>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRAXCaptureHeaderElementSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRAXCaptureHeaderElementSuite.scala
@@ -1,0 +1,1491 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+
+import com.rackspace.com.papi.components.checker.RunAssertionsHandler._
+import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.step.results.Result
+import com.rackspace.cloud.api.wadl.Converters._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+import scala.xml.Elem
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.JsonNode
+
+@RunWith(classOf[JUnitRunner])
+class ValidatorWADLRAXCaptureHeaderElementSuite extends BaseValidatorSuite {
+  ///
+  ///  Configs
+  ///
+  val baseConfig = {
+    val c = TestConfig()
+    c.xpathVersion = 31
+    c.removeDups = false
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableAssertExtension = false
+    c.enableCaptureHeaderExtension = false
+    c
+  }
+
+  val baseWithCaptureHeader = {
+    val c = TestConfig()
+    c.xpathVersion = 31
+    c.removeDups = false
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c
+  }
+
+  val baseWithCaptureHeaderRemoveDups = {
+    val c = TestConfig()
+    c.xpathVersion = 31
+    c.removeDups = true
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c
+  }
+
+
+  val baseWithCaptureHeaderAssert = {
+    val c = TestConfig()
+    c.xpathVersion = 31
+    c.removeDups = false
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableAssertExtension = true
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c
+  }
+
+  val baseWithCaptureHeaderAssertRemoveDups = {
+    val c = TestConfig()
+    c.xpathVersion = 31
+    c.removeDups = true
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableAssertExtension = true
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c
+  }
+
+
+  val baseWithCaptureHeaderParamDefaults = {
+    val c = TestConfig()
+    c.removeDups = false
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableAssertExtension = false
+    c.setParamDefaults = true
+    c.checkHeaders = true
+    c.enableCaptureHeaderExtension = true
+    c
+  }
+
+  val baseWithCaptureHeaderParamDefaultsRemoveDups = {
+    val c = TestConfig()
+    c.removeDups = true
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableAssertExtension = false
+    c.setParamDefaults = true
+    c.checkHeaders = true
+    c.enableCaptureHeaderExtension = true
+    c
+  }
+
+
+  val baseCaptureHeaderWithPlainParams = {
+    val c = TestConfig()
+    c.removeDups = false
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.checkElements = true
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c
+  }
+
+  val baseCaptureHeaderWithJoinXPaths = {
+    val c = TestConfig()
+    c.removeDups = false
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.checkElements = true
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c
+  }
+
+  val baseCaptureHeaderWithJoinXPathsAndRemoveDups = {
+    val c = TestConfig()
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.checkElements = true
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c
+  }
+
+
+//  RaxRoles Configs
+
+  val baseWithPlainParamsRaxRoles = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.removeDups = false
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c.checkElements = true
+    c
+  }
+
+
+  val baseWithRemoveDupsRaxRoles = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.removeDups = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c.checkElements = true
+    c
+  }
+
+  val baseWithJoinXPathsRaxRoles = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.removeDups = false
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c.checkElements = true
+    c
+  }
+
+  val baseWithJoinXPathsAndRemoveDupsRaxRoles = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c.checkElements = true
+    c
+  }
+
+
+//  RaxRoles Configs Masked
+
+  val baseWithPlainParamsRaxRolesMask = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c.removeDups = false
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c.checkElements = true
+    c
+  }
+
+
+  val baseWithRemoveDupsRaxRolesMask = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c.removeDups = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c.checkElements = true
+    c
+  }
+
+  val baseWithJoinXPathsRaxRolesMask = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c.removeDups = false
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c.checkElements = true
+    c
+  }
+
+  val baseWithJoinXPathsAndRemoveDupsRaxRolesMask = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableAssertExtension = false
+    c.setParamDefaults = false
+    c.enableCaptureHeaderExtension = true
+    c.checkElements = true
+    c
+  }
+
+
+  val WADL_withCaptureHeaders = <application xmlns="http://wadl.dev.java.net/2009/02"
+                                             xmlns:rax="http://docs.rackspace.com/api"
+                                             xmlns:req="http://www.rackspace.com/repose/wadl/checker/request"
+                                             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                             xmlns:tst="test.org"
+                                             xmlns:tst2="http://www.rackspace.com/repose/wadl/checker/step/test">
+  <resources base="https://test.api.openstack.com">
+    <resource path="/a" rax:roles="user">
+      <method name="PUT">
+        <request>
+          <representation mediaType="application/xml" element="tst:some_xml">
+            <param name="test" style="plain" path="tst:some_xml/tst:an_element/tst:another_element" required="true"/>
+            <rax:captureHeader name="X-ATT-ATTRIB" path="tst:some_xml/@att" />
+            <rax:captureHeader name="X-AN-ELEM" path="local-name($body/tst:some_xml/tst:an_element)" />
+            <rax:assert test="'foo!' = req:headers('X-AUTH', true())"/>
+          </representation>
+          <representation mediaType="application/json"/>
+          <representation mediaType="text/x-yaml">
+            <rax:captureHeader name="X-FALSE" path="false()" />
+          </representation>
+          <!-- assertion should be placed in all representations -->
+          <representation>
+            <rax:captureHeader name="X-BODY-EMPTY" path="empty($body)" />
+            <rax:captureHeader name="X-BODY-EMPTY2" path="empty($_)" />
+          </representation>
+        </request>
+      </method>
+      <method name="POST">
+        <request>
+          <representation mediaType="application/xml" element="tst2:a">
+            <param name="test2" style="plain" path="tst2:a/@id" required="true" rax:message="expecting an id attribute"/>
+            <!-- this assertion applies only to post /a when the representation is xml -->
+            <rax:captureHeader name="X-X-METHOD" path="$req:method" />
+            <rax:captureHeader name="X-X-URI" path="$req:uri='/a'"/>
+            <rax:captureHeader name="X-X-ROOT" path="name(/tst2:a)"/>
+            <rax:captureHeader name="X-X-ROOT2" path="local-name($_/tst2:a)"/>
+          </representation>
+          <representation mediaType="application/json">
+            <param name="test3" style="plain" path="$_?firstName" required="true" rax:message="need a first name" rax:code="403"/>
+          </representation>
+        </request>
+      </method>
+      <resource path="b">
+        <method name="GET"/>
+        <method name="DELETE" rax:roles="admin administrator">
+          <request>
+            <param name="x-auth" style="header" type="xs:string" default="baz!" required="true" repeating="true"/>
+            <!-- should be treated as a request assertion -->
+            <representation>
+              <rax:captureHeader name="X-X-METHOD" path="$req:method"/>
+              <rax:captureHeader name="X-X-AUTH" path="req:header('x-auth')"/>
+            </representation>
+          </request>
+        </method>
+        <method name="POST">
+          <request>
+            <representation mediaType="application/xml">
+                                 </representation>
+            <representation mediaType="application/json">
+              <!-- this assertion applies only to post /a/b if the representation is json -->
+              <rax:captureHeader name="X-X-URI-JSON" path="$req:uri" />
+              <rax:captureHeader name="X-X-STUFF-STRING" path="$_?stuff?string" />
+            </representation>
+            <!-- this assertion applies only to post /a/b request regardless of the representation-->
+            <rax:captureHeader name="X-X-URI" path="$req:uri" />
+          </request>
+        </method>
+      </resource>
+      <resource path="z">
+        <method name="PATCH">
+          <request>
+            <representation mediaType="application/xml" element="tst2:a">
+              <param name="test2" style="plain" path="tst2:a/@id" required="true" rax:message="expecting an id attribute"/>
+              <rax:captureHeader name="X-X-METHOD-XML" path="$req:method" />
+            </representation>
+          </request>
+        </method>
+        <method name="PATCH" rax:roles="#all">
+          <request>
+            <representation mediaType="application/json" rax:roles="#all">
+              <param name="test3" style="plain" path="$_?firstName" required="true" rax:message="need a first name" rax:code="403"/>
+            </representation>
+          </request>
+        </method>
+      </resource>
+      <!-- this assertion applies to all requests in the resource /a -->
+      <rax:captureHeader name="X-X-URI-LEVEL" path="$req:uriLevel" />
+      <rax:captureHeader name="X-HEADERS-START-WITH-A" path="some $h in $req:headerNames satisfies starts-with($h, 'a')" />
+      <!-- this assertion applies to all requests in the resource /a and all subresources of a /a/b for example-->
+      <rax:captureHeader name="X-HEADERS-START-WITH-B" path="some $h in $req:headerNames satisfies starts-with($h,'b')"  applyToChildren="true"/>
+    </resource>
+    <!-- this assertion applies to all requests in the wadl -->
+    <rax:captureHeader name="ALL-X-AUTH-HEADERS" path="req:headers('x-auth', true())"/>
+    </resources>
+  </application>
+
+
+  val WADL_withCaptureHeaders2 = <application xmlns="http://wadl.dev.java.net/2009/02"
+                                             xmlns:rax="http://docs.rackspace.com/api"
+                                             xmlns:req="http://www.rackspace.com/repose/wadl/checker/request"
+                                             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                                             xmlns:tst="test.org"
+                                             xmlns:tst2="http://www.rackspace.com/repose/wadl/checker/step/test">
+  <resources base="https://test.api.openstack.com">
+    <resource path="/a" rax:roles="user">
+      <method name="PUT">
+        <request>
+          <representation mediaType="application/xml" element="tst:some_xml">
+            <param name="test" style="plain" path="tst:some_xml/tst:an_element/tst:another_element" required="true"/>
+            <rax:captureHeader name="X-ATT-ATTRIB" path="tst:some_xml/@att" />
+            <rax:captureHeader name="X-AN-ELEM" path="local-name($req:body/tst:some_xml/tst:an_element)" />
+            <rax:assert test="'foo!' = req:headers('X-AUTH', true())"/>
+          </representation>
+          <representation mediaType="application/json"/>
+          <representation mediaType="text/x-yaml">
+            <rax:captureHeader name="X-FALSE" path="false()" />
+          </representation>
+          <!-- assertion should be placed in all representations -->
+          <representation>
+            <rax:captureHeader name="X-BODY-EMPTY" path="empty($req:body)" />
+            <rax:captureHeader name="X-BODY-EMPTY2" path="empty($req:_)" />
+          </representation>
+        </request>
+      </method>
+      <method name="POST">
+        <request>
+          <representation mediaType="application/xml" element="tst2:a">
+            <param name="test2" style="plain" path="tst2:a/@id" required="true" rax:message="expecting an id attribute"/>
+            <!-- this assertion applies only to post /a when the representation is xml -->
+            <rax:captureHeader name="X-X-METHOD" path="$req:method" />
+            <rax:captureHeader name="X-X-URI" path="$req:uri='/a'"/>
+            <rax:captureHeader name="X-X-ROOT" path="name(/tst2:a)"/>
+            <rax:captureHeader name="X-X-ROOT2" path="local-name($req:_/tst2:a)"/>
+          </representation>
+          <representation mediaType="application/json">
+            <param name="test3" style="plain" path="$_?firstName" required="true" rax:message="need a first name" rax:code="403"/>
+          </representation>
+        </request>
+      </method>
+      <resource path="b">
+        <method name="GET"/>
+        <method name="DELETE" rax:roles="admin administrator">
+          <request>
+            <param name="x-auth" style="header" type="xs:string" default="baz!" required="true" repeating="true"/>
+            <!-- should be treated as a request assertion -->
+            <representation>
+              <rax:captureHeader name="X-X-METHOD" path="$req:method"/>
+              <rax:captureHeader name="X-X-AUTH" path="req:header('x-auth')"/>
+            </representation>
+          </request>
+        </method>
+        <method name="POST">
+          <request>
+            <representation mediaType="application/xml">
+                                 </representation>
+            <representation mediaType="application/json">
+              <!-- this assertion applies only to post /a/b if the representation is json -->
+              <rax:captureHeader name="X-X-URI-JSON" path="$req:uri" />
+              <rax:captureHeader name="X-X-STUFF-STRING" path="$req:_?stuff?string" />
+            </representation>
+            <!-- this assertion applies only to post /a/b request regardless of the representation-->
+            <rax:captureHeader name="X-X-URI" path="$req:uri" />
+          </request>
+        </method>
+      </resource>
+      <resource path="z">
+        <method name="PATCH">
+          <request>
+            <representation mediaType="application/xml" element="tst2:a">
+              <param name="test2" style="plain" path="tst2:a/@id" required="true" rax:message="expecting an id attribute"/>
+              <rax:captureHeader name="X-X-METHOD-XML" path="$req:method" />
+            </representation>
+          </request>
+        </method>
+        <method name="PATCH" rax:roles="#all">
+          <request>
+            <representation mediaType="application/json" rax:roles="#all">
+              <param name="test3" style="plain" path="$_?firstName" required="true" rax:message="need a first name" rax:code="403"/>
+
+            </representation>
+          </request>
+        </method>
+      </resource>
+      <!-- this assertion applies to all requests in the resource /a -->
+      <rax:captureHeader name="X-X-URI-LEVEL" path="$req:uriLevel" />
+      <rax:captureHeader name="X-HEADERS-START-WITH-A" path="some $h in $req:headerNames satisfies starts-with($h, 'a')" />
+      <!-- this assertion applies to all requests in the resource /a and all subresources of a /a/b for example-->
+      <rax:captureHeader name="X-HEADERS-START-WITH-B" path="some $h in $req:headerNames satisfies starts-with($h,'b')"  applyToChildren="true"/>
+    </resource>
+    <!-- this assertion applies to all requests in the wadl -->
+    <rax:captureHeader name="ALL-X-AUTH-HEADERS" path="req:headers('x-auth', true())"/>
+    </resources>
+  </application>
+
+
+
+  //
+  // Config combinations
+  //
+  val captureHeaderDisabledConfigs = Map[String, Config]("base config with captureHeaders disabled"->baseConfig)
+
+  val captureHeaderEnabledConfigs  = Map[String, Config]("Config with captureHeaders enabled"->baseWithCaptureHeader,
+                                                  "Config with captureHeaders and remove dups"->baseWithCaptureHeaderRemoveDups)
+
+  val captureHeaderAssertEnabledConfigs  = Map[String, Config]("Config with captureHeaders and Assert enabled"->baseWithCaptureHeaderAssert,
+                                                       "Config with captureHeaders and Assert and remove dups"->baseWithCaptureHeaderAssertRemoveDups)
+
+
+  val captureHeaderEnabledParamDefaultConfigs = Map[String, Config]("Config with captureHeaders enabled, param defaults"->baseWithCaptureHeaderParamDefaults,
+                                                             "Config with captureHeaders enabled, param defaults and remove dups"->baseWithCaptureHeaderParamDefaultsRemoveDups)
+
+  val captureHeaderEnabledPlainParamConfigs = Map[String, Config]("Config with captureHeaders enabled, plain params"->baseCaptureHeaderWithPlainParams,
+                                                           "Config with captureHeaders enabled, plain params join XPath"->baseCaptureHeaderWithJoinXPaths,
+                                                           "Config with captureHeaders enabled, plain params join XPath, remove dups"->baseCaptureHeaderWithJoinXPathsAndRemoveDups)
+
+  val captureHeaderEnabledPlainRaxRoles = Map[String, Config]("Config with captureHeaders enabled, plain params, rax roles"->baseWithPlainParamsRaxRoles,
+                                                       "Config with captureHeaders enabled, plain params, rax roles, remove dups"->baseWithRemoveDupsRaxRoles,
+                                                       "Config with captureHeaders enabled, plain params, rax roles, join xpath"->baseWithJoinXPathsRaxRoles,
+                                                       "Config with captureHeaders enabled, plain params, rax roles, remove dups, join xpath"->baseWithJoinXPathsAndRemoveDupsRaxRoles)
+
+  val captureHeaderEnabledPlainRaxRolesMask = Map[String, Config]("Config with captureHeaders enabled, plain params, rax roles masked"->baseWithPlainParamsRaxRolesMask,
+                                                           "Config with captureHeaders enabled, plain params, rax roles masked, remove dups"->baseWithRemoveDupsRaxRolesMask,
+                                                           "Config with captureHeaders enabled, plain params, rax roles masked, join xpath"->baseWithJoinXPathsRaxRolesMask,
+                                                           "Config with captureHeaders enabled, plain params, rax roles masked, remove dups, join xpath"->baseWithJoinXPathsAndRemoveDupsRaxRolesMask)
+
+
+  //
+  // WADL combinations
+  //
+  val captureHeaderWADLs = Map[String, Elem]("WADL with $body captureHeaderions"->WADL_withCaptureHeaders,
+                                             "WADL with $req:body captureHeaderions"->WADL_withCaptureHeaders2)
+
+  //
+  // Assertions!
+  //
+
+  def happyPathAssertions(validator : Validator, wadlDesc : String, configDesc : String) {
+     test (s"A PUT on /a should validate with goodXML on $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+     }
+
+    test (s"A PUT on /a should validate with goodJSON on $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json",goodJSON, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+     }
+
+
+     test (s"A POST on /a should validate with goodXML on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/xml",goodXML_XSD2, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+     }
+
+    test (s"A POST on /a should validate with goodJSON on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/json",goodJSON_Schema1, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+     }
+
+    test (s"A GET on /a/b should validate on $wadlDesc with $configDesc") {
+      validator.validate(request("GET", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                                          "b"->List("ababa"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+
+    test (s"A DELETE on /a/b should validate on $wadlDesc with $configDesc") {
+      validator.validate(request("DELETE", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                                          "b"->List("Dbaba"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user", "Administrator"))), response, chain)
+    }
+
+    test (s"A POST on /a/b should validate with good XML on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a/b", "application/xml", goodXML, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                                          "b"->List("Dbaba"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+
+    test (s"A POST on /a/b should validate with good JSON on $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a/b", "application/json", goodJSON, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                                          "b"->List("Dbaba"),
+                                                          "X-Auth"->List("foo!"),
+                                                          "X-Roles"->List("user"))), response, chain)
+    }
+  }
+
+  def happyWhenCaptureHeadersAreDisabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A PUT on /a should validate but capture headers sholud not be set with goodXML on $wadlDesc with $configDesc") {
+      val req = request("PUT", "/a", "application/xml",goodXML, false,
+                          Map[String,List[String]]("a"->List("abba"),
+                          "b"->List("ababa"),
+                          "X-Auth"->List("foo!"),
+                          "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(!csReq.getHeaders("X-ATT-ATTRIB").hasMoreElements)
+        assert(!csReq.getHeaders("X-AN-ELEM").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI-LEVEL").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-A").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-B").hasMoreElements)
+        assert(!csReq.getHeaders("ALL-X-AUTH-HEADERS").hasMoreElements)
+        assert(!csReq.getHeaders("X-BODY-EMPTY").hasMoreElements)
+        assert(!csReq.getHeaders("X-BODY-EMPTY2").hasMoreElements)
+        }))
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A PUT on /a should validate but capture headers sholud not be set with goodJSON on $wadlDesc with $configDesc") {
+      val req = request("PUT", "/a", "application/json",goodJSON, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                   "b"->List("ababa"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(!csReq.getHeaders("X-FALSE").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI-LEVEL").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-A").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-B").hasMoreElements)
+        assert(!csReq.getHeaders("ALL-X-AUTH-HEADERS").hasMoreElements)
+        assert(!csReq.getHeaders("X-BODY-EMPTY").hasMoreElements)
+        assert(!csReq.getHeaders("X-BODY-EMPTY2").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A POST on /a should validate but capture headers sholud not be set with goodXML on $wadlDesc with $configDesc") {
+      val req = request("POST", "/a", "application/xml",goodXML_XSD2, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                   "b"->List("ababa"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(!csReq.getHeaders("X-X-METHOD").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-ROOT").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-ROOT2").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI-LEVEL").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-A").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-B").hasMoreElements)
+        assert(!csReq.getHeaders("ALL-X-AUTH-HEADERS").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+     }
+
+    test (s"A POST on /a should validate but capture header should not be set with goodJSON on $wadlDesc with $configDesc") {
+      val req = request("POST", "/a", "application/json",goodJSON_Schema1, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                   "b"->List("ababa"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(!csReq.getHeaders("X-X-URI-LEVEL").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-A").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-B").hasMoreElements)
+        assert(!csReq.getHeaders("ALL-X-AUTH-HEADERS").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+     }
+
+    test (s"A GET on /a/b should validate but capture header should not be set on $wadlDesc with $configDesc") {
+      val req = request("GET", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                   "b"->List("ababa"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-B").hasMoreElements)
+        assert(!csReq.getHeaders("ALL-X-AUTH-HEADERS").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A DELETE on /a/b should validate but capture header sholud not be set on $wadlDesc with $configDesc") {
+      val req = request("DELETE", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                   "b"->List("Dbaba"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user", "Administrator")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(!csReq.getHeaders("X-X-METHOD").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-AUTH").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-B").hasMoreElements)
+        assert(!csReq.getHeaders("ALL-X-AUTH-HEADERS").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A POST on /a/b should validate with good XML but capture header should not be set on $wadlDesc with $configDesc") {
+      val req = request("POST", "/a/b", "application/xml", goodXML, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                   "b"->List("Dbaba"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(!csReq.getHeaders("X-X-URI").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-B").hasMoreElements)
+        assert(!csReq.getHeaders("ALL-X-AUTH-HEADERS").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A POST on /a/b should validate with good JSON but capture header sholud not be set on $wadlDesc with $configDesc") {
+      val req = request("POST", "/a/b", "application/json", goodJSON, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                   "b"->List("Dbaba"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(!csReq.getHeaders("X-X-URI-JSON").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-STUFF-STRING").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-B").hasMoreElements)
+        assert(!csReq.getHeaders("ALL-X-AUTH-HEADERS").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A PATCH on /a/z should validate with good XML but capture header should not be set on $wadlDesc with $configDesc") {
+      val req = request("PATCH", "/a/z", "application/xml", goodXML_XSD2, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                   "b"->List("Dbaba"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(!csReq.getHeaders("X-X-METHOD-XML").hasMoreElements)
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-B").hasMoreElements)
+        assert(!csReq.getHeaders("ALL-X-AUTH-HEADERS").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A PATCH on /a/z should validate with good JSON but capture header sholud not be set on $wadlDesc with $configDesc") {
+      val req = request("PATCH", "/a/z", "application/json", goodJSON, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                   "b"->List("Dbaba"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-B").hasMoreElements)
+        assert(!csReq.getHeaders("ALL-X-AUTH-HEADERS").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+  }
+
+
+  //
+  //  We ensure that capture headers are set correctly here
+  //
+  def happyWhenCaptureHeadersAreEnabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A PUT on /a should validate capture headers sholud be set with goodXML on $wadlDesc with $configDesc") {
+      val req = request("PUT", "/a", "application/xml",goodXML, false,
+                          Map[String,List[String]]("a"->List("abba"),
+                          "c"->List("ababa"),
+                          "X-Auth"->List("foo!"),
+                          "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-ATT-ATTRIB").toList == List("1"))
+        assert(csReq.getHeaders("X-AN-ELEM").toList == List("an_element"))
+        assert(csReq.getHeaders("X-X-URI-LEVEL").toList == List("1"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("false"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-BODY-EMPTY").toList == List("false"))
+        assert(csReq.getHeaders("X-BODY-EMPTY2").toList == List("false"))
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A PUT on /a should validate capture headers sholud be set with goodJSON on $wadlDesc with $configDesc") {
+      val req = request("PUT", "/a", "application/json",goodJSON, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                   "b"->List("ababa"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-X-URI-LEVEL").toList == List("1"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-BODY-EMPTY").toList == List("false"))
+        assert(csReq.getHeaders("X-BODY-EMPTY2").toList == List("false"))
+        assert(!csReq.getHeaders("X-FALSE").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A PUT on /a should validate capture headers sholud be set with yaml on $wadlDesc with $configDesc") {
+      val req = request("PUT", "/a", "text/x-yaml","""
+         repose : "Loves all the YAML!"
+      """, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                   "b"->List("ababa"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-X-URI-LEVEL").toList == List("1"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-BODY-EMPTY").toList == List("false"))
+        assert(csReq.getHeaders("X-BODY-EMPTY2").toList == List("false"))
+        assert(csReq.getHeaders("X-FALSE").toList == List("false"))
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A POST on /a should validate capture headers sholud be set with goodXML on $wadlDesc with $configDesc") {
+      val req = request("POST", "/a", "application/xml",goodXML_XSD2, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                   "b"->List("ababa"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-X-URI-LEVEL").toList == List("1"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-X-METHOD").toList == List("POST"))
+        assert(csReq.getHeaders("X-X-URI").toList == List("true"))
+        assert(csReq.getHeaders("X-X-ROOT").toList == List("tst:a"))
+        assert(csReq.getHeaders("X-X-ROOT2").toList == List("a"))
+      }))
+
+      validator.validate(req, response, chain)
+     }
+
+    test (s"A POST on /a should validate capture header should be set with goodJSON on $wadlDesc with $configDesc") {
+      val req = request("POST", "/a", "application/json",goodJSON_Schema1, false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                   "b"->List("ababa"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-X-URI-LEVEL").toList == List("1"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(!csReq.getHeaders("X-X-METHOD").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-ROOT").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-ROOT2").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+     }
+
+    test (s"A GET on /a/b should validate capture header should be set on $wadlDesc with $configDesc") {
+      val req = request("GET", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("abba"),
+                                   "b"->List("ababa"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-A").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI-LEVEL").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A DELETE on /a/b validate but capture header sholud be set on $wadlDesc with $configDesc") {
+      val req = request("DELETE", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                   "c"->List("Dbaba"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user", "Administrator")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("false"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-X-METHOD").toList == List("DELETE"))
+        assert(csReq.getHeaders("X-X-AUTH").toList == List("foo!"))
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-A").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI-LEVEL").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A POST on /a/b should validate with good XML capture header should be set on $wadlDesc with $configDesc") {
+      val req = request("POST", "/a/b", "application/xml", goodXML, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                   "b"->List("Dbaba"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-X-URI").toList == List("/a/b"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(!csReq.getHeaders("X-X-URI-JSON").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A POST on /a/b should validate with good JSON capture header sholud be set on $wadlDesc with $configDesc") {
+      val req = request("POST", "/a/b", "application/json", goodJSON, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                   "b"->List("Dbaba"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-X-URI-JSON").toList == List("/a/b"))
+        assert(csReq.getHeaders("X-X-URI").toList == List("/a/b"))
+        assert(csReq.getHeaders("X-X-STUFF-STRING").toList == List("A String"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A PATCH on /a/z should validate with good XML capture header should be set on $wadlDesc with $configDesc") {
+      val req = request("PATCH", "/a/z", "application/xml", goodXML_XSD2, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                   "b"->List("Dbaba"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-X-METHOD-XML").toList == List("PATCH"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A PATCH on /a/z should validate with good JSON capture header sholud be set on $wadlDesc with $configDesc") {
+      val req = request("PATCH", "/a/z", "application/json", goodJSON, false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                   "b"->List("Dbaba"),
+                                   "X-Auth"->List("foo!"),
+                                   "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(!csReq.getHeaders("X-X-METHOD-XML").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+  }
+
+  //
+  //  These are just sanity checks against the WADL, they should never validate
+  //
+  def happySadPaths (validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"Plain text PUT should fail on /a $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT","/a","plain/text","hello!", false,
+                                                    Map[String,List[String]]("X-Roles"->List("user"))), response, chain),
+                         415, List("content type","application/xml","application/json","text/x\\-yaml"))
+    }
+
+    test (s"A PATCH on /a should fail with a 405 on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PATCH", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         405, List("Method", "POST", "PUT"))
+    }
+
+    test (s"A POST on /a/b/c should fail with a 404 on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a/b/c", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         404, List("not found"))
+    }
+
+    test (s"Plain text PATCH should fail on /a/z $wadlDesc with $configDesc when X-ROLES is user") {
+      assertResultFailed(validator.validate(request("PATCH","/a/z","plain/text","hello!", false,
+                                                    Map[String,List[String]]("X-Roles"->List("user"))), response, chain),
+                         415, List("content type","did not match"))
+    }
+
+    test (s"Plain text PATCH should fail on /a/z $wadlDesc with $configDesc when X-ROLES is foo") {
+      assertResultFailed(validator.validate(request("PATCH","/a/z","plain/text","hello!", false,
+                                                    Map[String,List[String]]("X-Roles"->List("foo"))), response, chain),
+                         415, List("content type","did not match"))
+    }
+  }
+
+
+  def happyWhenAssertsAreDisabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A PUT on /a should validate with goodXML and asserts enabled on $wadlDesc with $configDesc") {
+      val req = request("PUT", "/a", "application/xml",goodXML, false,
+                          Map[String,List[String]]("a"->List("abba"),
+                          "b"->List("ababa"),
+                          "X-Auth"->List("foo!"),
+                          "X-Roles"->List("user")))
+
+      validator.validate(req, response, chain)
+    }
+  }
+
+  def happyWhenParamDefaultsEnabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A DELETE on /a/b validate but capture header sholud be set with param defaults on $wadlDesc with $configDesc") {
+      val req = request("DELETE", "/a/b", null, "", false,
+                                 Map[String,List[String]]("a"->List("Bbba"),
+                                   "c"->List("Dbaba"),
+                                   "X-Roles"->List("user", "Administrator")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("false"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("baz!"))
+        assert(csReq.getHeaders("X-X-METHOD").toList == List("DELETE"))
+        assert(csReq.getHeaders("X-X-AUTH").toList == List("baz!"))
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-A").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI-LEVEL").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+  }
+
+  def sadWhenAssertsAreDisabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A PUT on /a should not validate with goodXML and asserts enabled on $wadlDesc with $configDesc") {
+      val req = request("PUT", "/a", "application/xml",goodXML, false,
+                          Map[String,List[String]]("a"->List("abba"),
+                          "b"->List("ababa"),
+                          "X-Auth"->List("bar!"),
+                          "X-Roles"->List("user")))
+
+      assertResultFailed(validator.validate(req, response, chain),
+        400, List("foo!"))
+    }
+  }
+
+  def testsWithPlainParamsEnabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A PUT on /a should not validate with goodXML that does not contain an_element (plain param) $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",
+                                                    <some_xml att='1' xmlns='test.org'>
+                                                    <another_element>
+                                                    <yet_another_element />
+                                                    </another_element>
+                                                    </some_xml>
+                                                    , false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("Expecting","tst:some_xml/tst:an_element/tst:another_element"))
+    }
+
+    test (s"A POST on /a should not validate with goodXML (wrong schema) on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("root", "tst2:a"))
+    }
+
+    test (s"A POST on /a with tst2:a and no @id attribute should fail with plain params enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/xml",
+                                                    <a xmlns="http://www.rackspace.com/repose/wadl/checker/step/test"
+                                                    stepType="ACCEPT"
+                                                    even="22"/>
+                                                    , false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         400, List("Expecting an id attribute"))
+    }
+
+    test (s"A POST on /a with a bad schema JSON should fail on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/json",""" { "foo" : "bar" } """,false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("user"))), response, chain),
+                         403, List("Need a first name"))
+    }
+  }
+
+
+  def testsWithPlainParamsDisabled(validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"A PUT on /a should validate with goodXML that does not contain an_element (plain param) $wadlDesc with $configDesc") {
+
+      val req = request("PUT", "/a", "application/xml",
+        <some_xml att='1' xmlns='test.org'>
+          <another_element>
+          <yet_another_element />
+          </another_element>
+          </some_xml>
+          , false,
+        Map[String,List[String]]("a"->List("abba"),
+          "b"->List("ababa"),
+          "X-Auth"->List("foo!"),
+          "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-ATT-ATTRIB").toList == List("1"))
+        assert(csReq.getHeaders("X-AN-ELEM").toList == List(""))
+        assert(csReq.getHeaders("X-X-URI-LEVEL").toList == List("1"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-BODY-EMPTY").toList == List("false"))
+        assert(csReq.getHeaders("X-BODY-EMPTY2").toList == List("false"))
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A POST on /a should validate with goodXML (wrong schema) on $wadlDesc with $configDesc") {
+
+      val req = request("POST", "/a", "application/xml", goodXML, false,
+        Map[String,List[String]]("a"->List("Bbba"),
+          "b"->List("Dbaba"),
+          "X-Auth"->List("foo!"),
+          "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-X-URI-LEVEL").toList == List("1"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-X-METHOD").toList == List("POST"))
+        assert(csReq.getHeaders("X-X-URI").toList == List("true"))
+        assert(csReq.getHeaders("X-X-ROOT").toList == List(""))
+        assert(csReq.getHeaders("X-X-ROOT2").toList == List(""))
+      }))
+
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A POST on /a with tst2:a and no @id attribute should validate with plain params enabled $wadlDesc with $configDesc") {
+      val req = request("POST", "/a", "application/xml",
+        <a xmlns="http://www.rackspace.com/repose/wadl/checker/step/test"
+          stepType="ACCEPT"
+          even="22"/>
+          , false,
+        Map[String,List[String]]("a"->List("abba"),
+          "b"->List("ababa"),
+          "X-Auth"->List("foo!"),
+          "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-X-URI-LEVEL").toList == List("1"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-X-METHOD").toList == List("POST"))
+        assert(csReq.getHeaders("X-X-URI").toList == List("true"))
+        assert(csReq.getHeaders("X-X-ROOT").toList == List("a"))
+        assert(csReq.getHeaders("X-X-ROOT2").toList == List("a"))
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+    test (s"A POST on /a with a bad schema JSON should validate on $wadlDesc with $configDesc") {
+      val req = request("POST", "/a", "application/json",""" { "foo" : "bar" } """,false,
+        Map[String,List[String]]("a"->List("abba"),
+          "b"->List("ababa"),
+          "X-Auth"->List("foo!"),
+          "X-Roles"->List("user")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-X-URI-LEVEL").toList == List("1"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(!csReq.getHeaders("X-X-METHOD").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-ROOT").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-ROOT2").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+  }
+
+  def testsWithRaxRolesEnabled(validator : Validator, wadlDesc : String, configDesc : String) {
+     test (s"A PUT on /a should fail with goodXML with no roles on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"))), response, chain),
+                         403, List("You are forbidden"))
+     }
+
+     test (s"A PUT on /a should fail with goodXML and an unknown role on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                                   Map[String,List[String]]("a"->List("abba"),
+                                                                            "b"->List("ababa"),
+                                                                            "X-Auth"->List("foo!"),
+                                                                            "X-Roles"->List("bizRole","admin"))), response, chain),
+                         403, List("You are forbidden"))
+     }
+
+
+    test (s"A DELETE on /a/b should fail with multiple unknown roles on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("DELETE", "/a/b", null, "", false,
+                                                    Map[String,List[String]]("a"->List("Bbba"),
+                                                                             "b"->List("Dbaba"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("bizBuz", "Wooga"))), response, chain),
+                         403, List("You are forbidden"))
+    }
+
+
+    test (s"A DELETE on /a/b should fail with no roles $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("DELETE", "/a/b", null, "", false,
+                                                    Map[String,List[String]]("a"->List("Bbba"),
+                                                                             "b"->List("Dbaba"),
+                                                                             "X-Auth"->List("foo!"))), response, chain),
+                         403, List("You are forbidden"))
+    }
+  }
+
+
+  def testsWithRaxRolesDisabled(validator : Validator, wadlDesc : String, configDesc : String) {
+
+    test (s"A PUT on /a should validate with goodXML with no roles on $wadlDesc with $configDesc") {
+      val req = request("PUT", "/a", "application/xml",goodXML, false,
+                          Map[String,List[String]]("a"->List("abba"),
+                          "c"->List("ababa"),
+                          "X-Auth"->List("foo!")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-ATT-ATTRIB").toList == List("1"))
+        assert(csReq.getHeaders("X-AN-ELEM").toList == List("an_element"))
+        assert(csReq.getHeaders("X-X-URI-LEVEL").toList == List("1"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("false"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-BODY-EMPTY").toList == List("false"))
+        assert(csReq.getHeaders("X-BODY-EMPTY2").toList == List("false"))
+      }))
+
+      validator.validate(req, response, chain)
+
+    }
+
+    test (s"A PUT on /a should validate with goodXML and an unknown role on $wadlDesc with $configDesc") {
+       val req = request("PUT", "/a", "application/xml",goodXML, false,
+                          Map[String,List[String]]("a"->List("abba"),
+                          "c"->List("ababa"),
+                          "X-Auth"->List("foo!"),
+                          "X-Roles"->List("adehount")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-ATT-ATTRIB").toList == List("1"))
+        assert(csReq.getHeaders("X-AN-ELEM").toList == List("an_element"))
+        assert(csReq.getHeaders("X-X-URI-LEVEL").toList == List("1"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("false"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-BODY-EMPTY").toList == List("false"))
+        assert(csReq.getHeaders("X-BODY-EMPTY2").toList == List("false"))
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+
+    test (s"A DELETE on /a/b should validate with multiple unknown roles on $wadlDesc with $configDesc") {
+      val req = request("DELETE", "/a/b", null, "", false,
+        Map[String,List[String]]("a"->List("Bbba"),
+          "c"->List("Dbaba"),
+          "X-Auth"->List("foo!"),
+          "X-Roles"->List("asBEKUH", "13456")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("false"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-X-METHOD").toList == List("DELETE"))
+        assert(csReq.getHeaders("X-X-AUTH").toList == List("foo!"))
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-A").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI-LEVEL").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+
+
+    test (s"A DELETE on /a/b should validate with no roles $wadlDesc with $configDesc") {
+      val req = request("DELETE", "/a/b", null, "", false,
+        Map[String,List[String]]("a"->List("Bbba"),
+          "c"->List("Dbaba"),
+          "X-Auth"->List("foo!")))
+
+      req.setAttribute(ASSERT_FUNCTION, ((csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("false"))
+        assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
+        assert(csReq.getHeaders("X-X-METHOD").toList == List("DELETE"))
+        assert(csReq.getHeaders("X-X-AUTH").toList == List("foo!"))
+        assert(!csReq.getHeaders("X-HEADERS-START-WITH-A").hasMoreElements)
+        assert(!csReq.getHeaders("X-X-URI-LEVEL").hasMoreElements)
+      }))
+
+      validator.validate(req, response, chain)
+    }
+  }
+
+
+  def testsWithRaxRolesMaskEnabled(validator : Validator, wadlDesc : String, configDesc : String) {
+     test (s"A PUT on /a should validate with goodXML with no roles on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                                    Map[String,List[String]]("a"->List("abba"),
+                                                                             "b"->List("ababa"),
+                                                                             "X-Auth"->List("foo!"))), response, chain),
+                         405, List("PUT"))
+     }
+
+     test (s"A PUT on /a should validate with goodXML and an unknown role on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml",goodXML, false,
+                                                   Map[String,List[String]]("a"->List("abba"),
+                                                                            "b"->List("ababa"),
+                                                                            "X-Auth"->List("foo!"),
+                                                                            "X-Roles"->List("bizRole","admin"))), response, chain),
+                         405, List("PUT"))
+     }
+
+
+    test (s"A DELETE on /a/b should validate with multiple unknown roles on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("DELETE", "/a/b", null, "", false,
+                                                    Map[String,List[String]]("a"->List("Bbba"),
+                                                                             "b"->List("Dbaba"),
+                                                                             "X-Auth"->List("foo!"),
+                                                                             "X-Roles"->List("bizBuz", "Wooga"))), response, chain),
+                         404, List("Resource not found"))
+    }
+
+
+    test (s"A DELETE on /a/b should validate with no roles $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("DELETE", "/a/b", null, "", false,
+                                                    Map[String,List[String]]("a"->List("Bbba"),
+                                                                             "b"->List("Dbaba"),
+                                                                             "X-Auth"->List("foo!"))), response, chain),
+                         404, List("Resource not found"))
+    }
+  }
+
+
+  //
+  // With captureHeaders disabled
+  //
+
+  for ((wadlDesc, wadl) <- captureHeaderWADLs) {
+    for ((configDesc, config) <- captureHeaderDisabledConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      happyWhenCaptureHeadersAreDisabled (validator, wadlDesc, configDesc)
+      happyWhenAssertsAreDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+
+  //
+  //  When captureHeaders are enabled
+  //
+  for ((wadlDesc, wadl) <- captureHeaderWADLs) {
+    for ((configDesc, config) <- captureHeaderEnabledConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      happyWhenCaptureHeadersAreEnabled (validator, wadlDesc, configDesc)
+      happyWhenAssertsAreDisabled(validator, wadlDesc, configDesc)
+      testsWithPlainParamsDisabled(validator, wadlDesc, configDesc)
+      testsWithRaxRolesDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+
+  //
+  //  When captureHeaders and Assert are enabled
+  //
+  for ((wadlDesc, wadl) <- captureHeaderWADLs) {
+    for ((configDesc, config) <- captureHeaderAssertEnabledConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      happyWhenCaptureHeadersAreEnabled (validator, wadlDesc, configDesc)
+      sadWhenAssertsAreDisabled(validator, wadlDesc, configDesc)
+      testsWithPlainParamsDisabled(validator, wadlDesc, configDesc)
+      testsWithRaxRolesDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+  //
+  //  When captureHeaders and param defaults are enabled
+  //
+  for ((wadlDesc, wadl) <- captureHeaderWADLs) {
+    for ((configDesc, config) <- captureHeaderEnabledParamDefaultConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      happyWhenCaptureHeadersAreEnabled (validator, wadlDesc, configDesc)
+      happyWhenAssertsAreDisabled(validator, wadlDesc, configDesc)
+      happyWhenParamDefaultsEnabled(validator, wadlDesc, configDesc)
+      testsWithPlainParamsDisabled(validator, wadlDesc, configDesc)
+      testsWithRaxRolesDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+
+  //
+  //  When captureHeaders with plain params enabled
+  //
+  for ((wadlDesc, wadl) <- captureHeaderWADLs) {
+    for ((configDesc, config) <- captureHeaderEnabledPlainParamConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      happyWhenCaptureHeadersAreEnabled (validator, wadlDesc, configDesc)
+      happyWhenAssertsAreDisabled(validator, wadlDesc, configDesc)
+      testsWithPlainParamsEnabled (validator, wadlDesc, configDesc)
+      testsWithRaxRolesDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+
+  //
+  //  When captureHeaders with plain params enabled, raxroles
+  //
+  for ((wadlDesc, wadl) <- captureHeaderWADLs) {
+    for ((configDesc, config) <- captureHeaderEnabledPlainRaxRoles) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      happyWhenCaptureHeadersAreEnabled (validator, wadlDesc, configDesc)
+      happyWhenAssertsAreDisabled(validator, wadlDesc, configDesc)
+      testsWithPlainParamsEnabled (validator, wadlDesc, configDesc)
+      testsWithRaxRolesEnabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+
+  //
+  //  When captureHeaders with plain params enabled, raxroles masked
+  //
+  for ((wadlDesc, wadl) <- captureHeaderWADLs) {
+    for ((configDesc, config) <- captureHeaderEnabledPlainRaxRolesMask) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths (validator, wadlDesc, configDesc)
+      happyWhenCaptureHeadersAreEnabled (validator, wadlDesc, configDesc)
+      happyWhenAssertsAreDisabled(validator, wadlDesc, configDesc)
+      testsWithPlainParamsEnabled (validator, wadlDesc, configDesc)
+      testsWithRaxRolesMaskEnabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
@@ -158,6 +158,10 @@ class BaseCheckerSpec extends BaseWADLSpec with LazyLogging {
     stepsWithAssertMessageMatch(checker, xpathMatch, message).filter (n => (n \ "@code").text == code.toString)
   }
 
+  def stepsWithCaptureHeader (checker : NodeSeq, name : String, expression : String) : NodeSeq = {
+    stepsWithType(checker, "CAPTURE_HEADER").filter( n => (n \ "@name").text == name).filter( n => (n \ "@path").text == expression)
+  }
+
   def stepsWithMethodMatch (checker : NodeSeq, methodMatch  : String) : NodeSeq = {
     stepsWithMatch (checker, methodMatch).filter(n => (n \ "@type").text == "METHOD")
   }
@@ -394,6 +398,7 @@ class BaseCheckerSpec extends BaseWADLSpec with LazyLogging {
   def RaxAssert(expression : String, message : String) : (NodeSeq) => NodeSeq = stepsWithAssertMessageMatch(_, expression, message)
   def RaxAssert(expression : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithAssertCodeMatch(_, expression, code)
   def RaxAssert(expression : String, message : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithAssertMessageCodeMatch(_, expression, message, code)
+  def RaxCaptureHeader(name : String, expression : String) : (NodeSeq) => NodeSeq = stepsWithCaptureHeader(_, name, expression)
   def ReqType(reqType : String) : (NodeSeq) => NodeSeq = stepsWithReqTypeMatch (_, "(?i)"+reqType)
   def AnyReqType : (NodeSeq) => NodeSeq = stepsWithReqTypeMatch (_, "(.*)()")
   def HeaderWithCapture(name : String, headerMatch : String, captureHeader : String) : (NodeSeq) => NodeSeq = stepsWithHeaderMatchCapture(_, name, headerMatch, captureHeader)

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerCaptureHeaderStepSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerCaptureHeaderStepSpec.scala
@@ -1,0 +1,881 @@
+package com.rackspace.com.papi.components.checker.wadl
+
+import com.rackspace.com.papi.components.checker.{LogAssertions, TestConfig}
+import org.apache.logging.log4j.Level
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml._
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerCaptureHeaderStepSpec extends BaseCheckerSpec with LogAssertions {
+  //
+  //  Register some common prefixes, you'll need the for XPath
+  //  assertions.
+  //
+  register ("xsd", "http://www.w3.org/2001/XMLSchema")
+  register ("wadl","http://wadl.dev.java.net/2009/02")
+  register ("xsl","http://www.w3.org/1999/XSL/Transform")
+  register ("chk","http://www.rackspace.com/repose/wadl/checker")
+  register ("tst","http://www.rackspace.com/repose/wadl/checker/step/test")
+
+
+  //
+  //  Configs...
+  //
+
+  val captureHeaderDisabled = {
+    val tc = TestConfig()
+    tc.enableCaptureHeaderExtension = false
+    tc.enableAssertExtension = false
+    tc.removeDups = false
+    tc
+  }
+
+  val captureHeaderEnabled = {
+    val tc = TestConfig()
+    tc.enableCaptureHeaderExtension = true
+    tc.enableAssertExtension = false
+    tc.removeDups = false
+    tc
+  }
+
+  val captureHeaderAssertEnabled = {
+    val tc = TestConfig()
+    tc.enableCaptureHeaderExtension = true
+    tc.enableAssertExtension = true
+    tc.removeDups = false
+    tc
+  }
+
+
+  val captureHeaderEnabledRemoveDups = {
+    val tc = TestConfig()
+    tc.enableCaptureHeaderExtension = true
+    tc.enableAssertExtension = false
+    tc.removeDups = true
+    tc
+  }
+
+  //
+  // WADLs...
+  //
+  val captureHeaderAtMethodLevel =
+            <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                 <request>
+                    <rax:captureHeader name="X-AUTH-DUP" path="req:header('X-AUTH')"/>
+                    <rax:assert test="req:header('X-AUTH') = 'foo!'"/>
+                  </request>
+               </method>
+            </resource>
+           </resources>
+          </application>
+
+  val captureHeaderAtMethodMultiRep =
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                    <rax:captureHeader name="X-AUTH-DUP" path="req:header('X-AUTH')"/>
+                  </request>
+               </method>
+            </resource>
+           </resources>
+          </application>
+
+  val captureHeaderAtResourceLevel =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                    <rax:captureHeader name="X-AUTH-DUP" path="req:header('X-AUTH')"/>
+                  </request>
+               </method>
+               <method name="PUT">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                  </request>
+               </method>
+               <resource path="c">
+                   <method name="GET">
+                   </method>
+                   <method name="POST">
+                    <request>
+                      <representation mediaType="application/xml"/>
+                      <representation mediaType="application/json"/>
+                      <representation mediaType="text/x-yaml"/>
+                    </request>
+                   </method>
+                   <method name="PUT">
+                     <request>
+                       <representation mediaType="application/xml"/>
+                       <representation mediaType="application/json"/>
+                       <representation mediaType="text/x-yaml"/>
+                     </request>
+                   </method>
+               </resource>
+               <rax:captureHeader name="X-CONTAINS-A" path="contains($req:uri,'/a')"/>
+            </resource>
+           </resources>
+          </application>
+
+  val captureHeaderAtResourceLevelApplyChildrenFalse =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                    <rax:captureHeader name="X-AUTH-DUP" path="req:header('X-AUTH')"/>
+                  </request>
+               </method>
+               <method name="PUT">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                  </request>
+               </method>
+               <resource path="c">
+                   <method name="GET">
+                   </method>
+                   <method name="POST">
+                    <request>
+                      <representation mediaType="application/xml"/>
+                      <representation mediaType="application/json"/>
+                      <representation mediaType="text/x-yaml"/>
+                    </request>
+                   </method>
+                   <method name="PUT">
+                     <request>
+                       <representation mediaType="application/xml"/>
+                       <representation mediaType="application/json"/>
+                       <representation mediaType="text/x-yaml"/>
+                     </request>
+                   </method>
+                </resource>
+                <rax:captureHeader name="X-CONTAINS-A" path="contains($req:uri,'/a')" applyToChildren="false"/>
+            </resource>
+           </resources>
+          </application>
+
+  val captureHeaderAtResourceLevelApplyChildrenTrue =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                    <rax:captureHeader name="X-AUTH-DUP" path="req:header('X-AUTH')"/>
+                  </request>
+               </method>
+               <method name="PUT">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                  </request>
+               </method>
+               <resource path="c">
+                   <method name="GET">
+                   </method>
+                   <method name="POST">
+                    <request>
+                      <representation mediaType="application/xml"/>
+                      <representation mediaType="application/json"/>
+                      <representation mediaType="text/x-yaml"/>
+                    </request>
+                   </method>
+                   <method name="PUT">
+                     <request>
+                       <representation mediaType="application/xml"/>
+                       <representation mediaType="application/json"/>
+                       <representation mediaType="text/x-yaml"/>
+                     </request>
+                   </method>
+               </resource>
+               <rax:captureHeader name="X-CONTAINS-A" path="contains($req:uri,'/a')" applyToChildren="true"/>
+            </resource>
+           </resources>
+          </application>
+
+
+  val captureHeaderAtResourceLevelApplyChildrenTrueRepAsserts =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:test="http://test/foo"
+                     >
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml">
+                      <rax:captureHeader name="X-FOO" path="/test:test/@foo"/>
+                    </representation>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml">
+                      <rax:captureHeader name="X-ACCEPT-DUP" path="req:headers('Accept', true())"/>
+                    </representation>
+                    <rax:captureHeader name="X-AUTH-DUP" path="req:header('X-AUTH')"/>
+                  </request>
+               </method>
+               <method name="PUT">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                  </request>
+               </method>
+               <resource path="c">
+                   <method name="GET">
+                   </method>
+                   <method name="POST">
+                    <request>
+                      <representation mediaType="application/xml"/>
+                      <representation mediaType="application/json"/>
+                      <representation mediaType="text/x-yaml"/>
+                    </request>
+                   </method>
+                   <method name="PUT">
+                     <request>
+                       <representation mediaType="application/xml"/>
+                       <representation mediaType="application/json">
+                            <rax:captureHeader name="X-ACCEPT-JSON" path="'application/json' = req:headers('Accept', true())"/>
+                       </representation>
+                       <representation mediaType="text/x-yaml"/>
+                     </request>
+                   </method>
+               </resource>
+               <rax:captureHeader name="X-CONTAINS-A" path="contains($req:uri,'/a')" applyToChildren="true"/>
+            </resource>
+           </resources>
+          </application>
+
+  val captureHeaderAtResourceLevelApplyChildrenTrueRepResourcesAsserts =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:test="http://test/foo">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml">
+                      <rax:captureHeader name="X-FOO" path="/test:test/@foo == 'bar'"/>
+                    </representation>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml">
+                      <rax:captureHeader name="X-ACCEPT-DUP" path="req:headers('Accept', true())"/>
+                    </representation>
+                    <rax:captureHeader name="X-AUTH-DUP" path="req:header('X-AUTH')"/>
+                  </request>
+               </method>
+               <method name="PUT">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                    <representation mediaType="text/x-yaml"/>
+                  </request>
+               </method>
+               <resource path="c">
+                   <method name="GET">
+                   </method>
+                   <method name="POST">
+                    <request>
+                      <representation mediaType="application/xml"/>
+                      <representation mediaType="application/json"/>
+                      <representation mediaType="text/x-yaml"/>
+                    </request>
+                   </method>
+                   <method name="PUT">
+                     <request>
+                       <representation mediaType="application/xml"/>
+                       <representation mediaType="application/json">
+                            <rax:captureHeader name="X-ACCEPT-JSON" path="'application/json' = req:headers('Accept', true())"/>
+                       </representation>
+                       <representation mediaType="text/x-yaml"/>
+                     </request>
+                   </method>
+               </resource>
+               <rax:captureHeader name="X-CONTAINS-A" path="contains($req:uri,'/a')" applyToChildren="true"/>
+            </resource>
+            <rax:captureHeader name="X-URI-NOT-EMPTY" path="not(empty($req:uri))"/>
+           </resources>
+          </application>
+
+  feature ("The WADLCheckerBuilder can correctly transforma a WADL into checker format") {
+
+    info ("As a developer")
+    info ("I want to be able to transform a WADL which references rax:assert extensions into a ")
+    info ("a description of a machine that can validate the API in checker format")
+    info ("so that an API validator can process the checker format to validate the API")
+
+    scenario ("The WADL contains a misplaced rax:captureHeader") {
+      Given("A WADL with a misplaced rax:assert")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                  </request>
+                  <!-- Notice captureHeader at method level, but not request level -->
+                  <rax:captureHeader name="X-AUTH-DUP" test="req:header('X-AUTH')"/>
+               </method>
+            </resource>
+           </resources>
+          </application>
+
+      When("the wadl is translated")
+      val checkerLog = log (Level.WARN) {
+        val checker = builder.build (inWADL, captureHeaderEnabled)
+        Then("No asserts should exist in the checker format")
+        assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 0")
+      }
+      And ("There should be a warning in the log that denotes that denotes the bad placement")
+      assert(checkerLog, "bad placement for <rax:captureHeader")
+      assert(checkerLog, "req:header('X-AUTH')")
+    }
+
+    scenario ("The WADL contains a method with a rax:captureHeader at the request level (rax:captureHeader disabled)") {
+      Given("A WADL with a GET operation with a rax:captureHeader at the request level, but rax:captureHeader disabled")
+      val inWADL = captureHeaderAtMethodLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), Accept)
+    }
+
+    scenario ("The WADL contains a method with a rax:captureHeader at the request level (rax:captureHeader enabled)") {
+      Given("A WADL with a GET operation with a rax:captureHeader at the request level, but rax:captureHeader enabled")
+      val inWADL = captureHeaderAtMethodLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabled)
+      Then ("The following captureHeaderions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 1")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), Accept)
+    }
+
+    scenario ("The WADL contains a method with a rax:captureHeader at the request level (rax:captureHeader, rax:assert enabled)") {
+      Given("A WADL with a GET operation with a rax:captureHeader at the request level, but rax:captureHeader enabled")
+      val inWADL = captureHeaderAtMethodLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderAssertEnabled)
+      Then ("The following captureHeaderions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 1")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), RaxAssert("req:header('X-AUTH') = 'foo!'"),
+        RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ContentFail)
+    }
+
+    scenario ("The WADL contains a method with a rax:captureHeader at the request level, XML, JSON, and YAML representations (rax:captureHeader disabled)") {
+      Given("A WADL with a GET operation with a rax:captureHeader at the request level, but rax:raxCaptureHeader disabled")
+      val inWADL = captureHeaderAtMethodMultiRep
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a method with a rax:captureHeader at the request level, XML, JSON, and YAML representations (rax:captureHeader enabled)") {
+      Given("A WADL with a GET operation with a rax:captureHeader at the request level, but rax:captureHeader enabled")
+      val inWADL = captureHeaderAtMethodMultiRep
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 3")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), Accept)
+    }
+
+    scenario ("The WADL contains a method with a rax:captureHeader at the request level, XML, JSON, and YAML representations (rax:captureHeader enabled, removeDups)") {
+      Given("A WADL with a GET operation with a rax:captureHeader at the request level, but rax:captureHeader enabled")
+      val inWADL = captureHeaderAtMethodMultiRep
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 1")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader disabled)") {
+      Given("A WADL with a rax:captureHeader at the resource level, but rax:captureHeader disabled")
+      val inWADL = captureHeaderAtResourceLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader enabled)") {
+      Given("A WADL with a with a rax:captureHeader at the resource level, but rax:captureHeader enabled")
+      val inWADL = captureHeaderAtResourceLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 9")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader enabled, removeDups)") {
+      Given("A WADL with a with a rax:captureHeader at the resource level, but rax:captureHeader enabled")
+      val inWADL = captureHeaderAtResourceLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 2")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader disabled, applyChildrenFalse)") {
+      Given("A WADL with a rax:captureHeader at the request level, but rax:captureHeader disabled, applyChildrenFalse")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenFalse
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader enabled, applyChildrenFalse)") {
+      Given("A WADL with a rax:captureHeader at the resource level, but rax:captureHeader enabled applyChldernFalse")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenFalse
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 9")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader enabled, applyChildrenFalse, removeDups)") {
+      Given("A WADL with a rax:captureHeader at the resource level, but rax:captureHeader enabled applyChldernFalse")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenFalse
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 2")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader disabled, applyChildrenTrue)") {
+      Given("A WADL with a rax:captureHeader at the resource level, but rax:captureHeader disabled applyChlidrenTrue")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenTrue
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader enabled, applyChildrenTrue)") {
+      Given("A WADL with a rax:captureHeader at the resource level applyChildernTrue")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenTrue
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabled)
+      Then ("The following captureHeaderions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 16")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader enabled, applyChildrenTrue, removeDups)") {
+      Given("A WADL with a rax:captureHeader at the resource level applyChildernTrue")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenTrue
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabledRemoveDups)
+      Then ("The following captureHeaderions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 2")
+
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader disabled, applyChildrenTrue, captureHeaders at representation)") {
+      Given("A WADL with a rax:captureHeader at the resource level, but rax:captureHeader disabled applyChlidrenTrue, and captureHeaders at representation")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenTrueRepAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader enabled, applyChildrenTrue, captureHeaders at representation)") {
+      Given("A WADL with a rax:captureHeader at the resource level, but rax:captureHeader enabled applyChlidrenTrue, and captureHeaders at representation")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenTrueRepAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabled)
+      Then ("The following assertions should hold")
+      assert(checker, "count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 19")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@path,'test:')]) = 'test'")
+      assert(checker, "namespace-uri-for-prefix('test', /chk:checker/chk:step[contains(@path,'test:')]) = 'http://test/foo'")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-FOO","/test:test/@foo"),
+             RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-ACCEPT-DUP","req:headers('Accept', true())"),
+             RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxCaptureHeader("X-ACCEPT-JSON","'application/json' = req:headers('Accept', true())"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader enabled, applyChildrenTrue, captureHeaders at representation, removeDups)") {
+      Given("A WADL with a rax:captureHeader at the resource level, but rax:captureHeader enabled applyChlidrenTrue, and captureHeaders at representation")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenTrueRepAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker, "count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 5")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@path,'test:')]) = 'test'")
+      assert(checker, "namespace-uri-for-prefix('test', /chk:checker/chk:step[contains(@path,'test:')]) = 'http://test/foo'")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-FOO","/test:test/@foo"),
+             RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-ACCEPT-DUP","req:headers('Accept', true())"),
+             RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxCaptureHeader("X-ACCEPT-JSON","'application/json' = req:headers('Accept', true())"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader disabled, applyChildrenTrue, captureHeaders at representation and resources level)") {
+      Given("A WADL with a rax:captureHeader at the resource level, but rax:captureHeader disabled applyChlidrenTrue, and captureHeaders at representation and resources level")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenTrueRepResourcesAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 0")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader enabled, applyChildrenTrue, captureHeaders at representation and resources level)") {
+      Given("A WADL with a rax:captureHeader at the resource level, but rax:captureHeader enabled applyChlidrenTrue, and captureHeaders at representation and resources level")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenTrueRepResourcesAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 32")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@path,'test:')]) = 'test'")
+      assert(checker, "namespace-uri-for-prefix('test', /chk:checker/chk:step[contains(@path,'test:')]) = 'http://test/foo'")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-FOO","/test:test/@foo == 'bar'"),
+             RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-ACCEPT-DUP","req:headers('Accept', true())"),
+             RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxCaptureHeader("X-ACCEPT-JSON","'application/json' = req:headers('Accept', true())"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+    }
+
+    scenario ("The WADL contains a resource with a rax:captureHeader at the resource level, XML, JSON, and YAML representations in methods (rax:captureHeader enabled, applyChildrenTrue, captureHeaders at representation and resources level, removeDups)") {
+      Given("A WADL with a rax:captureHeader at the resource level, but rax:captureHeader enabled applyChlidrenTrue, and captureHeaders at representation and resources level")
+      val inWADL = captureHeaderAtResourceLevelApplyChildrenTrueRepResourcesAsserts
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, captureHeaderEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='CAPTURE_HEADER']) = 6")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@path,'test:')]) = 'test'")
+      assert(checker, "namespace-uri-for-prefix('test', /chk:checker/chk:step[contains(@path,'test:')]) = 'http://test/foo'")
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-FOO","/test:test/@foo == 'bar'"),
+             RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-ACCEPT-DUP","req:headers('Accept', true())"),
+             RaxCaptureHeader("X-AUTH-DUP","req:header('X-AUTH')"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+
+
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("GET"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("POST"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON,
+             RaxCaptureHeader("X-ACCEPT-JSON","'application/json' = req:headers('Accept', true())"),
+             RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"), RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+      assert(checker, Start,URL("a"), URL("b"), URL("c"), Method("PUT"), ReqType("(text/x\\-yaml)(;.*)?"), RaxCaptureHeader("X-CONTAINS-A","contains($req:uri,'/a')"),
+             RaxCaptureHeader("X-URI-NOT-EMPTY","not(empty($req:uri))"), Accept)
+    }
+
+
+  }
+}


### PR DESCRIPTION
Currently capture header works on parameter  assertions. Here we put capture header in an element with relevant XPath 3.1 -- and this captures a header no matter what.  Should set things up exactly like assertion does.

Example : 

````xml
  <rax:captureHeader name="X-HEADER-NAME" path="/relevant/path"/>
````