### PR TITLE
Upgrade Saxon

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,13 @@
 # Releases #
+## In Progress Work ##
+1. Updated Dependencies
+   1. saxon: 9.7.0-15 → 9.8.0-4
+      1. There is no longer a need for a Saxon EE License to use XSLT 3.0
+      1. XSLT 2.0 processor is no longer available, XSLT 3.0 processor will be used for XSLT 2.0 code which ensures a high level of backwards compatibility.
+      1. XSLT 1.0 backward compatibility is no longer supported unless you have a Saxon EE license, if you don't have license switch your XSLT engine to be Xalan or XalanC.
+   1. wadl-tools: 1.0.36 → 1.0.37
+
+
 ## Release 2.3.0 (2017-08-08) ##
 1. Fixed a bug where rax:roles were not masked correctly if default headers were set.
 1. Added support for ```rax:captureHeader```, this allows setting XPath 3.1 paths at the method request, representation, resource, and resources

--- a/core/src/main/resources/xsl/builder.xsl
+++ b/core/src/main/resources/xsl/builder.xsl
@@ -52,7 +52,7 @@
     <!-- Paramenters -->
     <xsl:param name="user" as="xsd:string" select="'unknown'" />
     <xsl:param name="creator" as="xsd:string" select="'unknown'"/>
-    <xsl:param name="schematronOutput" as="node()"/>
+    <xsl:param name="schematronOutput" as="node()"><check:out/></xsl:param>
     <xsl:param name="configMetadata" as="node()">
         <params>
           <meta>
@@ -1556,14 +1556,14 @@
     </xsl:function>
 
     <xsl:function name="check:getNextReqTypeLinks" as="xsd:string*">
-        <xsl:param name="from" as="node()"/>
+        <xsl:param name="from" as="node()?"/>
         <xsl:sequence select="if ($from/wadl:request/wadl:representation[@mediaType]) then
                               (for $r in $from/wadl:request/wadl:representation[@mediaType]
                               return generate-id($r), check:ReqTypeFailID($from)) else ()"/>
     </xsl:function>
         
     <xsl:function name="check:getNextURLLinks" as="xsd:string*">
-        <xsl:param name="from" as="node()"/>
+        <xsl:param name="from" as="node()?"/>
         <xsl:sequence select="for $r in $from/wadl:resource[@path] return
             if ($r/@path = '/') then
             (check:getNextURLLinks($r))
@@ -1573,7 +1573,7 @@
     </xsl:function>
 
     <xsl:function name="check:getNextHeaderLinks" as="xsd:string*">
-      <xsl:param name="from" as="node()"/>
+      <xsl:param name="from" as="node()?"/>
       <xsl:variable name="headers" select="check:getHeaders($from)"/>
       <xsl:variable name="default" select="$headers[@default]" as="node()*"/>
       <xsl:choose>
@@ -1617,17 +1617,17 @@
     </xsl:function>
 
     <xsl:function name="check:haveHeaders" as="xsd:boolean">
-        <xsl:param name="from" as="node()"/>
+        <xsl:param name="from" as="node()?"/>
         <xsl:value-of select="$useHeaderCheck and check:getHeaders($from)"/>
     </xsl:function>
 
     <xsl:function name="check:getHeaders" as="node()*">
-      <xsl:param name="from" as="node()"/>
+      <xsl:param name="from" as="node()?"/>
       <xsl:sequence select="$from/wadl:param[@style='header' and @required='true']"/>
     </xsl:function>
 
     <xsl:function name="check:getNextAssertLinks" as="xsd:string*">
-        <xsl:param name="from" as="node()"/>
+        <xsl:param name="from" as="node()?"/>
         <xsl:choose>
             <xsl:when test="check:haveAsserts($from)">
                 <xsl:variable name="firstAssert" as="node()" select="check:getAsserts($from)[1]"/>
@@ -1640,17 +1640,17 @@
     </xsl:function>
 
     <xsl:function name="check:haveAsserts" as="xsd:boolean">
-        <xsl:param name="from" as="node()"/>
+        <xsl:param name="from" as="node()?"/>
         <xsl:value-of select="$useAssert and $from/rax:assert"/>
     </xsl:function>
 
     <xsl:function name="check:getAsserts" as="node()*">
-        <xsl:param name="from" as="node()"/>
+        <xsl:param name="from" as="node()?"/>
         <xsl:sequence select="$from/rax:assert"/>
     </xsl:function>
 
     <xsl:function name="check:getNextCaptureHeaderLinks" as="xsd:string*">
-        <xsl:param name="from" as="node()"/>
+        <xsl:param name="from" as="node()?"/>
         <xsl:choose>
             <xsl:when test="check:haveCaptureHeaders($from)">
                 <xsl:variable name="firstCaptureHeader" as="node()" select="check:getCaptureHeaders($from)[1]"/>
