### PR TITLE
Adding X-RELEVANT-ROLES header

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,10 @@
 1. Added support for ```rax:captureHeader```, this allows setting XPath 3.1 paths at the method request, representation, resource, and resources
    level to allow capturing a header with the result of the XPath. The XPaths can simultaneously introspect headers, uri, methods, and body content (xml or json).
 1. Fixed a bug where the priority of URL_FAIL states was set too high and this caused mislabeled 404 errors when rax:roles masked was enabled.
+1. Added support for `X-Relevant-Roles`, a header which will be added to the request any time `rax:roles` are being used.
+   `X-Relevant-Roles` are the values of the `X-Roles` header which match a `rax:roles` value for the resource being requested.
+   In other words, `X-Relevant-Roles` are the user roles which granted access to the resource.
+   Note that the `rax:captureHeader` feature must be enabled for the `X-Relevant-Roles` header to be populated. 
 
 ## Release 2.2.1 (2017-05-24) ##
 1. Fixed a bug where we were not correctly setting the classloader.

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/RaxRolesBehaviors.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/RaxRolesBehaviors.scala
@@ -30,37 +30,37 @@ trait RaxRolesBehaviors {
   def localWADLURI = (new File(System.getProperty("user.dir"), "mywadl.wadl")).toURI.toString
 
   def configWithRolesEnabled =
-    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true)
+    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, true)
 
   def configWithRolesEnabledDupsRemoved =
-    TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true)
+    TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, true)
 
   def configWithRolesMaskedEnabled =
-    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, false, true)
+    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, false, true, true)
 
   def configWithRolesMaskedEnabledDupsRemoved =
-    TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, false, true)
+    TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, false, true, true)
 
   def configWithRolesDisabledMaskedEnabled =
-    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, false, false, true)
+    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, false, false, true, true)
 
   def configWithRolesDisabledHeaderCheckEnabled =
-    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, false)
+    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, false, true)
 
   def configWithRolesDisabledHeaderCheckDisabled =
-    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, false, true, true, false, false, false)
+    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, false, true, true, false, false, false, true)
 
   def configWithRolesEnabledHeaderCheckDisabled =
-    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, false, true, true, false, false, true)
+    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, false, true, true, false, false, true, true)
 
   def configWithRolesMaskedEnabledHeaderCheckDisabled =
-    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, false, true, true, false, false, true, false, true)
+    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, false, true, true, false, false, true, false, true, true)
 
   def configWithRolesEnabledMessageExtDisabled =
-    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, false, false, false, true)
+    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, false, false, false, true, true)
 
   def configWithRolesMaskedEnabledMessageExtDisabled =
