### PR TITLE
rax:rolesMask potentially bad error messages with URL Fails

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 1. Fixed a bug where rax:roles were not masked correctly if default headers were set.
 1. Added support for ```rax:captureHeader```, this allows setting XPath 3.1 paths at the method request, representation, resource, and resources
    level to allow capturing a header with the result of the XPath. The XPaths can simultaneously introspect headers, uri, methods, and body content (xml or json).
+1. Fixed a bug where the priority of URL_FAIL states was set too high and this caused mislabeled 404 errors when rax:roles masked was enabled.
 
 ## Release 2.2.1 (2017-05-24) ##
 1. Fixed a bug where we were not correctly setting the classloader.

--- a/core/src/main/resources/xsl/priority-map.xml
+++ b/core/src/main/resources/xsl/priority-map.xml
@@ -29,7 +29,7 @@
     limitations under the License.
 -->
 <priority-map xmlns="http://www.rackspace.com/repose/wadl/checker/priority">
-    <map type="URL_FAIL"      priority="10000" attributeMultipliers="notMatch notTypes" multValue="50"/>
+    <map type="URL_FAIL"      priority="10000" attributeMultipliers="notMatch notTypes" multValue="2"/>
     <map type="METHOD_FAIL"   priority="20000" attributeMultipliers="notMatch" multValue="50"/>
     <map type="CONTENT_FAIL"  priority="40000"/>
     <map type="HEADER"        priority="41000"/>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithSparseNestedResources.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithSparseNestedResources.scala