@@ -1663,17 +1663,17 @@
     </xsl:function>
 
     <xsl:function name="check:haveCaptureHeaders" as="xsd:boolean">
-        <xsl:param name="from" as="node()"/>
+        <xsl:param name="from" as="node()?"/>
         <xsl:value-of select="$useCaptureHeaderExtension and $from/rax:captureHeader"/>
     </xsl:function>
 
     <xsl:function name="check:getCaptureHeaders" as="node()*">
-        <xsl:param name="from" as="node()"/>
+        <xsl:param name="from" as="node()?"/>
         <xsl:sequence select="$from/rax:captureHeader"/>
     </xsl:function>
     
     <xsl:function name="check:getNextMethodLinks" as="xsd:string*">
-        <xsl:param name="from" as="node()"/>
+        <xsl:param name="from" as="node()?"/>
         <xsl:for-each-group select="$from/wadl:method" group-by="@name">
             <xsl:choose>
                 <xsl:when test="count(current-group()) &gt; 1">

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
@@ -321,9 +321,15 @@ class Config extends LazyLogging {
   var enableAssertExtension : Boolean = true
 
   //
-  //  The XSL 1.0 engine to use.  Possible choices are Xalan, XalanC,
-  //  and Saxon. Note that Saxon is an XSL 2.0 engine, but most 1.0
-  //  XSLs should work fine.
+  //  The XSL engine to use.  Possible choices are Xalan, XalanC,
+  //  SaxonHE and SaxonEE. SaxonEE requires a Saxon License.
+  //
+  //  - Xalan, XalanC and SaxonEE support XSLT 1.0
+  //  - SaxonHE and SaxonEE support XSLT 3.0
+  //
+  //  There is no formal XSL 2.0 engine however XSLT 3.0 is highly
+  //  backwards compatible with XSLT 2.0 and 2.0 stylesheets will work
+  //  unmodified in most cases.
   //
   private var xsle : String = "XalanC"
   private val supportedXSLEngines = Set("Xalan", "XalanC", "SaxonHE", "SaxonEE",

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/CheckerServletRequest.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/CheckerServletRequest.scala
@@ -35,8 +35,8 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.w3c.dom.Document
 import net.sf.saxon.om.Sequence
 import net.sf.saxon.s9api.XdmValue
+import net.sf.saxon.s9api.XdmMap
 import net.sf.saxon.Configuration
-import net.sf.saxon.expr.JPConverter
 
 import scala.collection.JavaConverters._
 
@@ -149,9 +149,9 @@ class CheckerServletRequest(val request : HttpServletRequest) extends HttpServle
   }
   def contentErrorPriority_= (p : Long) : Unit = request.setAttribute (CONTENT_ERROR_PRIORITY, p)
 
-  def asXdmValue(c : Configuration) : XdmValue = request.getAttribute(REQUEST_XDM_VALUE) match {
+  def asXdmValue : XdmValue = request.getAttribute(REQUEST_XDM_VALUE) match {
     case reqValue : XdmValue => reqValue
-    case null => val rv = XdmValue.wrap(JPConverter.FromMap.INSTANCE.convert(new HttpServletRequestMap(this),c.getConversionContext))
+    case null => val rv = XdmMap.makeMap(new HttpServletRequestMap(this))
                  request.setAttribute(REQUEST_XDM_VALUE, rv)
                  rv
   }

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/XPathStepUtil.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/XPathStepUtil.scala
@@ -78,7 +78,6 @@ object XPathStepUtil extends LazyLogging {
   }
   protected val compiler = {
     val c = processor.newXQueryCompiler
-    c.setLanguageVersion(Config.RAX_ASSERT_XPATH_VERSION_STRING)
     c
   }
 
@@ -281,7 +280,7 @@ object XPathStepUtil extends LazyLogging {
 
     eval.setSource(xml)
     eval.setExternalVariable (new QName(prefix,uri,"__JSON__"), json)
-    eval.setExternalVariable (new QName(prefix,uri,"__REQUEST__"), req.asXdmValue(saxonConfig))
-    eval.setExternalVariable (new QName(prefix,uri,"__CONTEXT__"), context.asXdmValue(saxonConfig)) 
+    eval.setExternalVariable (new QName(prefix,uri,"__REQUEST__"), req.asXdmValue)
+    eval.setExternalVariable (new QName(prefix,uri,"__CONTEXT__"), context.asXdmValue)
   }
 }

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/base/StepContext.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/base/StepContext.scala
@@ -19,8 +19,8 @@ import com.rackspace.com.papi.components.checker.handler.ResultHandler
 import com.rackspace.com.papi.components.checker.util.HeaderMap
 
 import net.sf.saxon.s9api.XdmValue
+import net.sf.saxon.s9api.XdmMap
 import net.sf.saxon.Configuration
-import net.sf.saxon.expr.JPConverter
 
 import collection.JavaConverters._
 
@@ -28,12 +28,12 @@ import collection.JavaConverters._
 //  Used to keep context about the current request
 //
 case class StepContext(uriLevel : Int = 0, requestHeaders : HeaderMap = new HeaderMap, handler: Option[ResultHandler] = None) {
-  def asXdmValue(c : Configuration) : XdmValue = {
+  def asXdmValue : XdmValue = {
     val headers : java.util.Map[String, java.util.List[String]] = new java.util.HashMap[String,java.util.List[String]]()
     requestHeaders.foreach { case (k : String, l : List[String]) =>  headers.put (k, l.asJava) }
     val jcontext : java.util.Map[String, Object] = new java.util.HashMap[String, Object]()
     jcontext.put("uriLevel", uriLevel.asInstanceOf[Object])
     jcontext.put("headers", headers)
-    XdmValue.wrap(JPConverter.FromMap.INSTANCE.convert(jcontext, c.getConversionContext))
+    XdmMap.makeMap(jcontext)
   }
 }

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLPlainParamSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLPlainParamSuite.scala
@@ -366,48 +366,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
                  false, false, true))
 
   //
