### PR TITLE
rax:roles Masked has issues with setParamDefault

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,7 @@
 # Releases #
+## In Progress Work ##
+1. Fixed a bug where rax:roles were not masked correctly if default headers were set.
+
 ## Release 2.2.1 (2017-05-24) ##
 1. Fixed a bug where we were not correctly setting the classloader.
 

--- a/core/src/main/resources/xsl/raxRolesMask.xsl
+++ b/core/src/main/resources/xsl/raxRolesMask.xsl
@@ -89,7 +89,8 @@
                   select="('URL',
                           'URLXSD','METHOD','HEADER','HEADER_ANY',
                           'HEADERXSD','HEADERXSD_ANY', 'HEADER_ALL',
-                          'HEADER_SINGLE', 'HEADERXSD_SINGLE')"
+                          'HEADER_SINGLE', 'HEADERXSD_SINGLE',
+                          'SET_HEADER','SET_HEADER_ALWAYS')"
                   as="xs:string*"/>
 
     <xsl:template match="/">

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames.scala
@@ -61,6 +61,7 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames extends Fl
             </resource>
             <resource path="{yn}" rax:roles="a:admin-foo">
               <param name="yn" style="template" type="tst:yesno"/>
+              <param name="X-INT" style="header" type="xsd:string" required="true" default="999"/>
               <method href="#yn"/>
             </resource>
           </resource>
@@ -115,20 +116,20 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNames extends Fl
     it should behave like accessIsForbiddenWhenNoXRoles(validator, "DELETE", "/a/b", description)
 
     // GET on /a/yes, /a/no, /a/foo
-    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo"), description)
-    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo"), description)
-    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo"), description, List("'b'","yes","no"))
-    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer%"), description)
-    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo", "a:observer%"), description)
-    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer wsp"), description)
-    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo", "a:observer wsp"), description)
-    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer%"), description, List("'b'","yes","no"))
-    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer wsp"), description, List("'b'","yes","no"))
-    it should behave like accessIsForbidden(validator, "GET", "/a/yes", List("a:observer%"), description)
-    it should behave like accessIsForbidden(validator, "GET", "/a/no", List("a:observer%"), description)
-    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:observer%"), description, List("'b'","yes","no"))
-    it should behave like accessIsForbidden(validator, "GET", "/a/yes", List("a:observer wsp"), description)
-    it should behave like accessIsForbidden(validator, "GET", "/a/no", List("a:observer wsp"), description)
-    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:observer wsp"), description, List("'b'","yes","no"))
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/yes", List("a:admin-foo"), description)
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/no", List("a:admin-foo"), description)
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/foo", List("a:admin-foo"), description, List("'b'","yes","no"))
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer%"), description)
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/no", List("a:admin-foo", "a:observer%"), description)
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer wsp"), description)
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/no", List("a:admin-foo", "a:observer wsp"), description)
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer%"), description, List("'b'","yes","no"))
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer wsp"), description, List("'b'","yes","no"))
+    it should behave like accessIsForbiddenWithHeader(validator, "GET", "/a/yes", List("a:observer%"), description)
+    it should behave like accessIsForbiddenWithHeader(validator, "GET", "/a/no", List("a:observer%"), description)
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/foo", List("a:observer%"), description, List("'b'","yes","no"))
+    it should behave like accessIsForbiddenWithHeader(validator, "GET", "/a/yes", List("a:observer wsp"), description)
+    it should behave like accessIsForbiddenWithHeader(validator, "GET", "/a/no", List("a:observer wsp"), description)
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/foo", List("a:observer wsp"), description, List("'b'","yes","no"))
   }
 }

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNamesMasked.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNamesMasked.scala
@@ -61,6 +61,7 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNamesMasked exte
             </resource>
             <resource path="{yn}" rax:roles="a:admin-foo">
               <param name="yn" style="template" type="tst:yesno"/>
+              <param name="X-INT" style="header" type="xsd:string" required="true" default="999"/>
               <method href="#yn"/>
             </resource>
           </resource>
@@ -118,20 +119,20 @@ class GivenAWadlWithNestedResourcesAndMethodReferencesAndOddRoleNamesMasked exte
     it should behave like resourceNotFoundWhenNoXRoles(validator, "DELETE", "/a/b", description)
 
     // GET on /a/yes, /a/no, /a/foo
-    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo"), description)
-    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo"), description)
-    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo"), description, List("'b'","yes","no"))
-    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer%"), description)
-    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo", "a:observer%"), description)
-    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer%"), description, List("'b'","yes","no"))
-    it should behave like resourceNotFound(validator, "GET", "/a/yes", List("a:observer%"), description, List("{yes}"))
-    it should behave like resourceNotFound(validator, "GET", "/a/no", List("a:observer%"), description, List("{no}"))
-    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:observer%"), description, List("{foo}"))
-    it should behave like accessIsAllowed(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer wsp"), description)
-    it should behave like accessIsAllowed(validator, "GET", "/a/no", List("a:admin-foo", "a:observer wsp"), description)
-    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer wsp"), description, List("'b'","yes","no"))
-    it should behave like resourceNotFound(validator, "GET", "/a/yes", List("a:observer wsp"), description, List("{yes}"))
-    it should behave like resourceNotFound(validator, "GET", "/a/no", List("a:observer wsp"), description, List("{no}"))
-    it should behave like resourceNotFound(validator, "GET", "/a/foo", List("a:observer wsp"), description, List("{foo}"))
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/yes", List("a:admin-foo"), description)
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/no", List("a:admin-foo"), description)
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/foo", List("a:admin-foo"), description, List("'b'","yes","no"))
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer%"), description)
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/no", List("a:admin-foo", "a:observer%"), description)
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer%"), description, List("'b'","yes","no"))
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/yes", List("a:observer%"), description, List("{yes}"))
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/no", List("a:observer%"), description, List("{no}"))
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/foo", List("a:observer%"), description, List("{foo}"))
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/yes", List("a:admin-foo", "a:observer wsp"), description)
+    it should behave like accessIsAllowedWithHeader(validator, "GET", "/a/no", List("a:admin-foo", "a:observer wsp"), description)
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/foo", List("a:admin-foo", "a:observer wsp"), description, List("'b'","yes","no"))
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/yes", List("a:observer wsp"), description, List("{yes}"))
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/no", List("a:observer wsp"), description, List("{no}"))
+    it should behave like resourceNotFoundWithHeader(validator, "GET", "/a/foo", List("a:observer wsp"), description, List("{foo}"))
   }
 }


### PR DESCRIPTION
If setParamDefault is enabled then it seems as if a method with a default header (not ```X-Roles``` any header) will prevent the masking of that method.

The good news is:

1. Method is still protected :  It just won't be masked so you'll get a 403 if you don't have access
2. setParamDefault is not enabled by default