@@ -1,0 +1,123 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.cloud.api.wadl.Converters._
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class GivenAWadlWithSparseNestedResources extends FlatSpec with RaxRolesBehaviors {
+
+  val configs = Map[String, Config]("Config With Roles Enabled" -> configWithRolesEnabled,
+    "Config With Roles Enabled and Messsage Extensions Disabled" -> configWithRolesEnabledMessageExtDisabled,
+    "Config With Roles Enabled and Duplications Removed" -> configWithRolesEnabledDupsRemoved,
+    "Config With Roles Enabled and Header Checks Disabled" -> configWithRolesEnabledHeaderCheckDisabled,
+    "Config with Roles Enabled and Default Parameters Enabled" -> configWithRaxRolesEnabledDefaultsEnabled,
+    "Config with Roles Enabled, Default Parameters Enabled and Duplications Removed" -> configWithRaxRolesEnabledDupsRemovedDefaultsEnabled)
+
+  for ((description, configuration) <- configs) {
+
+    val validator = Validator((localWADLURI,
+      <application xmlns="http://wadl.dev.java.net/2009/02"
+                   xmlns:rax="http://docs.rackspace.com/api"
+                   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:tst="test://schema/a">
+        <grammars>
+           <schema elementFormDefault="qualified"
+                   attributeFormDefault="unqualified"
+                   xmlns="http://www.w3.org/2001/XMLSchema"
+                   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   targetNamespace="test://schema/a">
+              <simpleType name="yesno">
+                 <restriction base="xsd:string">
+                     <enumeration value="yes"/>
+                     <enumeration value="no"/>
+                 </restriction>
+             </simpleType>
+           </schema>
+        </grammars>
+        <resources base="https://test.api.openstack.com">
+          <resource path="/a">
+            <method name="PUT"/>
+            <resource path="/z">
+              <method name="PUT"/>
+            </resource>
+            <resource path="/b" rax:roles="b:creator">
+              <method name="PUT"/>
+              <resource path="c" rax:roles="c:creator">
+                <method name="POST"/>
+              </resource>
+            </resource>
+          </resource>
+        </resources>
+      </application>)
+      , configuration)
+
+    // PUT /a has resource level a:admin, method level a:observer
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("another:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer", "a:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("b:observer"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("b:creator"), description)
+    it should behave like accessIsAllowedWhenNoXRoles(validator, "PUT", "/a", description)
+
+    // PUT /a/z has resource level a:admin, method level a:observer
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("a:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("another:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("a:observer"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("a:observer", "a:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("b:observer"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("b:creator"), description)
+    it should behave like accessIsAllowedWhenNoXRoles(validator, "PUT", "/a/z", description)
+
+    //  Should be not found on /a/b/z
+    it should behave like resourceNotFound(validator, "PUT", "/a/b/z", List("b:creator"), description, List("{z}","'c'"))
+
+    //  Should be not found on /a/b/c/z
+    it should behave like resourceNotFound(validator, "PUT", "/a/b/c/z", List("b:creator"), description, List("{z}"))
+
+    // DELETE /a has resource level a:admin, method is not defined
+    it should behave like methodNotAllowed(validator, "DELETE", "/a", List("a:admin"), description)
+    it should behave like methodNotAllowed(validator, "DELETE", "/a", List(), description)
+
+    // POST /a/b has parent resource level a:admin, resource level b:creator
+    it should behave like methodNotAllowed(validator, "POST", "/a/b", List("a:admin"), description)
+
+    // PUT /a/b has parent resource level a:admin, resource level b:creator, method level b:observer
+    it should behave like accessIsForbidden(validator, "PUT", "/a/b", List("a:admin"), description)
+    it should behave like accessIsForbidden(validator, "PUT", "/a/b", List("another:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/b", List("b:creator"), description)
+    it should behave like accessIsForbidden(validator, "PUT", "/a/b", List("b:observer", "a:foo"), description)
+    it should behave like accessIsForbidden(validator, "PUT", "/a/b", List("a:creator"), description)
+    it should behave like accessIsForbidden(validator, "PUT", "/a/b", List(), description)
+    it should behave like accessIsForbidden(validator, "PUT", "/a/b", List("observer"), description)
+    it should behave like accessIsForbiddenWhenNoXRoles(validator, "PUT", "/a/b", description)
+
+
+    // POST /a/b/c has parent resource level a:admin, another:admin, b:creator, c:creator
+    it should behave like accessIsForbidden(validator, "POST", "/a/b/c", List("a:admin"), description)
+    it should behave like accessIsForbidden(validator, "POST", "/a/b/c", List("another:admin"), description)
+    it should behave like accessIsAllowed(validator, "POST", "/a/b/c", List("b:creator"), description)
+    it should behave like accessIsAllowed(validator, "POST", "/a/b/c", List("c:creator"), description)
+    it should behave like accessIsForbidden(validator, "PUT", "/a/b", List("c:creator"), description)
+    it should behave like methodNotAllowed(validator, "DELETE", "/a/b/c", List("a:admin"), description)
+    it should behave like methodNotAllowed(validator, "PUT", "/a/b/c", List("a:admin"), description)
+    it should behave like accessIsForbiddenWhenNoXRoles(validator, "POST", "/a/b/c", description)
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithSparseNestedResourcesMasked.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithSparseNestedResourcesMasked.scala
@@ -1,0 +1,124 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.cloud.api.wadl.Converters._
+import org.junit.runner.RunWith
+import org.scalatest.FlatSpec
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class GivenAWadlWithSparseNestedResourcesMasked extends FlatSpec with RaxRolesBehaviors {
+
+  val configs = Map[String, Config]("Config With Roles Enabled" -> configWithRolesMaskedEnabled,
+    "Config With Roles Enabled and Messsage Extensions Disabled" -> configWithRolesMaskedEnabledMessageExtDisabled,
+    "Config With Roles Enabled and Duplications Removed" -> configWithRolesMaskedEnabledDupsRemoved,
+    "Config With Roles Enabled and Header Checks Disabled" -> configWithRolesMaskedEnabledHeaderCheckDisabled,
+    "Config With Roles Enabled and Defaults Enabled" -> configWithRolesMaskedEnabledDefaultsEnabled,
+    "Config With Roles Enabled and Dubplications Removed and Defaults Enabled" -> configWithRolesMaskedEnabledDupsRemovedDefaultsEnabled)
+
+  for ((description, configuration) <- configs) {
+
+    val validator = Validator((localWADLURI,
+      <application xmlns="http://wadl.dev.java.net/2009/02"
+                   xmlns:rax="http://docs.rackspace.com/api"
+                   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:tst="test://schema/a">
+        <grammars>
+           <schema elementFormDefault="qualified"
+                   attributeFormDefault="unqualified"
+                   xmlns="http://www.w3.org/2001/XMLSchema"
+                   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   targetNamespace="test://schema/a">
+              <simpleType name="yesno">
+                 <restriction base="xsd:string">
+                     <enumeration value="yes"/>
+                     <enumeration value="no"/>
+                 </restriction>
+             </simpleType>
+           </schema>
+        </grammars>
+        <resources base="https://test.api.openstack.com">
+          <resource path="/a">
+            <method name="PUT"/>
+            <resource path="/z">
+              <method name="PUT"/>
+            </resource>
+            <resource path="/b" rax:roles="b:creator">
+              <method name="PUT"/>
+              <resource path="c" rax:roles="c:creator">
+                <method name="POST"/>
+              </resource>
+            </resource>
+          </resource>
+        </resources>
+      </application>)
+      , configuration)
+
+    // PUT /a has resource level a:admin, method level a:observer
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("another:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("a:observer", "a:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("b:observer"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a", List("b:creator"), description)
+    it should behave like accessIsAllowedWhenNoXRoles(validator, "PUT", "/a", description)
+
+    // PUT /a/z has resource level a:admin, method level a:observer
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("a:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("another:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("a:observer"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("a:observer", "a:admin"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("b:observer"), description)
+    it should behave like accessIsAllowed(validator, "PUT", "/a/z", List("b:creator"), description)
+    it should behave like accessIsAllowedWhenNoXRoles(validator, "PUT", "/a/z", description)
+
+    //  Should be not found on /a/b/z
+    it should behave like resourceNotFound(validator, "PUT", "/a/b/z", List("b:creator"), description, List("{z}","'c'"))
+
+    //  Should be not found on /a/b/c/z
+    it should behave like resourceNotFound(validator, "PUT", "/a/b/c/z", List("b:creator"), description, List("{z}"))
+
+
+    // DELETE /a has resource level a:admin, method is not defined
+    it should behave like methodNotAllowed(validator, "DELETE", "/a", List("a:admin"), description)
+    it should behave like methodNotAllowed(validator, "DELETE", "/a", List(), description)
+
+    // POST /a/b has parent resource level a:admin, resource level b:creator
+    it should behave like resourceNotFound(validator, "POST", "/a/b", List("a:admin"), description, List("{b}"))
+
+    // PUT /a/b has parent resource level a:admin, resource level b:creator, method level b:observer
+    it should behave like resourceNotFound(validator, "PUT", "/a/b", List("a:admin"), description, List("{b}"))
+    it should behave like resourceNotFound(validator, "PUT", "/a/b", List("another:admin"), description, List("{b}"))
+    it should behave like accessIsAllowed(validator, "PUT", "/a/b", List("b:creator"), description)
+    it should behave like resourceNotFound(validator, "PUT", "/a/b", List("b:observer", "a:foo"), description, List("{b}"))
+    it should behave like resourceNotFound(validator, "PUT", "/a/b", List("a:creator"), description, List("{b}"))
+    it should behave like resourceNotFound(validator, "PUT", "/a/b", List(), description, List("{b}"))
+    it should behave like resourceNotFound(validator, "PUT", "/a/b", List("observer"), description, List("{b}"))
+    it should behave like resourceNotFoundWhenNoXRoles(validator, "PUT", "/a/b", description, List("{b}"))
+
+
+    // POST /a/b/c has parent resource level a:admin, another:admin, b:creator, c:creator
+    it should behave like resourceNotFound(validator, "POST", "/a/b/c", List("a:admin"), description, List("{b}"))
+    it should behave like resourceNotFound(validator, "POST", "/a/b/c", List("another:admin"), description, List("{b}"))
+    it should behave like accessIsAllowed(validator, "POST", "/a/b/c", List("b:creator"), description)
+    it should behave like accessIsAllowed(validator, "POST", "/a/b/c", List("c:creator"), description)
+    it should behave like methodNotAllowed(validator, "PUT", "/a/b", List("c:creator"), description)
+    it should behave like resourceNotFound(validator, "DELETE", "/a/b/c", List("a:admin"), description, List("{b}"))
+    it should behave like resourceNotFound(validator, "PUT", "/a/b/c", List("a:admin"), description, List("{b}"))
+    it should behave like resourceNotFoundWhenNoXRoles(validator, "POST", "/a/b/c", description, List("{b}"))
+  }
+}


### PR DESCRIPTION
The issue occurs when we get one path, which does not require roles:

```/a/z```

and another path which does require a role (user)

```/a/b```

If I make a request with the role user for /a/b/c, the response should be 404, don't understand {c}...instead you'll get 404, don't understand {b}.  Why?

The error for missing z has higher priority because z is a specific miss.  The error condition for missing c is lower because c...is a non-specific miss.