-  // Like validator_XSDElementContentPlainOptMsgCode but using Saxon
-  //
-  val validator_XSDElementContentPlainOptMsgCodeS = Validator((localWADLURI,
-      <application xmlns="http://wadl.dev.java.net/2009/02"
-                   xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
-                   xmlns:rax="http://docs.rackspace.com/api">
-        <grammars>
-           <include href="src/test/resources/xsd/test-urlxsd.xsd"/>
-        </grammars>
-        <resources base="https://test.api.openstack.com">
-           <resource path="/a/b">
-               <method name="PUT">
-                  <request>
-                      <representation mediaType="application/xml" element="tst:a">
-                          <param style="plain" path="tst:a/@stepType" required="true" rax:message="No stepType attribute on a" rax:code="500"/>
-                      </representation>
-                      <representation mediaType="application/json"/>
-                  </request>
-               </method>
-               <method name="POST">
-                  <request>
-                      <representation mediaType="application/xml" element="tst:e">
-                          <param style="plain" path="tst:e/tst:stepType" required="true" rax:message="no stepType on e" rax:code="501"/>
-                      </representation>
-                  </request>
-               </method>
-           </resource>
-           <resource path="/c">
-               <method name="POST">
-                  <request>
-                      <representation mediaType="application/json"/>
-                  </request>
-               </method>
-               <method name="GET"/>
-           </resource>
-        </resources>
-    </application>)
-    , TestConfig(false, false, true, true, true, 10,
-                 true, false , false, "SaxonHE", true,
-                 false, false, true))
-
-  //
   // Like validator_XSDElementContentPlainOpt but with custom rax:code
   //
   val validator_XSDElementContentPlainOptCode = Validator((localWADLURI,
@@ -1088,10 +1046,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
     validator_XSDElementContentPlainOptMsgCodeX.validate(request("PUT","/a/b","application/xml", goodXML_XSD2),response,chain)
   }
 
-  test ("PUT on /a/b with application/xml should succeed on validator_XSDElementContentPlainOptMsgCodeS with valid XML1") {
-    validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b","application/xml", goodXML_XSD2),response,chain)
-  }
-
   test ("PUT on /a/b with application/xml should succeed on validator_XSDElementContentPlainOpt2 with valid XML1") {
     validator_XSDElementContentPlainOpt2.validate(request("PUT","/a/b","application/xml", goodXML_XSD2),response,chain)
   }
@@ -1122,10 +1076,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
 
   test ("POST on /a/b with application/xml should succeed on validator_XSDElementContentPlainOptMsgCodeX with valid XML1") {
     validator_XSDElementContentPlainOptMsgCodeX.validate(request("POST","/a/b","application/xml", goodXML_XSD1),response,chain)
-  }
-
-  test ("POST on /a/b with application/xml should succeed on validator_XSDElementContentPlainOptMsgCodeS with valid XML1") {
-    validator_XSDElementContentPlainOptMsgCodeS.validate(request("POST","/a/b","application/xml", goodXML_XSD1),response,chain)
   }
 
   test ("POST on /a/b with application/xml should succeed on validator_XSDElementContentPlainOpt2 with valid XML1") {
@@ -1160,10 +1110,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
     validator_XSDElementContentPlainOptMsgCodeX.validate(request("PUT","/a/b","application/json", goodJSON),response,chain)
   }
 
-  test ("PUT on /a/b with application/json should succeed on validator_XSDElementContentPlainOptMsgCodeS with well formed JSON") {
-    validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b","application/json", goodJSON),response,chain)
-  }
-
   test ("PUT on /a/b with application/json should succeed on validator_XSDElementContentPlainOpt2 with well formed JSON") {
     validator_XSDElementContentPlainOpt2.validate(request("PUT","/a/b","application/json", goodJSON),response,chain)
   }
@@ -1194,10 +1140,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
 
   test ("POST on /c with application/json should succeed on validator_XSDElementContentPlainOptMsgCodeX with well formed JSON") {
     validator_XSDElementContentPlainOptMsgCodeX.validate(request("POST","/c","application/json", goodJSON),response,chain)
-  }
-
-  test ("POST on /c with application/json should succeed on validator_XSDElementContentPlainOptMsgCodeS with well formed JSON") {
-    validator_XSDElementContentPlainOptMsgCodeS.validate(request("POST","/c","application/json", goodJSON),response,chain)
   }
 
   test ("POST on /c with application/json should succeed on validator_XSDElementContentPlainOpt2 with well formed JSON") {
@@ -1232,10 +1174,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
     validator_XSDElementContentPlainOptMsgCodeX.validate(request("GET","/c"),response,chain)
   }
 
-  test ("GOT on /c should succeed on validator_XSDElementContentPlainOptMsgCodeS") {
-    validator_XSDElementContentPlainOptMsgCodeS.validate(request("GET","/c"),response,chain)
-  }
-
   test ("GOT on /c should succeed on validator_XSDElementContentPlainOpt2") {
     validator_XSDElementContentPlainOpt2.validate(request("GET","/c"),response,chain)
   }
@@ -1266,10 +1204,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
 
   test ("PUT on /a/b should fail with well formed XML PUT in the wrong location in validator_XSDElementContentPlainOptMsgCodeX") {
     assertResultFailed(validator_XSDElementContentPlainOptMsgCodeX.validate(request("PUT","/a/b", "application/xml", goodXML_XSD1),response,chain), 400, "Bad Content: Expecting the root element to be: tst:a")
-  }
-
-  test ("PUT on /a/b should fail with well formed XML PUT in the wrong location in validator_XSDElementContentPlainOptMsgCodeS") {
-    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b", "application/xml", goodXML_XSD1),response,chain), 400, "Bad Content: Expecting the root element to be: tst:a")
   }
 
   test ("PUT on /a/b should fail with well formed XML PUT in the wrong location in validator_XSDElementContentPlainOpt2") {
@@ -1304,10 +1238,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
     assertResultFailed(validator_XSDElementContentPlainOptMsgCodeX.validate(request("PUT","/a/b", "application/xml", badXML_Plain2),response,chain), 500, "No stepType attribute on a")
   }
 
-  test ("PUT on /a/b should fail with well formed XML PUT with missing required plain params on validator_XSDElementContentPlainOptMsgCodeS") {
-    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b", "application/xml", badXML_Plain2),response,chain), 500, "No stepType attribute on a")
-  }
-
   test ("PUT on /a/b should fail with well formed XML PUT with missing required plain params on validator_XSDElementContentPlainOpt2") {
     assertResultFailed(validator_XSDElementContentPlainOpt2.validate(request("PUT","/a/b", "application/xml", badXML_Plain2),response,chain), 400, "Bad Content: Expecting tst:a/@stepType")
   }
@@ -1340,9 +1270,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
     assertResultFailed(validator_XSDElementContentPlainOptMsgCodeX.validate(request("POST","/a/b", "application/xml", goodXML_XSD2),response,chain), 400, "Bad Content: Expecting the root element to be: tst:e")
   }
 