-    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, false, false, false, true, false, true)
+    TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, false, false, false, true, false, true, true)
 
   def configWithRaxRolesEnabledDefaultsEnabled = {
     val cfg = configWithRolesEnabled

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/TestConfig.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/TestConfig.scala
@@ -34,6 +34,27 @@ object TestConfig {
              enableIgnoreXSDExtension : Boolean, enableMessageExtension : Boolean,
              checkJSONGrammar : Boolean, enableIgnoreJSONSchemaExtension : Boolean,
              enableRaxRolesExtension: Boolean, preserveRequestBody : Boolean,
+             maskRaxRoles403 : Boolean, enableCaptureHeaderExtension: Boolean) : Config = {
+
+    val config = apply(removeDups, saxoneeValidation, wellFormed, checkXSDGrammar, checkElements,
+      xpathVersion, checkPlainParams, doXSDGrammarTransform, enablePreProcessExtension,
+      xslEngine, joinXPathChecks, checkHeaders, enableIgnoreXSDExtension, enableMessageExtension,
+      checkJSONGrammar, enableIgnoreJSONSchemaExtension, enableRaxRolesExtension, preserveRequestBody,
+      maskRaxRoles403)
+
+    config.enableCaptureHeaderExtension = enableCaptureHeaderExtension
+
+    config
+  }
+
+  def apply (removeDups : Boolean, saxoneeValidation : Boolean, wellFormed : Boolean,
+             checkXSDGrammar : Boolean, checkElements : Boolean, xpathVersion : Int,
+             checkPlainParams : Boolean, doXSDGrammarTransform : Boolean,
+             enablePreProcessExtension : Boolean, xslEngine : String,
+             joinXPathChecks : Boolean, checkHeaders : Boolean,
+             enableIgnoreXSDExtension : Boolean, enableMessageExtension : Boolean,
+             checkJSONGrammar : Boolean, enableIgnoreJSONSchemaExtension : Boolean,
+             enableRaxRolesExtension: Boolean, preserveRequestBody : Boolean,
              maskRaxRoles403 : Boolean) : Config = {
 
     val config = apply(removeDups, saxoneeValidation, wellFormed, checkXSDGrammar, checkElements,

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRelevantRolesSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRelevantRolesSuite.scala
@@ -1,0 +1,203 @@
+/** *
+  * Copyright 2017 Rackspace US, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.cloud.api.wadl.Converters._
+import com.rackspace.com.papi.components.checker.RunAssertionsHandler.ASSERT_FUNCTION
+import com.rackspace.com.papi.components.checker.servlet.{CheckerServletRequest, CheckerServletResponse}
+import com.rackspace.com.papi.components.checker.step.results.Result
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.collection.JavaConversions._
+import scala.xml.Elem
+
+@RunWith(classOf[JUnitRunner])
+class ValidatorWADLRelevantRolesSuite extends BaseValidatorSuite {
+  //
+  //  Configs
+  //
+  val baseConfig: Config = {
+    val c = TestConfig()
+    c.removeDups = false
+    c.checkWellFormed = true
+    c.checkElements = true
+    c.checkPlainParams = true
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = false
+    c.enableCaptureHeaderExtension = true
+    c.checkHeaders = true
+    c
+  }
+
+  val baseConfigWithMaskRaxRoles: Config = {
+    val c = TestConfig()
+    c.removeDups = false
+    c.checkWellFormed = true
+    c.checkElements = true
+    c.checkPlainParams = true
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c.enableCaptureHeaderExtension = true
+    c.checkHeaders = true
+    c
+  }
+
+  //
+  // WADLs
+  //
+  val WADL_withRaxRoles: Elem = {
+    <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/a" rax:roles="an:admin">
+          <method name="GET" rax:roles="an:observer"/>
+          <method name="POST"/>
+        </resource>
+        <resource path="/b" rax:roles="an:admin">
+          <resource path="/a" rax:roles="#all">
+            <method name="GET"/>
+          </resource>
+        </resource>
+        <resource path="/c">
+          <method name="GET"/>
+        </resource>
+        <resource path="/quotes">
+          <resource path="/apos" rax:roles="f&apos;oo bar">
+            <method name="GET"/>
+          </resource>
+          <resource path="/quot" rax:roles="f&quot;oo bar">
+            <method name="GET"/>
+          </resource>
+          <resource path="/aposquot" rax:roles="f&apos;&quot;oo bar">
+            <method name="GET"/>
+          </resource>
+        </resource>
+        <resource path="/nbsp">
+          <resource path="/raw" rax:roles="f oo bar">
+            <method name="GET"/>
+          </resource>
+          <resource path="/encoded" rax:roles="f&#160;oo bar">
+            <method name="GET"/>
+          </resource>
+        </resource>
+      </resources>
+    </application>
+  }
+
+  //
+  // Tests
+  //
+  Map(
+    "base config with maskRaxRoles disabled" -> baseConfig,
+    "base config with maskRaxRoles enabled" -> baseConfigWithMaskRaxRoles
+  ) foreach { case (configDesc, config) =>
+    test(s"X-RELEVANT-ROLES header should contain relevant roles using $configDesc") {
+      val validator = Validator(WADL_withRaxRoles, config)
+      val req = request("GET", "/a", "application/xml", goodXML, parseContent = false,
+        Map("X-Roles" -> List("an:admin", "foo", "bar", "an:observer")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-RELEVANT-ROLES").toList == List("an:admin", "an:observer"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"X-RELEVANT-ROLES should only contain case-sensitive equal roles using $configDesc") {
+      val validator = Validator(WADL_withRaxRoles, config)
+      val req = request("GET", "/a", "application/xml", goodXML, parseContent = false,
+        Map("X-Roles" -> List("an:ADMIN", "an:admin")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-RELEVANT-ROLES").toList == List("an:admin"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"X-RELEVANT-ROLES header should be all roles if rax:roles is set to #all using $configDesc") {
+      val validator = Validator(WADL_withRaxRoles, config)
+      val req = request("GET", "/b/a", "application/xml", goodXML, parseContent = false,
+        Map("X-Roles" -> List("an:admin", "admin", "foo", "bar", "observer")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-RELEVANT-ROLES").toList == List("an:admin", "admin", "foo", "bar", "observer"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"X-RELEVANT-ROLES header should contain a matching role with an apostrophe using $configDesc") {
+      val validator = Validator(WADL_withRaxRoles, config)
+      val req = request("GET", "/quotes/apos", "application/xml", goodXML, parseContent = false,
+        Map("X-Roles" -> List("f'oo")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-RELEVANT-ROLES").toList == List("f'oo"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"X-RELEVANT-ROLES header should contain a matching role with a quote using $configDesc") {
+      val validator = Validator(WADL_withRaxRoles, config)
+      val req = request("GET", "/quotes/quot", "application/xml", goodXML, parseContent = false,
+        Map("X-Roles" -> List("f\"oo")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-RELEVANT-ROLES").toList == List("f\"oo"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"X-RELEVANT-ROLES header should contain a matching role with an apostrophe and quote using $configDesc") {
+      val validator = Validator(WADL_withRaxRoles, config)
+      val req = request("GET", "/quotes/aposquot", "application/xml", goodXML, parseContent = false,
+        Map("X-Roles" -> List("f'\"oo")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-RELEVANT-ROLES").toList == List("f'\"oo"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"X-RELEVANT-ROLES header should contain a matching role with a NBSP using $configDesc") {
+      val validator = Validator(WADL_withRaxRoles, config)
+      val req = request("GET", "/nbsp/raw", "application/xml", goodXML, parseContent = false,
+        Map("X-Roles" -> List("f oo")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-RELEVANT-ROLES").toList == List("f oo"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"X-RELEVANT-ROLES header should contain a matching role with an encoded NBSP using $configDesc") {
+      val validator = Validator(WADL_withRaxRoles, config)
+      val req = request("GET", "/nbsp/encoded", "application/xml", goodXML, parseContent = false,
+        Map("X-Roles" -> List("f oo")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-RELEVANT-ROLES").toList == List("f oo"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerRaxRolesSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerRaxRolesSpec.scala
@@ -205,46 +205,62 @@ class WADLCheckerRaxRolesSpec extends BaseCheckerSpec {
         And("URLs and Methods should be validated as well as headers")
         assert (checker, Start, URL("a"), Method("PUT"),
                 HeaderAny("X-ROLES","a:admin","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), Method("PUT"),
                 HeaderAny("X-ROLES","a:observer","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("POST"),
                 HeaderAny("X-ROLES","a:admin","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("POST"),
                 HeaderAny("X-ROLES","b:creator","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("PUT"),
                 HeaderAny("X-ROLES","b:observer","You are forbidden to perform the operation", 403),
-                Accept)
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator', 'b:observer')) then $h else ()"),
+          Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("PUT"),
                 HeaderAny("X-ROLES","a:admin","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator', 'b:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("PUT"),
                 HeaderAny("X-ROLES","b:creator","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator', 'b:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("DELETE"),
                 HeaderAny("X-ROLES","b:admin","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("DELETE"),
                 HeaderAny("X-ROLES","b:observer","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("DELETE"),
                 HeaderAny("X-ROLES","a:admin","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("DELETE"),
                 HeaderAny("X-ROLES","b:creator","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
                 Accept)
-        assert (checker, Start, URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, URL("a"), URLXSD("tst:yesno"), Method("POST"),
                 HeaderAny("X-ROLES","a:admin","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URLXSD("tst:yesno"), Method("PUT"),
                 HeaderAny("X-ROLES","a:admin","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URLXSD("tst:yesno"), Method("PUT"),
                 HeaderAny("X-ROLES","b:observer","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), Method("PUT"), ContentFail)
         assert (checker, Start, URL("a"), URL("b"), Method("POST"), ContentFail)
@@ -256,10 +272,16 @@ class WADLCheckerRaxRolesSpec extends BaseCheckerSpec {
         assert (checker, Start, URL("c"), ContentFail)
         assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), URLFail)
         assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), MethodFail("GET|POST"))
-        assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("GET"), HeaderAny("X-ROLES","a:admin"), Accept)
+        assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("GET"), HeaderAny("X-ROLES","a:admin"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin')) then $h else ()"),
+                Accept)
         assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("GET"), ContentFail)
-        assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), HeaderAny("X-ROLES","a:admin"), Accept)
-        assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), HeaderAny("X-ROLES","a:observer"), Accept)
+        assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), HeaderAny("X-ROLES","a:admin"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), HeaderAny("X-ROLES","a:observer"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), ContentFail)
       }
 
@@ -280,54 +302,98 @@ class WADLCheckerRaxRolesSpec extends BaseCheckerSpec {
                              namespace-uri-from-QName(resolve-QName($s/@notTypes, $s)) = 'test://schema/a' and
                              local-name-from-QName(resolve-QName($s/@notTypes, $s)) = 'yesno'""")
         And("URLs and Methods should be validated as well as headers")
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"),URL("a"), Method("PUT"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"),URL("a"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"),URL("a"), MethodFail("PUT"))
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"),URL("a"), URLFail("b"))
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"),URL("a"), URLFailT("tst:yesno"))
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URLFail("a|c"))
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("POST"),Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("PUT"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("DELETE"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("POST"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("DELETE"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), MethodFail("DELETE|GET|POST|PUT"))
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), URLFail)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URLXSD("tst:yesno"), Method("POST"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URLXSD("tst:yesno"), Method("PUT"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URLXSD("tst:yesno"), Method("POST"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URLXSD("tst:yesno"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URLXSD("tst:yesno"), MethodFail("POST|PUT"))
-        assert (checker, Start, HeaderAny("X-ROLES","a:observer"),URL("a"), Method("PUT"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:observer"),URL("a"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:observer"),URL("a"), MethodFail("PUT"))
         assert (checker, Start, HeaderAny("X-ROLES","a:observer"),URL("a"), URLFail)
         assert (checker, Start, HeaderAny("X-ROLES","a:observer"), URLFail("a|c"))
-        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("POST"),Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("PUT"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("DELETE"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("POST"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("DELETE"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), MethodFail("DELETE|GET|POST|PUT"))
         assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), URLFail)
         assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URLFail("b"))
         assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URLFailT("tst:yesno"))
-        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("PUT"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("DELETE"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("DELETE"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), MethodFail("DELETE|GET|PUT"))
         assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), URLFail)
-        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URLXSD("tst:yesno"), Method("PUT"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URLXSD("tst:yesno"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URLXSD("tst:yesno"), MethodFail("PUT"))
-        assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), Method("DELETE"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), Method("DELETE"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), MethodFail("DELETE|GET"))
         assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), URLFail)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), MethodFail)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), ContentFail)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("GET"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), Header("X-Auth-Token", "(?s).*"), MethodFail("GET|POST"))
-        assert (checker, Start, HeaderAny("X-ROLES","a:observer"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:observer"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:observer"), URL("c"), Header("X-Auth-Token", "(?s).*"), MethodFail("POST"))
         assert (checker, Start, URLFail("a"))
         assert (checker, Start, URL("a"), URLFail("b"))
         assert (checker, Start, URL("a"), MethodFail)
-        assert (checker, Start, URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, URL("a"), URL("b"), MethodFail("GET"))
         assert (checker, Start, URL("a"), URL("b"), URLFail)
         assert (checker, Start, MethodFail)
@@ -352,22 +418,30 @@ class WADLCheckerRaxRolesSpec extends BaseCheckerSpec {
         And("URLs and Methods should be validated as well as headers")
         assert (checker, Start, URL("a"), Method("PUT"),
                 HeaderAny("X-ROLES","a:admin|a:observer","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("POST"),
                 HeaderAny("X-ROLES","a:admin|b:creator","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("PUT"),
-                HeaderAny("X-ROLES","b:observer|a:admin|b:creator","You are forbidden to perform the operation", 403),
+                HeaderAny("X-ROLES","a:admin|b:creator|b:observer","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator', 'b:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URL("b"), Method("DELETE"),
-                HeaderAny("X-ROLES","b:admin|b:observer|a:admin|b:creator","You are forbidden to perform the operation", 403),
+                HeaderAny("X-ROLES","a:admin|b:creator|b:observer|b:admin","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
                 Accept)
-        assert (checker, Start, URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, URL("a"), URLXSD("tst:yesno"), Method("POST"),
                 HeaderAny("X-ROLES","a:admin","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), URLXSD("tst:yesno"), Method("PUT"),
                 HeaderAny("X-ROLES","a:admin|b:observer","You are forbidden to perform the operation", 403),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:observer')) then $h else ()"),
                 Accept)
         assert (checker, Start, URL("a"), Method("PUT"), ContentFail)
         assert (checker, Start, URL("a"), URL("b"), Method("POST"), ContentFail)
@@ -379,9 +453,13 @@ class WADLCheckerRaxRolesSpec extends BaseCheckerSpec {
         assert (checker, Start, URL("c"), ContentFail)
         assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), URLFail)
         assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), MethodFail("GET|POST"))
-        assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("GET"), HeaderAny("X-ROLES","a:admin"), Accept)
+        assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("GET"), HeaderAny("X-ROLES","a:admin"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin')) then $h else ()"),
+                Accept)
         assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("GET"), ContentFail)
-        assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), HeaderAny("X-ROLES","a:admin|a:observer"), Accept)
+        assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), HeaderAny("X-ROLES","a:admin|a:observer"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), ContentFail)
       }
 
@@ -402,54 +480,98 @@ class WADLCheckerRaxRolesSpec extends BaseCheckerSpec {
                              namespace-uri-from-QName(resolve-QName($s/@notTypes, $s)) = 'test://schema/a' and
                              local-name-from-QName(resolve-QName($s/@notTypes, $s)) = 'yesno'""")
         And("URLs and Methods should be validated as well as headers")
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"),URL("a"), Method("PUT"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"),URL("a"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"),URL("a"), MethodFail("PUT"))
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"),URL("a"), URLFail("b"))
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"),URL("a"), URLFailT("tst:yesno"))
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URLFail("a|c"))
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("POST"),Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("PUT"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("DELETE"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("POST"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("DELETE"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), MethodFail("DELETE|GET|POST|PUT"))
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URL("b"), URLFail)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URLXSD("tst:yesno"), Method("POST"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URLXSD("tst:yesno"), Method("PUT"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URLXSD("tst:yesno"), Method("POST"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URLXSD("tst:yesno"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("a"), URLXSD("tst:yesno"), MethodFail("POST|PUT"))
-        assert (checker, Start, HeaderAny("X-ROLES","a:observer"),URL("a"), Method("PUT"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:observer"),URL("a"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:observer"),URL("a"), MethodFail("PUT"))
         assert (checker, Start, HeaderAny("X-ROLES","a:observer"),URL("a"), URLFail)
         assert (checker, Start, HeaderAny("X-ROLES","a:observer"), URLFail("a|c"))
-        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("POST"),Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("PUT"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("DELETE"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("POST"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("DELETE"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), MethodFail("DELETE|GET|POST|PUT"))
         assert (checker, Start, HeaderAny("X-ROLES","b:creator"), URL("a"), URL("b"), URLFail)
         assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URLFail("b"))
         assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URLFailT("tst:yesno"))
-        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("PUT"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("DELETE"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("DELETE"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), MethodFail("DELETE|GET|PUT"))
         assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URL("b"), URLFail)
-        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URLXSD("tst:yesno"), Method("PUT"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URLXSD("tst:yesno"), Method("PUT"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","b:observer"), URL("a"), URLXSD("tst:yesno"), MethodFail("PUT"))
-        assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), Method("DELETE"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), Method("DELETE"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'b:admin', 'b:creator', 'b:observer')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), MethodFail("DELETE|GET"))
         assert (checker, Start, HeaderAny("X-ROLES","b:admin"), URL("a"), URL("b"), URLFail)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), MethodFail)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), ContentFail)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("GET"), Accept)
-        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin')) then $h else ()"),
+                Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:admin"), URL("c"), Header("X-Auth-Token", "(?s).*"), MethodFail("GET|POST"))
-        assert (checker, Start, HeaderAny("X-ROLES","a:observer"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"), Accept)
+        assert (checker, Start, HeaderAny("X-ROLES","a:observer"), URL("c"), Header("X-Auth-Token", "(?s).*"), Method("POST"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "for $h in req:headers('X-ROLES', true()) return if ($h = ('a:admin', 'a:observer')) then $h else ()"),
+                Accept)
         assert (checker, Start, HeaderAny("X-ROLES","a:observer"), URL("c"), Header("X-Auth-Token", "(?s).*"), MethodFail("POST"))
         assert (checker, Start, URLFail("a"))
         assert (checker, Start, URL("a"), URLFail("b"))
         assert (checker, Start, URL("a"), MethodFail)
-        assert (checker, Start, URL("a"), URL("b"), Method("GET"), Accept)
+        assert (checker, Start, URL("a"), URL("b"), Method("GET"),
+                RaxCaptureHeader("X-RELEVANT-ROLES", "req:headers('X-ROLES', true())"),
+                Accept)
         assert (checker, Start, URL("a"), URL("b"), MethodFail("GET"))
         assert (checker, Start, URL("a"), URL("b"), URLFail)
         assert (checker, Start, MethodFail)


### PR DESCRIPTION
This PR adds support for relevant roles. Relevant roles are roles which grant a request access to a resource. Technically, these roles are the intersection of roles which belong to the user (i.e., the values of the X-Roles header) and roles which are required to access a resource (i.e., the values of rax:roles). Relevant roles will be added to the X-Relevant-Roles request header.