### PR TITLE
Be smarter about generating opt code

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,8 @@
 1. Added support for `X-Relevant-Roles`, a header which will be added to the request any time `rax:roles` are being used.
    `X-Relevant-Roles` are the values of the `X-Roles` header which match a `rax:roles` value for the resource being requested.
    In other words, `X-Relevant-Roles` are the user roles which granted access to the resource.
-   Note that the `rax:captureHeader` feature must be enabled for the `X-Relevant-Roles` header to be populated. 
+   Note that the `rax:captureHeader` feature must be enabled for the `X-Relevant-Roles` header to be populated.
+1. Clean up : code for optimization stages is now generated in smaller templates to avoid method size restrictions and allow for bytecode generation.
 
 ## Release 2.2.1 (2017-05-24) ##
 1. Fixed a bug where we were not correctly setting the classloader.

--- a/core/src/main/resources/xsl/opt/commonJoinTemplate.xsl
+++ b/core/src/main/resources/xsl/opt/commonJoinTemplate.xsl
@@ -35,6 +35,7 @@
     <xsl:namespace-alias stylesheet-prefix="xslout" result-prefix="xsl"/>
     <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
 
+    <xsl:variable name="pfx" as="xs:string" select="'TMP-'"/>
     <xsl:variable name="rules" as="node()" select="/rules:rules"/>
     <xsl:variable name="types" as="xs:string*" select="distinct-values(tokenize(string-join($rules/rules:rule/@types, ' '), ' '))"/>
 
@@ -58,12 +59,23 @@
                 <xslout:param name="checker" as="node()"/>
                 <xslout:variable name="nextStep" as="node()*" select="check:stepsByIds($checker, check:next(.))"/>
                 <xsl:for-each select="$types">
-                    <xsl:variable name="rule" as="node()" select="key('rule-by-type', ., $rules)"/>
-                    <xsl:variable name="required" as="xs:string*" select="for $r in tokenize($rule/@required,' ') return
-                                                                          (: Don't treat next as a required attribute, we are joining by it :)
-                                                                          if ($r = 'next') then () else $r"/>
-                    <xsl:variable name="optional" as="xs:string*" select="tokenize($rule/@optional,' ')"/>
-                    <xsl:variable name="match" as="xs:string?" select="$rule/@match"/>
+                    <xslout:call-template name="{$pfx}{.}">
+                        <xslout:with-param name="checker" select="$checker"/>
+                        <xslout:with-param name="nextStep" select="$nextStep"/>
+                    </xslout:call-template>
+                </xsl:for-each>
+            </xslout:template>
+            <xsl:for-each select="$types">
+                <xsl:variable name="rule" as="node()" select="key('rule-by-type', ., $rules)"/>
+                <xsl:variable name="required" as="xs:string*" select="for $r in tokenize($rule/@required,' ') return
+                                                                      (: Don't treat next as a required attribute, we are joining by it :)
+                                                                      if ($r = 'next') then () else $r"/>
+                <xsl:variable name="optional" as="xs:string*" select="tokenize($rule/@optional,' ')"/>
+                <xsl:variable name="match" as="xs:string?"
+                              select="$rule/@match"/>
+                <xslout:template name="{$pfx}{.}">
+                    <xslout:param name="checker" as="node()"/>
+                    <xslout:param name="nextStep" as="node()*"/>
                     <xsl:call-template name="matchJoinTemplates">
                         <xsl:with-param name="type" select="."/>
                         <xsl:with-param name="required" select="if (empty($required)) then 'type' else $required"/>
@@ -71,8 +83,8 @@
                         <xsl:with-param name="currentMatch" select="()"/>
                         <xsl:with-param name="match" select="$match"/>
                     </xsl:call-template>
-                </xsl:for-each>
-            </xslout:template>
+                </xslout:template>
+            </xsl:for-each>
         </xslout:stylesheet>
     </xsl:template>
     <xsl:template name="matchJoinTemplates">

--- a/core/src/main/resources/xsl/opt/headerJoinTemplate.xsl
+++ b/core/src/main/resources/xsl/opt/headerJoinTemplate.xsl
@@ -35,6 +35,7 @@
     <xsl:namespace-alias stylesheet-prefix="xslout" result-prefix="xsl"/>
     <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
 
+    <xsl:variable name="pfx" as="xs:string" select="'TMP-'"/>
     <xsl:variable name="rules" as="node()" select="/rules:rules"/>
     <xsl:variable name="types" as="xs:string*" select="('HEADER', 'HEADER_ANY', 'HEADER_SINGLE')"/>
 
@@ -58,12 +59,22 @@
                 <xslout:param name="checker" as="node()"/>
                 <xslout:variable name="nextStep" as="node()*" select="check:stepsByIds($checker, check:next(.))"/>
                 <xsl:for-each select="$types">
-                    <xsl:variable name="rule" as="node()" select="key('rule-by-type', ., $rules)"/>
-                    <xsl:variable name="required" as="xs:string*" select="for $r in tokenize($rule/@required,' ') return
-                                                                          (: Exclude name, match attributes we are joining by these :)
-                                                                          if ($r = ('name','match')) then () else $r"/>
-                    <xsl:variable name="optional" as="xs:string*" select="tokenize($rule/@optional,' ')"/>
-                    <xsl:variable name="match" as="xs:string?" select="$rule/@match"/>
+                    <xslout:call-template name="{$pfx}{.}">
+                        <xslout:with-param name="checker"  select="$checker"/>
+                        <xslout:with-param name="nextStep" select="$nextStep"/>
+                    </xslout:call-template>
+                </xsl:for-each>
+            </xslout:template>
+            <xsl:for-each select="$types">
+                <xsl:variable name="rule" as="node()" select="key('rule-by-type', ., $rules)"/>
+                <xsl:variable name="required" as="xs:string*" select="for $r in tokenize($rule/@required,' ') return
+                                                                      (: Exclude name, match attributes we are joining by these :)
+                                                                      if ($r = ('name','match')) then () else $r"/>
+                <xsl:variable name="optional" as="xs:string*" select="tokenize($rule/@optional,' ')"/>
+                <xsl:variable name="match" as="xs:string?" select="$rule/@match"/>
+                <xslout:template name="{$pfx}{.}">
+                    <xslout:param name="checker" as="node()"/>
+                    <xslout:param name="nextStep" as="node()*"/>
                     <xsl:call-template name="matchJoinTemplates">
                         <xsl:with-param name="type" select="."/>
                         <xsl:with-param name="required" select="if (empty($required)) then 'type' else $required"/>
@@ -71,8 +82,8 @@
                         <xsl:with-param name="currentMatch" select="()"/>
                         <xsl:with-param name="match" select="$match"/>
                     </xsl:call-template>
-                </xsl:for-each>
-            </xslout:template>
+                </xslout:template>
+            </xsl:for-each>
         </xslout:stylesheet>
     </xsl:template>
     <xsl:template name="matchJoinTemplates">


### PR DESCRIPTION
We are generating XSLT code to handle optimization stages. This is great, but we are generating everything in huge templates -- these fail to get converted to bytecode because the JVM has method size restrictions.  We should generate smaller templates so that we can take advantage of bytecode generation.