-  test ("POST on /a/b should fail with well formed XML POST in the wrong location in validator_XSDElementContentPlainOptMsgCodeS") {
-    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("POST","/a/b", "application/xml", goodXML_XSD2),response,chain), 400, "Bad Content: Expecting the root element to be: tst:e")
-  }
 
   test ("POST on /a/b should fail with well formed XML POST in the wrong location in validator_XSDElementContentPlainOpt2") {
     assertResultFailed(validator_XSDElementContentPlainOpt2.validate(request("POST","/a/b", "application/xml", goodXML_XSD2),response,chain), 400, "Bad Content: Expecting the root element to be: tst:e")
@@ -1376,10 +1303,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
     assertResultFailed(validator_XSDElementContentPlainOptMsgCodeX.validate(request("POST","/a/b", "application/xml", badXML_Plain1),response,chain), 501, "no stepType on e")
   }
 
-  test ("POST on /a/b should fail with well formed XML POST with missing required plain params on validator_XSDElementContentPlainOptMsgCodeS") {
-    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("POST","/a/b", "application/xml", badXML_Plain1),response,chain), 501, "no stepType on e")
-  }
-
   test ("POST on /a/b should fail with well formed XML POST with missing required plain params on validator_XSDElementContentPlainOpt2") {
     assertResultFailed(validator_XSDElementContentPlainOpt2.validate(request("POST","/a/b", "application/xml", badXML_Plain1),response,chain), 400, "Bad Content: Expecting tst:e/tst:stepType")
   }
@@ -1410,10 +1333,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
 
   test ("PUT on /a/b should fail with well formed XML that does not match schema on validator_XSDElementContentPlainOptMsgCodeX") {
     assertResultFailed(validator_XSDElementContentPlainOptMsgCodeX.validate(request("PUT","/a/b", "application/xml", goodXML),response,chain), 400)
-  }
-
-  test ("PUT on /a/b should fail with well formed XML that does not match schema on validator_XSDElementContentPlainOptMsgCodeS") {
-    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b", "application/xml", goodXML),response,chain), 400)
   }
 
   test ("PUT on /a/b should fail with well formed XML that does not match schema on validator_XSDElementContentPlainOpt2") {
@@ -1470,16 +1389,6 @@ class ValidatorWADLPlainParamSuite extends BaseValidatorSuite {
 
   test ("PUT on /a/b should fail with well formed XML, correct element, but does not validate against the schema in validator_XSDElementContentPlainOptMsgCodeX") {
     assertResultFailed(validator_XSDElementContentPlainOptMsgCodeX.validate(request("PUT","/a/b", "application/xml",
-                                                             <a xmlns="http://www.rackspace.com/repose/wadl/checker/step/test" stepType="foo">
-                                                                <id>21f1fcf6-bf38-11e1-878e-133ab65fcec3</id>
-                                                                <stepType>URL_FAIL</stepType>
-                                                                <even>22</even>
-                                                              </a>
-                                                            ),response,chain), 400)
-  }
-
-  test ("PUT on /a/b should fail with well formed XML, correct element, but does not validate against the schema in validator_XSDElementContentPlainOptMsgCodeS") {
-    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b", "application/xml",
                                                              <a xmlns="http://www.rackspace.com/repose/wadl/checker/step/test" stepType="foo">
                                                                 <id>21f1fcf6-bf38-11e1-878e-133ab65fcec3</id>
                                                                 <stepType>URL_FAIL</stepType>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLPlainParamSuiteSaxonEE.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLPlainParamSuiteSaxonEE.scala
@@ -1,0 +1,124 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.cloud.api.wadl.Converters._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ValidatorWADLPlainParamSuiteSaxonEE extends BaseValidatorSuite {
+  val badXML_Plain1 = <e xmlns="http://www.rackspace.com/repose/wadl/checker/step/test">
+                        <id>21f1fcf6-bf38-11e1-878e-133ab65fcec3</id>
+                        <even>22</even>
+                     </e>
+  val badXML_Plain2 = <a xmlns="http://www.rackspace.com/repose/wadl/checker/step/test"
+                        id="21f1fcf6-bf38-11e1-878e-133ab65fcec3"
+                        even="22"/>
+
+  //
+  // Like validator_XSDElementContentPlainOptMsgCode but using Saxon
+  //
+  val validator_XSDElementContentPlainOptMsgCodeS = Validator((localWADLURI,
+      <application xmlns="http://wadl.dev.java.net/2009/02"
+                   xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+                   xmlns:rax="http://docs.rackspace.com/api">
+        <grammars>
+           <include href="src/test/resources/xsd/test-urlxsd.xsd"/>
+        </grammars>
+        <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="PUT">
+                  <request>
+                      <representation mediaType="application/xml" element="tst:a">
+                          <param style="plain" path="tst:a/@stepType" required="true" rax:message="No stepType attribute on a" rax:code="500"/>
+                      </representation>
+                      <representation mediaType="application/json"/>
+                  </request>
+               </method>
+               <method name="POST">
+                  <request>
+                      <representation mediaType="application/xml" element="tst:e">
+                          <param style="plain" path="tst:e/tst:stepType" required="true" rax:message="no stepType on e" rax:code="501"/>
+                      </representation>
+                  </request>
+               </method>
+           </resource>
+           <resource path="/c">
+               <method name="POST">
+                  <request>
+                      <representation mediaType="application/json"/>
+                  </request>
+               </method>
+               <method name="GET"/>
+           </resource>
+        </resources>
+    </application>)
+    , TestConfig(false, false, true, true, true, 10,
+                 true, false , false, "SaxonEE", true,
+                 false, false, true))
+
+  test ("PUT on /a/b with application/xml should succeed on validator_XSDElementContentPlainOptMsgCodeS with valid XML1") {
+    validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b","application/xml", goodXML_XSD2),response,chain)
+  }
+
+  test ("POST on /a/b with application/xml should succeed on validator_XSDElementContentPlainOptMsgCodeS with valid XML1") {
+    validator_XSDElementContentPlainOptMsgCodeS.validate(request("POST","/a/b","application/xml", goodXML_XSD1),response,chain)
+  }
+
+  test ("PUT on /a/b with application/json should succeed on validator_XSDElementContentPlainOptMsgCodeS with well formed JSON") {
+    validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b","application/json", goodJSON),response,chain)
+  }
+
+  test ("POST on /c with application/json should succeed on validator_XSDElementContentPlainOptMsgCodeS with well formed JSON") {
+    validator_XSDElementContentPlainOptMsgCodeS.validate(request("POST","/c","application/json", goodJSON),response,chain)
+  }
+
+  test ("GOT on /c should succeed on validator_XSDElementContentPlainOptMsgCodeS") {
+    validator_XSDElementContentPlainOptMsgCodeS.validate(request("GET","/c"),response,chain)
+  }
+
+  test ("PUT on /a/b should fail with well formed XML PUT in the wrong location in validator_XSDElementContentPlainOptMsgCodeS") {
+    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b", "application/xml", goodXML_XSD1),response,chain), 400, "Bad Content: Expecting the root element to be: tst:a")
+  }
+
+  test ("PUT on /a/b should fail with well formed XML PUT with missing required plain params on validator_XSDElementContentPlainOptMsgCodeS") {
+    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b", "application/xml", badXML_Plain2),response,chain), 500, "No stepType attribute on a")
+  }
+
+  test ("POST on /a/b should fail with well formed XML POST in the wrong location in validator_XSDElementContentPlainOptMsgCodeS") {
+    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("POST","/a/b", "application/xml", goodXML_XSD2),response,chain), 400, "Bad Content: Expecting the root element to be: tst:e")
+  }
+
+  test ("POST on /a/b should fail with well formed XML POST with missing required plain params on validator_XSDElementContentPlainOptMsgCodeS") {
+    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("POST","/a/b", "application/xml", badXML_Plain1),response,chain), 501, "no stepType on e")
+  }
+
+  test ("PUT on /a/b should fail with well formed XML that does not match schema on validator_XSDElementContentPlainOptMsgCodeS") {
+    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b", "application/xml", goodXML),response,chain), 400)
+  }
+
+  test ("PUT on /a/b should fail with well formed XML, correct element, but does not validate against the schema in validator_XSDElementContentPlainOptMsgCodeS") {
+    assertResultFailed(validator_XSDElementContentPlainOptMsgCodeS.validate(request("PUT","/a/b", "application/xml",
+                                                             <a xmlns="http://www.rackspace.com/repose/wadl/checker/step/test" stepType="foo">
+                                                                <id>21f1fcf6-bf38-11e1-878e-133ab65fcec3</id>
+                                                                <stepType>URL_FAIL</stepType>
+                                                                <even>22</even>
+                                                              </a>
+                                                            ),response,chain), 400)
+  }
+
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLSuite.scala
@@ -2184,7 +2184,9 @@ class ValidatorWADLSuite extends BaseValidatorSuite {
     , TestConfig(false, false, true, true, false, 1, false, true, true, "Xalan"))
 
   //
-  //  Like validator_XSDContentTT except uses Saxon instead of XalanC for XSL 1.0 engine
+  //  Like validator_XSDContentTT except uses Saxon instead of XalanC,
+  //  we use XSLT 2.0 instead of 1 to allow for compatibility with
+  //  SaxonHE -- which no longer supports XSLT 1.0
   //
   val validator_XSDContentTTS = Validator((localWADLURI,
       <application xmlns="http://wadl.dev.java.net/2009/02"
@@ -2197,7 +2199,7 @@ class ValidatorWADLSuite extends BaseValidatorSuite {
                <method name="PUT">
                   <request>
                       <representation mediaType="application/xml">
-                          <rax:preprocess href="src/test/resources/xsl/beginStart.xsl"/>
+                          <rax:preprocess href="src/test/resources/xsl/beginStart2.xsl"/>
                       </representation>
                       <representation mediaType="application/json"/>
                   </request>
@@ -2220,7 +2222,7 @@ class ValidatorWADLSuite extends BaseValidatorSuite {
            </resource>
         </resources>
     </application>)
-    , TestConfig(false, false, true, true, false, 1, false, true, true, "SaxonHE"))
+    , TestConfig(false, false, true, true, false, 20, false, true, true, "SaxonHE"))
 
 
   test ("PUT on /a/b with application/xml should succeed on validator_XSDContentTT with valid XML1") {

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/servlet/HttpServletRequestMapSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/servlet/HttpServletRequestMapSuite.scala
@@ -32,6 +32,8 @@ import java.io.BufferedReader
 import javax.xml.namespace.QName
 import javax.xml.xpath.XPathConstants
 
+import net.sf.saxon.s9api.XdmMap
+
 import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
@@ -50,9 +52,9 @@ class HttpServletRequestMapSuite extends BaseValidatorSuite {
 
 
   test("Method should be accesible in XPath") {
-    val req1 = new HttpServletRequestMap(request("GET","/"))
-    val req2 = new HttpServletRequestMap(request("DELETE","/"))
-    val req3 = new HttpServletRequestMap(request("PUT", "/"))
+    val req1 = XdmMap.makeMap(new HttpServletRequestMap(request("GET","/")))
+    val req2 = XdmMap.makeMap(new HttpServletRequestMap(request("DELETE","/")))
+    val req3 = XdmMap.makeMap(new HttpServletRequestMap(request("PUT", "/")))
 
     val xpath1 = borrowExpression("$request?method='GET'", defaultContext, XPATH_VERSION).asInstanceOf[VarXPathExpression]
     val xpath2 = borrowExpression("$request?method='DELETE'", defaultContext, XPATH_VERSION).asInstanceOf[VarXPathExpression]
@@ -90,9 +92,9 @@ class HttpServletRequestMapSuite extends BaseValidatorSuite {
   }
 
   test("URI should be accessible in XPath") {
-    val req1 = new HttpServletRequestMap(request("GET","/path/to/foo"))
-    val req2 = new HttpServletRequestMap(request("DELETE","/path/to/bar"))
-    val req3 = new HttpServletRequestMap(request("PUT", "/yet/another/path.txt"))
+    val req1 = XdmMap.makeMap(new HttpServletRequestMap(request("GET","/path/to/foo")))
+    val req2 = XdmMap.makeMap(new HttpServletRequestMap(request("DELETE","/path/to/bar")))
+    val req3 = XdmMap.makeMap(new HttpServletRequestMap(request("PUT", "/yet/another/path.txt")))
 
 
     val xpath1 = borrowExpression("$request?uri='/path/to/foo'", defaultContext, XPATH_VERSION).asInstanceOf[VarXPathExpression]
@@ -140,17 +142,17 @@ class HttpServletRequestMapSuite extends BaseValidatorSuite {
   }
 
   test("Headers should be accessible, though in a (lower) case sensitive manner") {
-    var req1 = new HttpServletRequestMap(request("GET", "/path/to/foo", "application/json", "null", false,
+    var req1 = XdmMap.makeMap(new HttpServletRequestMap(request("GET", "/path/to/foo", "application/json", "null", false,
                                                  Map[String,List[String]]("foo"->List("bar"),
                                                                           "bIz"->List("baz","boom","bit"),
-                                                                          "x"->List("y"))))
-    var req2 = new HttpServletRequestMap(request("DELETE", "/path/to/bar", "application/json", "null", false,
-                                                 Map[String,List[String]]("FoO"->List("baz"))))
+                                                                          "x"->List("y")))))
+    var req2 = XdmMap.makeMap(new HttpServletRequestMap(request("DELETE", "/path/to/bar", "application/json", "null", false,
+                                                 Map[String,List[String]]("FoO"->List("baz")))))
 
-    var req3 = new HttpServletRequestMap(request("PUT", "/yet/another/path.txt", "application/json", "null", false,
-                                                 Map[String,List[String]]()))
+    var req3 = XdmMap.makeMap(new HttpServletRequestMap(request("PUT", "/yet/another/path.txt", "application/json", "null", false,
+                                                 Map[String,List[String]]())))
 
-    var req4 = new HttpServletRequestMap(request("POST", "/no/headers/allowed"))
+    var req4 = XdmMap.makeMap(new HttpServletRequestMap(request("POST", "/no/headers/allowed")))
 
 
     assert (getVarPath ("""
@@ -181,15 +183,15 @@ class HttpServletRequestMapSuite extends BaseValidatorSuite {
   }
 
   test("Mix access method, uri, headers") {
-    var req1 = new HttpServletRequestMap(request("GET", "/path/to/foo", "application/json", "null", false,
+    var req1 = XdmMap.makeMap(new HttpServletRequestMap(request("GET", "/path/to/foo", "application/json", "null", false,
                                                  Map[String,List[String]]("foo"->List("bar"),
                                                                           "bIz"->List("baz","boom","bit"),
-                                                                          "x"->List("y"))))
-    var req2 = new HttpServletRequestMap(request("DELETE", "/path/to/bar", "application/json", "null", false,
-                                                 Map[String,List[String]]("FoO"->List("baz"))))
+                                                                          "x"->List("y")))))
+    var req2 = XdmMap.makeMap(new HttpServletRequestMap(request("DELETE", "/path/to/bar", "application/json", "null", false,
+                                                 Map[String,List[String]]("FoO"->List("baz")))))
 
-    var req3 = new HttpServletRequestMap(request("PUT", "/yet/another/path.txt", "application/json", "null", false,
-                                                 Map[String,List[String]]()))
+    var req3 = XdmMap.makeMap(new HttpServletRequestMap(request("PUT", "/yet/another/path.txt", "application/json", "null", false,
+                                                 Map[String,List[String]]())))
 
     assert(getVarPath("""($request?method='GET') and ($request?uri='/path/to/foo') and ($request?headers?x = 'y')""",
                       XPathConstants.BOOLEAN, Map(REQUEST_VAR->req1)).asInstanceOf[Boolean])

--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,11 @@
         <scala.minor>11</scala.minor>
         <scala.patch>7</scala.patch>
         <scala.MajDotMin>${scala.major}.${scala.minor}</scala.MajDotMin>
-        <saxon-ee.version>9.7.0-15</saxon-ee.version>
+        <saxon-ee.version>9.8.0-4</saxon-ee.version>
         <scala.test.version>2.2.6</scala.test.version>
         <scala.uri.version>0.4.2</scala.uri.version>
         <junit.version>4.10</junit.version>
-        <wadl-tools.version>1.0.36</wadl-tools.version>
+        <wadl-tools.version>1.0.37</wadl-tools.version>
         <xmlsec.version>1.4.6</xmlsec.version>
         <xerces.version>2.12.1-rax</xerces.version>
         <servlet.version>3.1</servlet.version>

--- a/util/src/main/scala/com/rackspace/com/papi/compenents/checker/util/JSONConverter.scala
+++ b/util/src/main/scala/com/rackspace/com/papi/compenents/checker/util/JSONConverter.scala
@@ -34,7 +34,6 @@ object JSONConverter {
   private val processor   = new Processor(false)
   private val compiler    = {
     val c = processor.newXQueryCompiler()
-    c.setLanguageVersion("3.1")
     c
   }
   private val query = "/xq/load-json.xq"

--- a/util/src/test/scala/com/rackspace/com/papi/components/checker/util/VarXPathExpressionSuite.scala
+++ b/util/src/test/scala/com/rackspace/com/papi/components/checker/util/VarXPathExpressionSuite.scala
@@ -22,6 +22,8 @@ import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
 
+import net.sf.saxon.s9api.XdmMap
+
 import scala.collection.JavaConversions._
 
 @RunWith(classOf[JUnitRunner])
@@ -84,9 +86,9 @@ class VarXPathExpressionSuite extends FunSuite {
     try {
       varExpression = XPathExpressionPool.borrowExpression(expression, nsContext, XPATH_VERSION_3_1).asInstanceOf[VarXPathExpression]
       assert (varExpression.evaluate (inDoc, XPathConstants.STRING,
-                                      Map[QName, Object](new QName("person") -> mapAsJavaMap(Map[String,String]("firstName"->"Jorge", "lastName"->"Williams")))) == "Jorge Williams")
+                                      Map[QName, Object](new QName("person") -> XdmMap.makeMap(mapAsJavaMap(Map[String,String]("firstName"->"Jorge", "lastName"->"Williams"))))) == "Jorge Williams")
       assert (varExpression.evaluate (inDoc, XPathConstants.STRING,
-                                      Map[QName, Object](new QName("person") -> mapAsJavaMap(Map[String,String]("firstName"->"Rachel", "lastName"->"Kraft")))) == "Rachel Kraft")
+                                      Map[QName, Object](new QName("person") -> XdmMap.makeMap(mapAsJavaMap(Map[String,String]("firstName"->"Rachel", "lastName"->"Kraft"))))) == "Rachel Kraft")
     } finally {
       if (varExpression != null) XPathExpressionPool.returnExpression(expression, nsContext, XPATH_VERSION_3_1, varExpression)
     }

--- a/util/src/test/scala/com/rackspace/com/papi/components/checker/util/XQueryEvaluatorPoolSuite.scala
+++ b/util/src/test/scala/com/rackspace/com/papi/components/checker/util/XQueryEvaluatorPoolSuite.scala
@@ -29,7 +29,6 @@ class XQueryEvaluatorPoolSuite extends FunSuite {
   private val processor   = new Processor(false)
   private val compiler    = {
     val c = processor.newXQueryCompiler()
-    c.setLanguageVersion("3.1")
     c
   }
   private val query = "/xq/load-json.xq"


### PR DESCRIPTION

This upgrades to Saxon 9.8. The biggest feature we get from this is that XSLT 3.0 no longer requires a license.  Additionally there are some major performance improvements in Saxon 9.8 that allow wadl-tools normalization stage to execute much more quickly.