### PR TITLE
Make Join Optimizations more Efficient

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,8 @@
       1. XSLT 2.0 processor is no longer available, XSLT 3.0 processor will be used for XSLT 2.0 code which ensures a high level of backwards compatibility.
       1. XSLT 1.0 backward compatibility is no longer supported unless you have a Saxon EE license, if you don't have license switch your XSLT engine to be Xalan or XalanC.
    1. wadl-tools: 1.0.36 → 1.0.37
-
+1. Clean up : join optimization stages rewritten to execute more efficiently; compile time speedups of 3-4x have been observed in complex setups.
+   1. Since XSLT 3.0 no longer requires a Saxon EE License, the XPath join optimization now produces XSLT 3.0 code when using Saxon HE.
 
 ## Release 2.3.0 (2017-08-08) ##
 1. Fixed a bug where rax:roles were not masked correctly if default headers were set.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -147,13 +147,25 @@
                                 </fileMapper>
                             </fileMappers>
                         </transformationSet>
+                        <transformationSet>
+                            <dir>src/main/resources/xsl/opt</dir>
+                            <includes>
+                                <include>removeDups-rules.xml</include>
+                            </includes>
+                            <stylesheet>src/main/resources/xsl/opt/joinSetupTemplate.xsl</stylesheet>
+                            <fileMappers>
+                                <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FileExtensionMapper">
+                                    <targetExtension>.setup.xsl</targetExtension>
+                                </fileMapper>
+                            </fileMappers>
+                        </transformationSet>
                     </transformationSets>
                 </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>net.sf.saxon</groupId>
                         <artifactId>Saxon-HE</artifactId>
-                        <version>9.4.0-9</version>
+                        <version>9.8.0-4</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/core/src/main/resources/xsl/opt/commonJoin.xsl
+++ b/core/src/main/resources/xsl/opt/commonJoin.xsl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   join.xsl
+   commonJoin.xsl
 
    This stylesheet take a document in checker format and safely joins
    states in different branches of execution. The operation works like
@@ -47,9 +47,10 @@
         xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:check="http://www.rackspace.com/repose/wadl/checker"
+        xmlns:map="http://www.w3.org/2005/xpath-functions/map"
         xmlns="http://www.rackspace.com/repose/wadl/checker"
         exclude-result-prefixes="xsd check"
-        version="2.0">
+        version="3.0">
 
     <!--
         Most of the work of joining is done by the following util. The
@@ -125,13 +126,13 @@
     <!--
         Convert joins into a checker step.
     -->
-    <xsl:template match="check:join" mode="join">
+    <xsl:template name="createJoinStep">
         <xsl:param name="checker" as="node()"/>
-        <xsl:param name="joins" as="node()*"/>
-        <xsl:variable name="steps" select="@steps"/>
-        <xsl:variable name="joinSteps" as="node()*" select="check:stepsByIds($checker, tokenize($steps, ' '))"/>
+        <xsl:param name="joins" as="map(xsd:string, xsd:string*)"/>
+        <xsl:param name="stepsToJoin" as="map(xsd:string, xsd:string)"/>
+        <xsl:variable name="joinSteps" as="node()*" select="check:stepsByIds($checker, $joins(.))"/>
 
-        <step id="{generate-id(.)}">
+        <step id="{.}">
             <!--
                 Since the steps are exactly alike, we need to simply copy
                 over the attributes from the first join step.
@@ -142,8 +143,10 @@
                 <xsl:call-template name="joinNext">
                     <xsl:with-param name="checker" select="$checker"/>
                     <xsl:with-param name="joins" select="$joins"/>
+                    <xsl:with-param name="stepsToJoin" select="$stepsToJoin"/>
                 </xsl:call-template>
             </xsl:if>
         </step>
     </xsl:template>
+
 </xsl:stylesheet>

--- a/core/src/main/resources/xsl/opt/commonJoinTemplate.xsl
+++ b/core/src/main/resources/xsl/opt/commonJoinTemplate.xsl
@@ -29,17 +29,17 @@
     xmlns:rules="http://www.rackspace.com/repose/wadl/checker/opt/removeDups/rules"
     xmlns:check="http://www.rackspace.com/repose/wadl/checker"
     xmlns:xslout="http://www.rackspace.com/repose/wadl/checker/Transform"
-    exclude-result-prefixes="rules"
-    version="2.0">
+    exclude-result-prefixes="rules" version="3.0">
 
     <xsl:namespace-alias stylesheet-prefix="xslout" result-prefix="xsl"/>
     <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
 
     <xsl:variable name="pfx" as="xs:string" select="'TMP-'"/>
     <xsl:variable name="rules" as="node()" select="/rules:rules"/>
-    <xsl:variable name="types" as="xs:string*" select="distinct-values(tokenize(string-join($rules/rules:rule/@types, ' '), ' '))"/>
+    <xsl:variable name="types" as="xs:string*"
+        select="distinct-values(tokenize(string-join($rules/rules:rule/@types, ' '), ' '))"/>
 
-    <xsl:key name="rule-by-type" match="rules:rule" use="tokenize(@types,' ')"/>
+    <xsl:key name="rule-by-type" match="rules:rule" use="tokenize(@types, ' ')"/>
 
     <xsl:template match="/">
         <xsl:comment>
@@ -48,16 +48,15 @@
             **********                                                    **********
 </xsl:comment>
         <xsl:text>&#xa;</xsl:text>
-        <xslout:stylesheet
-            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        <xslout:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:check="http://www.rackspace.com/repose/wadl/checker"
-            xmlns="http://www.rackspace.com/repose/wadl/checker"
-            exclude-result-prefixes="xsd check"
-            version="2.0">
+            xmlns="http://www.rackspace.com/repose/wadl/checker" exclude-result-prefixes="xsd check"
+            version="3.0">
             <xslout:template match="check:step[@next]" mode="getJoins">
                 <xslout:param name="checker" as="node()"/>
-                <xslout:variable name="nextStep" as="node()*" select="check:stepsByIds($checker, check:next(.))"/>
+                <xslout:variable name="nextStep" as="node()*"
+                    select="check:stepsByIds($checker, check:next(.))"/>
                 <xsl:for-each select="$types">
                     <xslout:call-template name="{$pfx}{.}">
                         <xslout:with-param name="checker" select="$checker"/>
@@ -67,19 +66,28 @@
             </xslout:template>
             <xsl:for-each select="$types">
                 <xsl:variable name="rule" as="node()" select="key('rule-by-type', ., $rules)"/>
-                <xsl:variable name="required" as="xs:string*" select="for $r in tokenize($rule/@required,' ') return
-                                                                      (: Don't treat next as a required attribute, we are joining by it :)
-                                                                      if ($r = 'next') then () else $r"/>
-                <xsl:variable name="optional" as="xs:string*" select="tokenize($rule/@optional,' ')"/>
-                <xsl:variable name="match" as="xs:string?"
-                              select="$rule/@match"/>
+                <xsl:variable name="required" as="xs:string*"
+                    select="
+                        (for $r in tokenize($rule/@required, ' ')
+                        return
+                            (: Don't treat next as a required attribute, we are joining by it :)
+                            if ($r = 'next') then
+                                ()
+                            else
+                                $r,
+                        tokenize($rule/@optional, ' '))"/>
+                <xsl:variable name="match" as="xs:string?" select="$rule/@match"/>
                 <xslout:template name="{$pfx}{.}">
                     <xslout:param name="checker" as="node()"/>
                     <xslout:param name="nextStep" as="node()*"/>
                     <xsl:call-template name="matchJoinTemplates">
                         <xsl:with-param name="type" select="."/>
-                        <xsl:with-param name="required" select="if (empty($required)) then 'type' else $required"/>
-                        <xsl:with-param name="optional" select="$optional"/>
+                        <xsl:with-param name="required"
+                            select="
+                                if (empty($required)) then
+                                    'type'
+                                else
+                                    $required"/>
                         <xsl:with-param name="currentMatch" select="()"/>
                         <xsl:with-param name="match" select="$match"/>
                     </xsl:call-template>
@@ -90,63 +98,24 @@
     <xsl:template name="matchJoinTemplates">
         <xsl:param name="type" as="xs:string"/>
         <xsl:param name="required" as="xs:string*"/>
-        <xsl:param name="optional" as="xs:string*"/>
         <xsl:param name="currentMatch" as="xs:string*"/>
         <xsl:param name="match" as="xs:string?"/>
-        <xsl:choose>
-            <xsl:when test="empty($optional)">
-                <xslout:for-each-group group-by="@{$required[1]}">
-                    <xsl:attribute name="select">
-                        <xsl:text>$nextStep[@type='</xsl:text>
-                        <xsl:value-of select="$type"/>
-                        <xsl:text>' </xsl:text>
-                        <xsl:if test="$match">
-                            <xsl:text>and </xsl:text>
-                            <xsl:value-of select="$match"/>
-                        </xsl:if>
-                        <xsl:text>]</xsl:text>
-                    </xsl:attribute>
-                    <xsl:call-template name="forEachJoinTemplate">
-                        <xsl:with-param name="attribs" select="subsequence($required,2)"/>
-                    </xsl:call-template>
-                </xslout:for-each-group>
-            </xsl:when>
-            <xsl:when test="count($optional) = count($currentMatch)">
-                <xsl:variable name="allAttribs" as="xs:string*" select="($required, for $o in $optional return
-                                                                         if (concat('@',$o) = $currentMatch) then $o else ())"/>
-                <xsl:variable name="matchString" as="xs:string" select="string-join(($currentMatch, $match), ' and ')"/>
-                <xslout:for-each-group group-by="@{$allAttribs[1]}">
-                    <xsl:attribute name="select">
-                        <xsl:text>$nextStep[@type ='</xsl:text>
-                        <xsl:value-of select="$type"/>
-                        <xsl:text>' </xsl:text>
-                        <xsl:text>and </xsl:text>
-                        <xsl:value-of select="$matchString"/>
-                        <xsl:text>]</xsl:text>
-                    </xsl:attribute>
-                    <xsl:call-template name="forEachJoinTemplate">
-                        <xsl:with-param name="attribs" select="subsequence($allAttribs,2)"/>
-                    </xsl:call-template>
-                </xslout:for-each-group>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:variable name="newMatch" as="xs:string" select="$optional[count($currentMatch)+1]"/>
-                <xsl:call-template name="matchJoinTemplates">
-                    <xsl:with-param name="type" select="$type"/>
-                    <xsl:with-param name="required" select="$required"/>
-                    <xsl:with-param name="optional" select="$optional"/>
-                    <xsl:with-param name="currentMatch" select="($currentMatch, concat('@',$newMatch))"/>
-                    <xsl:with-param name="match" select="$match"/>
-                </xsl:call-template>
-                <xsl:call-template name="matchJoinTemplates">
-                    <xsl:with-param name="type" select="$type"/>
-                    <xsl:with-param name="required" select="$required"/>
-                    <xsl:with-param name="optional" select="$optional"/>
-                    <xsl:with-param name="currentMatch" select="($currentMatch, concat('not(@',$newMatch,')'))"/>
-                    <xsl:with-param name="match" select="$match"/>
-                </xsl:call-template>
-            </xsl:otherwise>
-        </xsl:choose>
+
+        <xslout:for-each-group group-by="@{$required[1]}">
+            <xsl:attribute name="select">
+                <xsl:text>$nextStep[@type='</xsl:text>
+                <xsl:value-of select="$type"/>
+                <xsl:text>' </xsl:text>
+                <xsl:if test="$match">
+                    <xsl:text>and </xsl:text>
+                    <xsl:value-of select="$match"/>
+                </xsl:if>
+                <xsl:text>]</xsl:text>
+            </xsl:attribute>
+            <xsl:call-template name="forEachJoinTemplate">
+                <xsl:with-param name="attribs" select="subsequence($required, 2)"/>
+            </xsl:call-template>
+        </xslout:for-each-group>
     </xsl:template>
 
     <xsl:template name="forEachJoinTemplate">
@@ -163,13 +132,10 @@
                     </xslout:for-each-group>
                 </xsl:when>
                 <xsl:otherwise>
-                    <check:join>
-                        <xslout:attribute name="steps">
-                            <xslout:value-of separator=" ">
-                                <xslout:sequence select="current-group()/@id"/>
-                            </xslout:value-of>
-                        </xslout:attribute>
-                    </check:join>
+                    <xslout:variable name="node" as="node()"><check:join /></xslout:variable>
+                    <xslout:variable name="joinGroup" as="xs:string*" select="distinct-values(current-group()/@id)"/>
+                    <xslout:variable name="joinId" as="xsd:string" select="generate-id($node)"/>
+                    <xslout:map-entry key="$joinId" select="$joinGroup"/>
                 </xsl:otherwise>
             </xsl:choose>
         </xslout:if>

--- a/core/src/main/resources/xsl/opt/headerJoin.xsl
+++ b/core/src/main/resources/xsl/opt/headerJoin.xsl
@@ -54,7 +54,7 @@
         xmlns:check="http://www.rackspace.com/repose/wadl/checker"
         xmlns="http://www.rackspace.com/repose/wadl/checker"
         exclude-result-prefixes="xsd check"
-        version="2.0">
+        version="3.0">
 
     <!--
         Most of the work of joining is done by the following util. The
@@ -71,17 +71,18 @@
     <!--
         Convert joins into a checker step.
     -->
-    <xsl:template match="check:join" mode="join">
+    <xsl:template name="createJoinStep">
         <xsl:param name="checker" as="node()"/>
-        <xsl:param name="joins" as="node()*"/>
-        <xsl:variable name="steps" select="@steps"/>
-        <xsl:variable name="joinSteps" as="node()*" select="check:stepsByIds($checker, tokenize($steps,' '))"/>
+        <xsl:param name="joins" as="map(xsd:string, xsd:string*)"/>
+        <xsl:param name="stepsToJoin" as="map(xsd:string, xsd:string)"/>
+        <xsl:variable name="joinSteps" as="node()*" select="check:stepsByIds($checker, $joins(.))"/>
         <xsl:variable name="distinctMatches" as="xsd:string*" select="distinct-values($joinSteps/@match)"/>
 
-        <step id="{generate-id(.)}" type="{@type}" name="{@name}">
+        <step id="{.}" type="{$joinSteps[1]/@type}" name="{$joinSteps[1]/@name}">
             <xsl:call-template name="joinNext">
                 <xsl:with-param name="checker" select="$checker"/>
                 <xsl:with-param name="joins" select="$joins"/>
+                <xsl:with-param name="stepsToJoin" select="$stepsToJoin"/>
             </xsl:call-template>
             <xsl:attribute name="match">
                 <xsl:value-of select="$distinctMatches" separator="|" />

--- a/core/src/main/resources/xsl/opt/headerJoinTemplate.xsl
+++ b/core/src/main/resources/xsl/opt/headerJoinTemplate.xsl
@@ -29,8 +29,7 @@
     xmlns:rules="http://www.rackspace.com/repose/wadl/checker/opt/removeDups/rules"
     xmlns:check="http://www.rackspace.com/repose/wadl/checker"
     xmlns:xslout="http://www.rackspace.com/repose/wadl/checker/Transform"
-    exclude-result-prefixes="rules"
-    version="2.0">
+    exclude-result-prefixes="rules" version="2.0">
 
     <xsl:namespace-alias stylesheet-prefix="xslout" result-prefix="xsl"/>
     <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
@@ -39,7 +38,7 @@
     <xsl:variable name="rules" as="node()" select="/rules:rules"/>
     <xsl:variable name="types" as="xs:string*" select="('HEADER', 'HEADER_ANY', 'HEADER_SINGLE')"/>
 
-    <xsl:key name="rule-by-type" match="rules:rule" use="tokenize(@types,' ')"/>
+    <xsl:key name="rule-by-type" match="rules:rule" use="tokenize(@types, ' ')"/>
 
     <xsl:template match="/">
         <xsl:comment>
@@ -48,37 +47,46 @@
             **********
 </xsl:comment>
         <xsl:text>&#xa;</xsl:text>
-        <xslout:stylesheet
-            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        <xslout:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:check="http://www.rackspace.com/repose/wadl/checker"
-            xmlns="http://www.rackspace.com/repose/wadl/checker"
-            exclude-result-prefixes="xsd check"
-            version="2.0">
+            xmlns="http://www.rackspace.com/repose/wadl/checker" exclude-result-prefixes="xsd check"
+            version="3.0">
             <xslout:template match="check:step[@next]" mode="getJoins">
                 <xslout:param name="checker" as="node()"/>
-                <xslout:variable name="nextStep" as="node()*" select="check:stepsByIds($checker, check:next(.))"/>
+                <xslout:variable name="nextStep" as="node()*"
+                    select="check:stepsByIds($checker, check:next(.))"/>
                 <xsl:for-each select="$types">
                     <xslout:call-template name="{$pfx}{.}">
-                        <xslout:with-param name="checker"  select="$checker"/>
+                        <xslout:with-param name="checker" select="$checker"/>
                         <xslout:with-param name="nextStep" select="$nextStep"/>
                     </xslout:call-template>
                 </xsl:for-each>
             </xslout:template>
             <xsl:for-each select="$types">
                 <xsl:variable name="rule" as="node()" select="key('rule-by-type', ., $rules)"/>
-                <xsl:variable name="required" as="xs:string*" select="for $r in tokenize($rule/@required,' ') return
-                                                                      (: Exclude name, match attributes we are joining by these :)
-                                                                      if ($r = ('name','match')) then () else $r"/>
-                <xsl:variable name="optional" as="xs:string*" select="tokenize($rule/@optional,' ')"/>
+                <xsl:variable name="required" as="xs:string*"
+                    select="
+                        (for $r in tokenize($rule/@required, ' ')
+                        return
+                            (: Exclude name, match attributes we are joining by these :)
+                            if ($r = ('name', 'match')) then
+                                ()
+                            else
+                                $r,
+                        tokenize($rule/@optional, ' '))"/>
                 <xsl:variable name="match" as="xs:string?" select="$rule/@match"/>
                 <xslout:template name="{$pfx}{.}">
                     <xslout:param name="checker" as="node()"/>
                     <xslout:param name="nextStep" as="node()*"/>
                     <xsl:call-template name="matchJoinTemplates">
                         <xsl:with-param name="type" select="."/>
-                        <xsl:with-param name="required" select="if (empty($required)) then 'type' else $required"/>
-                        <xsl:with-param name="optional" select="$optional"/>
+                        <xsl:with-param name="required"
+                            select="
+                                if (empty($required)) then
+                                    'type'
+                                else
+                                    $required"/>
                         <xsl:with-param name="currentMatch" select="()"/>
                         <xsl:with-param name="match" select="$match"/>
                     </xsl:call-template>
@@ -89,63 +97,24 @@
     <xsl:template name="matchJoinTemplates">
         <xsl:param name="type" as="xs:string"/>
         <xsl:param name="required" as="xs:string*"/>
-        <xsl:param name="optional" as="xs:string*"/>
         <xsl:param name="currentMatch" as="xs:string*"/>
         <xsl:param name="match" as="xs:string?"/>
-        <xsl:choose>
-            <xsl:when test="empty($optional)">
-                <xslout:for-each-group group-by="@{$required[1]}">
-                    <xsl:attribute name="select">
-                        <xsl:text>$nextStep[@type='</xsl:text>
-                        <xsl:value-of select="$type"/>
-                        <xsl:text>' </xsl:text>
-                        <xsl:if test="$match">
-                            <xsl:text>and </xsl:text>
-                            <xsl:value-of select="$match"/>
-                        </xsl:if>
-                        <xsl:text>]</xsl:text>
-                    </xsl:attribute>
-                    <xsl:call-template name="forEachJoinTemplate">
-                        <xsl:with-param name="attribs" select="subsequence($required,2)"/>
-                    </xsl:call-template>
-                </xslout:for-each-group>
-            </xsl:when>
-            <xsl:when test="count($optional) = count($currentMatch)">
-                <xsl:variable name="allAttribs" as="xs:string*" select="($required, for $o in $optional return
-                                                                         if (concat('@',$o) = $currentMatch) then $o else ())"/>
-                <xsl:variable name="matchString" as="xs:string" select="string-join(($currentMatch, $match), ' and ')"/>
-                <xslout:for-each-group group-by="@{$allAttribs[1]}">
-                    <xsl:attribute name="select">
-                        <xsl:text>$nextStep[@type ='</xsl:text>
-                        <xsl:value-of select="$type"/>
-                        <xsl:text>' </xsl:text>
-                        <xsl:text>and </xsl:text>
-                        <xsl:value-of select="$matchString"/>
-                        <xsl:text>]</xsl:text>
-                    </xsl:attribute>
-                    <xsl:call-template name="forEachJoinTemplate">
-                        <xsl:with-param name="attribs" select="subsequence($allAttribs,2)"/>
-                    </xsl:call-template>
-                </xslout:for-each-group>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:variable name="newMatch" as="xs:string" select="$optional[count($currentMatch)+1]"/>
-                <xsl:call-template name="matchJoinTemplates">
-                    <xsl:with-param name="type" select="$type"/>
-                    <xsl:with-param name="required" select="$required"/>
-                    <xsl:with-param name="optional" select="$optional"/>
-                    <xsl:with-param name="currentMatch" select="($currentMatch, concat('@',$newMatch))"/>
-                    <xsl:with-param name="match" select="$match"/>
-                </xsl:call-template>
-                <xsl:call-template name="matchJoinTemplates">
-                    <xsl:with-param name="type" select="$type"/>
-                    <xsl:with-param name="required" select="$required"/>
-                    <xsl:with-param name="optional" select="$optional"/>
-                    <xsl:with-param name="currentMatch" select="($currentMatch, concat('not(@',$newMatch,')'))"/>
-                    <xsl:with-param name="match" select="$match"/>
-                </xsl:call-template>
-            </xsl:otherwise>
-        </xsl:choose>
+
+        <xslout:for-each-group group-by="@{$required[1]}">
+            <xsl:attribute name="select">
+                <xsl:text>$nextStep[@type='</xsl:text>
+                <xsl:value-of select="$type"/>
+                <xsl:text>' </xsl:text>
+                <xsl:if test="$match">
+                    <xsl:text>and </xsl:text>
+                    <xsl:value-of select="$match"/>
+                </xsl:if>
+                <xsl:text>]</xsl:text>
+            </xsl:attribute>
+            <xsl:call-template name="forEachJoinTemplate">
+                <xsl:with-param name="attribs" select="subsequence($required, 2)"/>
+            </xsl:call-template>
+        </xslout:for-each-group>
     </xsl:template>
 
     <xsl:template name="forEachJoinTemplate">
@@ -162,15 +131,10 @@
                     </xslout:for-each-group>
                 </xsl:when>
                 <xsl:otherwise>
-                    <check:join>
-                        <xslout:attribute name="type" select="current-group()[1]/@type"/>
-                        <xslout:attribute name="name" select="current-group()[1]/@name"/>
-                        <xslout:attribute name="steps">
-                            <xslout:value-of separator=" ">
-                                <xslout:sequence select="current-group()/@id"/>
-                            </xslout:value-of>
-                        </xslout:attribute>
-                    </check:join>
+                    <xslout:variable name="node" as="node()"><check:join /></xslout:variable>
+                    <xslout:variable name="joinGroup" as="xs:string*" select="distinct-values(current-group()/@id)"/>
+                    <xslout:variable name="joinId" as="xsd:string" select="generate-id($node)"/>
+                    <xslout:map-entry key="$joinId" select="$joinGroup"/>
                 </xsl:otherwise>
             </xsl:choose>
         </xslout:if>

--- a/core/src/main/resources/xsl/opt/joinCleanup.xsl
+++ b/core/src/main/resources/xsl/opt/joinCleanup.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    exclude-result-prefixes="xs"
+    version="2.0">
+    <xsl:variable name="EMPTY" as="xs:string">[{[!EMPTY!]}]</xsl:variable>
+    <xsl:template match="@* | node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()"/>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="@*[. = $EMPTY]"/>
+</xsl:stylesheet>

--- a/core/src/main/resources/xsl/opt/joinSetupTemplate.xsl
+++ b/core/src/main/resources/xsl/opt/joinSetupTemplate.xsl
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  joinSetupTemplate.xsl
+
+  This template is called at compile time to build
+  removeDups-rules.setup.xsl this contains auto-generated code to
+  to annotate optional attributes for the purpose of speeding up join
+  optimization stages.
+
+  The input to the template is removeDups-rules.xml which contains
+  rules for how states can be combined.
+
+  Copyright 2015 Rackspace US, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns="http://www.rackspace.com/repose/wadl/checker/opt/removeDups/rules"
+    xmlns:rules="http://www.rackspace.com/repose/wadl/checker/opt/removeDups/rules"
+    xmlns:check="http://www.rackspace.com/repose/wadl/checker"
+    xmlns:xslout="http://www.rackspace.com/repose/wadl/checker/Transform"
+    exclude-result-prefixes="rules"
+    version="2.0">
+
+    <xsl:namespace-alias stylesheet-prefix="xslout" result-prefix="xsl"/>
+    <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+    <xsl:variable name="EMPTY" as="xs:string">[{[!EMPTY!]}]</xsl:variable>
+    <xsl:template match="rules:rules">
+        <xsl:comment>
+            **********                                                    **********
+            ********** THIS IS A GENERATED STYLESHEET DO NOT EDIT BY HAND **********
+            **********                                                    **********
+        </xsl:comment>
+        <xsl:text>&#xa;</xsl:text>
+        <xslout:stylesheet
+            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:check="http://www.rackspace.com/repose/wadl/checker"
+            xmlns="http://www.rackspace.com/repose/wadl/checker"
+            exclude-result-prefixes="xsd check"
+            version="2.0">
+
+            <xslout:template match="@* | node()">
+                <xslout:copy>
+                    <xslout:apply-templates select="@* | node()"/>
+                </xslout:copy>
+            </xslout:template>
+
+            <xsl:apply-templates/>
+
+        </xslout:stylesheet>
+    </xsl:template>
+
+    <xsl:template match="rules:rule">
+        <xsl:variable name="types"      as="xs:string*" select="tokenize(@types,' ')"/>
+        <xsl:variable name="optionals"  as="xs:string*" select="tokenize(@optional,' ')"/>
+        <xsl:variable name="sq" as="xs:string">'</xsl:variable>
+        <xsl:variable name="qtypes" as="xs:string*" select="for $t in $types return concat($sq,$t,$sq)"/>
+        <xsl:variable name="typematch" as="xs:string"><xsl:value-of select="$qtypes" separator=", "/></xsl:variable>
+        <xslout:template match="check:step[@type=({$typematch})]">
+            <xslout:copy>
+                <xsl:for-each select="$optionals">
+                    <xslout:if test="not(@{.})">
+                        <xslout:attribute name="{.}" select="'{$EMPTY}'"/>
+                    </xslout:if>
+                </xsl:for-each>
+                <xslout:apply-templates select="@* | node()"/>
+            </xslout:copy>
+        </xslout:template>
+    </xsl:template>
+    <xsl:template match="text()"/>
+
+</xsl:stylesheet>

--- a/core/src/main/resources/xsl/opt/removeDups-rules.xml
+++ b/core/src/main/resources/xsl/opt/removeDups-rules.xml
@@ -55,7 +55,7 @@
     <rule types="METHOD REQ_TYPE" required="next match">
         Steps that simply contain a match.
     </rule>
-    <rule types="XSD" contians="next" optional="transform">
+    <rule types="XSD" required="next" optional="transform">
         Rule for XSD types.
     </rule>
     <rule types="URL_FAIL" optional="notTypes notMatch">

--- a/core/src/main/resources/xsl/opt/removeDups.xsl
+++ b/core/src/main/resources/xsl/opt/removeDups.xsl
@@ -41,41 +41,40 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-<xsl:stylesheet
-    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:check="http://www.rackspace.com/repose/wadl/checker"
-    xmlns="http://www.rackspace.com/repose/wadl/checker"
-    exclude-result-prefixes="xsd check"
-    version="2.0">
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+    xmlns:util="http://www.rackspace.com/repose/wadl/checker/util"
+    xmlns="http://www.rackspace.com/repose/wadl/checker" exclude-result-prefixes="xsd check"
+    version="3.0">
 
     <xsl:import href="../util/funs.xsl"/>
+    <xsl:import href="../util/pruneSteps.xsl"/>
+
     <xsl:include href="removeDups-rules.xsl"/>
+
 
     <xsl:output indent="yes" method="xml"/>
 
     <xsl:template match="check:checker" name="replaceAllDups">
         <xsl:param name="checker" select="." as="node()"/>
-        <xsl:variable name="dups" as="node()">
-            <xsl:call-template name="getDups">
-                <xsl:with-param name="checker" select="$checker"/>
-            </xsl:call-template>
-        </xsl:variable>
+        <xsl:variable name="dups" as="map(xsd:string, xsd:string*)" select="check:getDups($checker)"/>
         <xsl:choose>
-            <xsl:when test="not($dups/check:group)">
+            <xsl:when test="map:size($dups) = 0">
                 <!-- No duplicats found, tidy up empty epsillon cases -->
                 <checker>
-                  <xsl:copy-of select="/check:checker/namespace::*"/>
-                  <xsl:apply-templates select="/check:checker/check:meta" mode="copyMeta"/>
-                  <xsl:copy-of select="/check:checker/check:grammar"/>
-                  <xsl:apply-templates select="$checker" mode="epsilonRemove"/>
+                    <xsl:copy-of select="/check:checker/namespace::*"/>
+                    <xsl:apply-templates select="/check:checker/check:meta" mode="copyMeta"/>
+                    <xsl:copy-of select="/check:checker/check:grammar"/>
+                    <xsl:apply-templates select="$checker" mode="epsilonRemove"/>
                 </checker>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:call-template name="replaceAllDups">
                     <xsl:with-param name="checker">
                         <xsl:call-template name="replaceDups">
-                            <xsl:with-param name="checker" select="$checker"/>
+                            <xsl:with-param name="checker" select="util:pruneSteps($checker)"/>
                             <xsl:with-param name="dups" select="$dups"/>
                         </xsl:call-template>
                     </xsl:with-param>
@@ -92,13 +91,9 @@
 
     <xsl:template match="check:checker" name="replaceEpsilons" mode="epsilonRemove">
         <xsl:param name="checker" select="." as="node()"/>
-        <xsl:variable name="dups" as="node()">
-            <xsl:call-template name="getEpsilonDups">
-                <xsl:with-param name="checker" select="$checker"/>
-            </xsl:call-template>
-        </xsl:variable>
+        <xsl:variable name="dups" as="map(xsd:string, xsd:string*)" select="check:getEpsilonDups($checker)"/>
         <xsl:choose>
-            <xsl:when test="not($dups/check:group)">
+            <xsl:when test="map:size($dups) = 0">
                 <xsl:for-each select="$checker//check:step">
                     <xsl:copy-of select="."/>
                 </xsl:for-each>
@@ -107,7 +102,7 @@
                 <xsl:call-template name="replaceEpsilons">
                     <xsl:with-param name="checker">
                         <xsl:call-template name="replaceDups">
-                            <xsl:with-param name="checker" select="$checker"/>
+                            <xsl:with-param name="checker" select="util:pruneSteps($checker)"/>
                             <xsl:with-param name="dups" select="$dups"/>
                         </xsl:call-template>
                     </xsl:with-param>
@@ -118,94 +113,63 @@
 
     <xsl:template name="replaceDups">
         <xsl:param name="checker" as="node()"/>
-        <xsl:param name="dups" as="node()"/>
-        <xsl:variable name="excludes" as="xsd:string*">
-            <xsl:sequence select="tokenize(string-join($dups/check:group/@exclude,' '),' ')"/>
-        </xsl:variable>
+        <xsl:param name="dups" as="map(xsd:string, xsd:string*)"/>
         <checker>
             <xsl:apply-templates select="$checker" mode="unDup">
                 <xsl:with-param name="dups" select="$dups"/>
-                <xsl:with-param name="excludes" select="$excludes"/>
             </xsl:apply-templates>
         </checker>
     </xsl:template>
 
     <xsl:template match="check:step" mode="unDup">
-        <xsl:param name="dups" as="node()"/>
-        <xsl:param name="excludes" as="xsd:string*"/>
-        <xsl:choose>
-            <xsl:when test="$excludes = @id"/>
-            <xsl:otherwise>
-                <step>
-                    <xsl:apply-templates select="@*" mode="unDup">
-                        <xsl:with-param name="dups" select="$dups"/>
-                        <xsl:with-param name="excludes" select="$excludes"/>
-                        <xsl:with-param name="id" select="@id"/>
-                    </xsl:apply-templates>
-                    <xsl:copy-of select="element()"/>
-                </step>
-            </xsl:otherwise>
-        </xsl:choose>
+        <xsl:param name="dups" as="map(xsd:string, xsd:string*)"/>
+        <step>
+            <xsl:apply-templates select="@*" mode="unDup">
+                <xsl:with-param name="dups" select="$dups"/>
+                <xsl:with-param name="id" select="@id"/>
+            </xsl:apply-templates>
+            <xsl:copy-of select="element()"/>
+        </step>
     </xsl:template>
 
     <xsl:template match="@*" mode="unDup">
-        <xsl:param name="dups" as="node()"/>
-        <xsl:param name="excludes" as="xsd:string*"/>
+        <xsl:param name="dups" as="map(xsd:string, xsd:string*)"/>
         <xsl:param name="id" as="xsd:string"/>
         <xsl:choose>
             <!-- Substitude excludes from nexts -->
             <xsl:when test="name() = 'next'">
-                <xsl:variable name="nexts" as="xsd:string*" select="tokenize(.,' ')"/>
+                <xsl:variable name="nexts" as="xsd:string*" select="tokenize(., ' ')"/>
+                <xsl:variable name="newNext" as="xsd:string*" select="for $n in $nexts return
+                    if (map:contains($dups, $n)) then $dups($n) else $n"/>
                 <xsl:attribute name="next">
-                  <xsl:value-of select="check:removeDupNext(check:swapExclude($nexts,$excludes,$dups))" separator=" "/>
+                    <xsl:value-of select="$newNext" separator=" "/>
                 </xsl:attribute>
             </xsl:when>
-            <!-- Copy labels only if all excluded labels match -->
-            <xsl:when test="name() = 'label'">
-                <xsl:variable name="excludedIDs" as="xsd:string*" select="tokenize($dups/check:group[@include=$id]/@exclude, ' ')"/>
-                <xsl:variable name="excludedLabels" select="//check:step[@id=$excludedIDs]/@label" as="xsd:string*"/>
-                <xsl:if test="every $l in $excludedLabels satisfies $l=.">
-                    <xsl:copy/>
-                </xsl:if>
-            </xsl:when>
+            <!-- Don't copy labels -->
+            <xsl:when test="name() = 'label'"/>
             <xsl:otherwise>
                 <xsl:copy/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
 
-    <xsl:function name="check:removeDupNext" as="xsd:string*">
-        <xsl:param name="nexts" as="xsd:string*"/>
-        <xsl:for-each-group select="$nexts" group-by=".">
-            <xsl:value-of select="current-group()[1]"/>
-        </xsl:for-each-group>
-    </xsl:function>
-
-    <xsl:function name="check:swapExclude" as="xsd:string*">
-        <xsl:param name="nexts" as="xsd:string*"/>
-        <xsl:param name="excludes" as="xsd:string*"/>
-        <xsl:param name="dups" as="node()"/>
-        <xsl:sequence select="for $n in $nexts return if ($excludes = $n) then
-                              $dups/check:group/@include[tokenize(../@exclude,' ') = $n]
-                              else $n"/>
-    </xsl:function>
-
-    <xsl:template name="getEpsilonDups" as="node()">
+    <xsl:function name="check:getEpsilonDups" as="map(xsd:string, xsd:string*)">
         <xsl:param name="checker" as="node()"/>
-        <checker>
+        <xsl:map>
             <!-- Treat epsilon methods as dups -->
-            <xsl:for-each select="$checker//check:step[@type='METHOD']">
-                <xsl:variable name="nexts" as="xsd:string*" select="tokenize(@next,' ')"/>
-                <xsl:variable name="nextStep" as="node()*" select="$checker//check:step[@id = $nexts]"/>
-                <xsl:if test="every $s in $nextStep satisfies $s/@type='METHOD'">
-                    <group>
-                        <xsl:attribute name="include" select="$nexts" separator=" "/>
-                        <xsl:attribute name="exclude" select="@id"/>
-                    </group>
+            <xsl:for-each select="$checker//check:step[@type = 'METHOD']">
+                <xsl:variable name="nexts" as="xsd:string*" select="tokenize(@next, ' ')"/>
+                <xsl:variable name="nextStep" as="node()*"
+                    select="$checker//check:step[@id = $nexts]"/>
+                <xsl:if
+                    test="
+                        every $s in $nextStep
+                            satisfies $s/@type = 'METHOD'">
+                    <xsl:map-entry key="string(@id)" select="$nexts"/>
                 </xsl:if>
             </xsl:for-each>
-        </checker>
-    </xsl:template>
+        </xsl:map>
+    </xsl:function>
 
 
     <xsl:template match="text()" mode="#all"/>

--- a/core/src/main/resources/xsl/opt/removeDupsTemplate.xsl
+++ b/core/src/main/resources/xsl/opt/removeDupsTemplate.xsl
@@ -29,17 +29,17 @@
     xmlns:rules="http://www.rackspace.com/repose/wadl/checker/opt/removeDups/rules"
     xmlns:check="http://www.rackspace.com/repose/wadl/checker"
     xmlns:xslout="http://www.rackspace.com/repose/wadl/checker/Transform"
-    exclude-result-prefixes="rules"
-    version="2.0">
+    exclude-result-prefixes="rules" version="3.0">
 
     <xsl:namespace-alias stylesheet-prefix="xslout" result-prefix="xsl"/>
     <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
 
     <xsl:variable name="pfx" as="xs:string" select="'TMP-'"/>
     <xsl:variable name="rules" as="node()" select="/rules:rules"/>
-    <xsl:variable name="types" as="xs:string*" select="distinct-values(tokenize(string-join($rules/rules:rule/@types, ' '), ' '))"/>
+    <xsl:variable name="types" as="xs:string*"
+        select="distinct-values(tokenize(string-join($rules/rules:rule/@types, ' '), ' '))"/>
 
-    <xsl:key name="rule-by-type" match="rules:rule" use="tokenize(@types,' ')"/>
+    <xsl:key name="rule-by-type" match="rules:rule" use="tokenize(@types, ' ')"/>
 
     <xsl:template match="/">
         <xsl:comment>
@@ -48,106 +48,83 @@
             **********                                                    **********
 </xsl:comment>
         <xsl:text>&#xa;</xsl:text>
-        <xslout:stylesheet
-            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        <xslout:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             xmlns:check="http://www.rackspace.com/repose/wadl/checker"
-            xmlns="http://www.rackspace.com/repose/wadl/checker"
-            exclude-result-prefixes="xsd check"
-            version="2.0">
-           <xslout:template name="getDups" as="node()">
-               <xslout:param name="checker" as="node()"/>
-               <check:checker>
-                   <xsl:for-each select="$types">
-                       <xslout:call-template name="{$pfx}{.}">
-                           <xslout:with-param name="checker" select="$checker"/>
-                       </xslout:call-template>
-                   </xsl:for-each>
-               </check:checker>
-           </xslout:template>
-           <xsl:for-each select="$types">
-               <xsl:variable name="rule" as="node()" select="key('rule-by-type', ., $rules)"/>
-               <xsl:variable name="required" as="xs:string*" select="tokenize($rule/@required,' ')"/>
-               <xsl:variable name="optional" as="xs:string*" select="tokenize($rule/@optional,' ')"/>
-               <xsl:variable name="match" as="xs:string?"
-                             select="$rule/@match"/>
-               <xslout:template name="{$pfx}{.}">
-                   <xslout:param name="checker" as="node()"/>
-                   <xsl:choose>
-                       <xsl:when test="empty($optional) and empty($required)">
-                           <xslout:variable name="{.}" as="node()*"
-                                            select="key('checker-by-type','{.}', $checker){if ($match) then concat('[',$match,']') else ()}"/>
-                           <xslout:if test="count(${.}) > 1">
-                               <check:group>
-                                   <xslout:attribute name="include">
-                                       <xslout:value-of select="${.}[1]/@id"></xslout:value-of>
-                                   </xslout:attribute>
-                                   <xslout:attribute name="exclude">
-                                       <xslout:value-of separator=" ">
-                                           <xslout:sequence select="subsequence(${.},2)/@id"></xslout:sequence>
-                                       </xslout:value-of>
-                                   </xslout:attribute>
-                               </check:group>
-                           </xslout:if>
-                       </xsl:when>
-                       <xsl:otherwise>
-                           <xsl:call-template name="matchTemplates">
-                               <xsl:with-param name="type" select="."/>
-                               <xsl:with-param name="required" select="if (empty($required)) then 'type' else $required"/>
-                               <xsl:with-param name="optional" select="$optional"/>
-                               <xsl:with-param name="currentMatch" select="()"/>
-                               <xsl:with-param name="match" select="$match"/>
-                           </xsl:call-template>
-                       </xsl:otherwise>
-                   </xsl:choose>
-               </xslout:template>
-           </xsl:for-each>
+            xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+            xmlns="http://www.rackspace.com/repose/wadl/checker" exclude-result-prefixes="xsd check"
+            version="3.0">
+            <xslout:function name="check:getDups" as="map(xs:string, xs:string*)">
+                <xslout:param name="checker" as="node()"/>
+                <xslout:sequence>
+                    <xsl:attribute name="select">
+                        <xsl:text>map:merge((</xsl:text>
+                        <xsl:for-each select="$types">
+                            <xsl:text>check:</xsl:text>
+                            <xsl:value-of select="$pfx"/>
+                            <xsl:value-of select="."/>
+                            <xsl:text>($checker)</xsl:text>
+                            <xsl:if test="position() != last()">
+                                <xsl:text>, </xsl:text>
+                            </xsl:if>
+                        </xsl:for-each>
+                        <xsl:text>))</xsl:text>
+                    </xsl:attribute>
+                </xslout:sequence>
+            </xslout:function>
+            <xsl:for-each select="$types">
+                <xsl:variable name="rule" as="node()" select="key('rule-by-type', ., $rules)"/>
+                <xsl:variable name="required" as="xs:string*"
+                    select="
+                        (if (empty($rule/@required)) then
+                            'type'
+                        else
+                            tokenize($rule/@required, ' '),
+                        tokenize($rule/@optional, ' '))"/>
+                <xsl:variable name="match" as="xs:string?" select="$rule/@match"/>
+                <xslout:function name="check:{$pfx}{.}" as="map(xs:string, xs:string*)">
+                    <xslout:param name="checker" as="node()"/>
+                    <xslout:map>
+                        <xsl:choose>
+                            <xsl:when test="empty($required)">
+                                <xslout:variable name="{.}" as="node()*"
+                                    select="key('checker-by-type','{.}', $checker){if ($match) then concat('[',$match,']') else ()}"/>
+                                <xslout:if test="count(${.}) > 1">
+                                    <xslout:variable name="include" as="xs:string"
+                                        select="${.}[1]/@id"/>
+                                    <xslout:for-each select="${.}/@id">
+                                        <xslout:map-entry key="string(.)" select="$include"/>
+                                    </xslout:for-each>
+                                </xslout:if>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:call-template name="matchTemplates">
+                                    <xsl:with-param name="type" select="."/>
+                                    <xsl:with-param name="required" select="$required"/>
+                                    <xsl:with-param name="currentMatch" select="()"/>
+                                    <xsl:with-param name="match" select="$match"/>
+                                </xsl:call-template>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xslout:map>
+                </xslout:function>
+            </xsl:for-each>
         </xslout:stylesheet>
     </xsl:template>
 
     <xsl:template name="matchTemplates">
         <xsl:param name="type" as="xs:string"/>
         <xsl:param name="required" as="xs:string*"/>
-        <xsl:param name="optional" as="xs:string*"/>
         <xsl:param name="currentMatch" as="xs:string*"/>
         <xsl:param name="match" as="xs:string?"/>
-        <xsl:choose>
-            <xsl:when test="empty($optional)">
-                <xslout:for-each-group select="key('checker-by-type','{$type}', $checker){if ($match) then concat('[',$match,']') else ()}"
-                        group-by="@{$required[1]}">
-                    <xsl:call-template name="forEachTemplate">
-                        <xsl:with-param name="attribs" select="subsequence($required,2)"/>
-                    </xsl:call-template>
-                </xslout:for-each-group>
-            </xsl:when>
-            <xsl:when test="count($optional) = count($currentMatch)">
-                <xsl:variable name="allAttribs" as="xs:string*" select="($required, for $o in $optional return
-                                                                         if (concat('@',$o) = $currentMatch) then $o else ())"/>
-                <xsl:variable name="matchString" as="xs:string" select="string-join(($currentMatch, $match), ' and ')"/>
-                <xslout:for-each-group select="key('checker-by-type','{$type}', $checker)[{$matchString}]" group-by="@{$allAttribs[1]}">
-                    <xsl:call-template name="forEachTemplate">
-                        <xsl:with-param name="attribs" select="subsequence($allAttribs,2)"/>
-                    </xsl:call-template>
-                </xslout:for-each-group>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:variable name="newMatch" as="xs:string" select="$optional[count($currentMatch)+1]"/>
-                <xsl:call-template name="matchTemplates">
-                    <xsl:with-param name="type" select="$type"/>
-                    <xsl:with-param name="required" select="$required"/>
-                    <xsl:with-param name="optional" select="$optional"/>
-                    <xsl:with-param name="currentMatch" select="($currentMatch, concat('@',$newMatch))"/>
-                    <xsl:with-param name="match" select="$match"/>
-                </xsl:call-template>
-                <xsl:call-template name="matchTemplates">
-                    <xsl:with-param name="type" select="$type"/>
-                    <xsl:with-param name="required" select="$required"/>
-                    <xsl:with-param name="optional" select="$optional"/>
-                    <xsl:with-param name="currentMatch" select="($currentMatch, concat('not(@',$newMatch,')'))"/>
-                    <xsl:with-param name="match" select="$match"/>
-                </xsl:call-template>
-            </xsl:otherwise>
-        </xsl:choose>
+
+        <xslout:for-each-group
+            select="key('checker-by-type','{$type}', $checker){if ($match) then concat('[',$match,']') else ()}"
+            group-by="@{$required[1]}">
+            <xsl:call-template name="forEachTemplate">
+                <xsl:with-param name="attribs" select="subsequence($required, 2)"/>
+            </xsl:call-template>
+        </xslout:for-each-group>
     </xsl:template>
 
     <xsl:template name="forEachTemplate">
@@ -164,16 +141,10 @@
                     </xslout:for-each-group>
                 </xsl:when>
                 <xsl:otherwise>
-                    <check:group>
-                        <xslout:attribute name="include">
-                            <xslout:value-of select="current-group()[1]/@id"/>
-                        </xslout:attribute>
-                        <xslout:attribute name="exclude">
-                            <xslout:value-of separator=" ">
-                                <xslout:sequence select="subsequence(current-group(), 2)/@id"/>
-                            </xslout:value-of>
-                        </xslout:attribute>
-                    </check:group>
+                    <xslout:variable name="include" as="xs:string" select="current-group()[1]/@id"/>
+                    <xslout:for-each select="current-group()/@id">
+                        <xslout:map-entry key="string(.)" select="$include"/>
+                    </xslout:for-each>
                 </xsl:otherwise>
             </xsl:choose>
         </xslout:if>

--- a/core/src/main/resources/xsl/util/join.xsl
+++ b/core/src/main/resources/xsl/util/join.xsl
@@ -65,9 +65,10 @@
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
     xmlns:check="http://www.rackspace.com/repose/wadl/checker"
     xmlns:util="http://www.rackspace.com/repose/wadl/checker/util"
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map"
     xmlns="http://www.rackspace.com/repose/wadl/checker"
     exclude-result-prefixes="xsd check"
-    version="2.0">
+    version="3.0">
 
     <xsl:import href="pruneSteps.xsl"/>
 
@@ -75,13 +76,15 @@
 
     <xsl:template match="check:checker" name="joinDups">
         <xsl:param name="checker" select="." as="node()"/>
-        <xsl:variable name="joins" as="node()*">
-               <xsl:apply-templates mode="getJoins" select="$checker//check:step">
-                <xsl:with-param name="checker" select="$checker"/>
-               </xsl:apply-templates>
+        <xsl:variable name="joins" as="map(xsd:string, xsd:string*)">
+            <xsl:map>
+                <xsl:apply-templates mode="getJoins" select="$checker//check:step">
+                    <xsl:with-param name="checker" select="$checker"/>
+                </xsl:apply-templates>
+            </xsl:map>
         </xsl:variable>
         <xsl:choose>
-            <xsl:when test="empty($joins)">
+            <xsl:when test="empty(map:keys($joins))">
                 <checker>
                     <xsl:copy-of select="/check:checker/namespace::*"/>
                     <xsl:apply-templates select="/check:checker/check:meta" mode="copyMeta"/>
@@ -100,6 +103,7 @@
                         <xsl:call-template name="doJoin">
                             <xsl:with-param name="checker" select="$checker"/>
                             <xsl:with-param name="joins" select="$joins"/>
+                            <xsl:with-param name="stepsToJoin" select="check:stepsToJoin(map:keys($joins), $joins, map{})"/>
                         </xsl:call-template>
                     </xsl:with-param>
                 </xsl:call-template>
@@ -107,6 +111,29 @@
         </xsl:choose>
     </xsl:template>
 
+    <xsl:function name="check:stepsToJoin" as="map(xsd:string, xsd:string)">
+        <xsl:param name="joins" as="xsd:string*"/>
+        <xsl:param name="joinStepIndex" as="map(xsd:string, xsd:string*)"/>
+        <xsl:param name="map" as="map(xsd:string, xsd:string)"/>
+        <xsl:choose>
+            <xsl:when test="not(empty($joins))">
+                <xsl:variable name="id" as="xsd:string" select="$joins[1]"/>
+                <xsl:variable name="newMap" as="map(xsd:string, xsd:string)">
+                    <xsl:map>
+                        <xsl:for-each select="$joinStepIndex($id)">
+                            <xsl:if test="not(map:contains($map, .))">
+                                <xsl:map-entry key="." select="$id"/>
+                            </xsl:if>
+                        </xsl:for-each>
+                    </xsl:map>
+                </xsl:variable>
+                <xsl:sequence select="check:stepsToJoin(subsequence($joins, 2), $joinStepIndex, map:merge(($map, $newMap)))"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="$map"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
 
     <xsl:template match="@* | node()" mode="copyMeta" priority="10">
         <xsl:copy>
@@ -123,24 +150,30 @@
 
     <xsl:template name="doJoin">
         <xsl:param name="checker" as="node()"/>
-        <xsl:param name="joins" as="node()*"/>
+        <xsl:param name="joins" as="map(xsd:string, xsd:string*)"/>
+        <xsl:param name="stepsToJoin" as="map(xsd:string, xsd:string)"/>
 
         <checker>
             <xsl:apply-templates select="$checker" mode="copy">
                 <xsl:with-param name="joins" select="$joins"/>
+                <xsl:with-param name="stepsToJoin" select="$stepsToJoin"/>
             </xsl:apply-templates>
-            <xsl:apply-templates select="$joins" mode="join">
-                <xsl:with-param name="checker" select="$checker"/>
-                <xsl:with-param name="joins" select="$joins"/>
-            </xsl:apply-templates>
+            <xsl:for-each select="map:keys($joins)">
+                <xsl:call-template name="createJoinStep">
+                    <xsl:with-param name="checker" select="$checker"/>
+                    <xsl:with-param name="joins" select="$joins"/>
+                    <xsl:with-param name="stepsToJoin" select="$stepsToJoin"/>
+                </xsl:call-template>
+            </xsl:for-each>
         </checker>
     </xsl:template>
 
     <xsl:template name="joinNext">
         <xsl:param name="checker" as="node()*"/>
-        <xsl:param name="joins" as="node()*"/>
-        <xsl:param name="join" as="node()" select="."/>
-        <xsl:param name="steps" as="node()*" select="check:stepsByIds($checker, tokenize($join/@steps,' '))"/>
+        <xsl:param name="joins" as="map(xsd:string, xsd:string*)"/>
+        <xsl:param name="stepsToJoin" as="map(xsd:string, xsd:string)"/>
+        <xsl:param name="join" as="xsd:string" select="."/>
+        <xsl:param name="steps" as="node()*" select="check:stepsByIds($checker, $joins(.))"/>
         <xsl:param name="nexts" as="xsd:string*" select="()"/>
         <xsl:choose>
             <xsl:when test="empty($steps)">
@@ -151,11 +184,12 @@
                 </xsl:attribute>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:variable name="snexts" as="xsd:string*" select="check:getNexts($joins,tokenize($steps[1]/@next,' '))"/>
+                <xsl:variable name="snexts" as="xsd:string*" select="check:getNexts($joins, $stepsToJoin, tokenize($steps[1]/@next,' '))"/>
                 <xsl:call-template name="joinNext">
                     <xsl:with-param name="checker" select="$checker"/>
                     <xsl:with-param name="joins" select="$joins"/>
-                    <xsl:with-param name="steps" select="$steps[position() != 1]"/>
+                    <xsl:with-param name="stepsToJoin" select="$stepsToJoin"/>
+                    <xsl:with-param name="steps" select="subsequence($steps, 2)"/>
                     <xsl:with-param name="nexts"
                                     select="(for $s in $snexts
                                              return if (not($s = $nexts)) then $s else (), $nexts)"/>
@@ -165,11 +199,13 @@
     </xsl:template>
 
     <xsl:template match="check:step" mode="copy">
-        <xsl:param name="joins" as="node()*"/>
+        <xsl:param name="joins" as="map(xsd:string, xsd:string*)"/>
+        <xsl:param name="stepsToJoin" as="map(xsd:string, xsd:string)"/>
         <step>
             <xsl:apply-templates select="@*[name() != 'next']" mode="copy"/>
             <xsl:apply-templates select="@next" mode="copy">
                 <xsl:with-param name="joins" select="$joins"/>
+                <xsl:with-param name="stepsToJoin" select="$stepsToJoin"/>
             </xsl:apply-templates>
             <xsl:copy-of select="element()"/>
         </step>
@@ -180,33 +216,50 @@
     </xsl:template>
 
     <xsl:template match="@next" name="updateNext" mode="copy">
-        <xsl:param name="joins" as="node()*"/>
+        <xsl:param name="joins" as="map(xsd:string, xsd:string*)"/>
+        <xsl:param name="stepsToJoin" as="map(xsd:string, xsd:string)"/>
         <xsl:param name="nexts" as="xsd:string*" select="tokenize(string(.),' ')"/>
-        <xsl:attribute name="next"  separator=" " select="check:getNexts($joins,$nexts)"/>
+        <xsl:attribute name="next"  separator=" " select="check:getNexts($joins,$stepsToJoin,$nexts)"/>
     </xsl:template>
 
     <xsl:function name="check:getNexts" as="xsd:string*">
-        <xsl:param name="joins" as="node()*"/>
+        <xsl:param name="joins" as="map(xsd:string, xsd:string*)"/>
+        <xsl:param name="stepsToJoin" as="map(xsd:string, xsd:string)"/>
         <xsl:param name="nexts" as="xsd:string*"/>
+        <xsl:variable name="candidateJoins" as="xsd:string*" select="distinct-values(for $n in $nexts return map:get($stepsToJoin, $n))"/>
         <xsl:choose>
-            <xsl:when test="empty($joins)">
+            <xsl:when test="empty($candidateJoins)">
                 <xsl:sequence select="$nexts"/>
             </xsl:when>
             <xsl:otherwise>
-                <xsl:variable name="join" select="$joins[1]" as="node()"/>
-                <xsl:variable name="steps" select="tokenize($join/@steps,' ')"/>
-                <xsl:variable name="next_out" as="xsd:string*">
+                <xsl:sequence select="check:replaceJoins($joins, $candidateJoins, $nexts)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <xsl:function name="check:replaceJoins" as="xsd:string*">
+        <xsl:param name="joinSteps" as="map(xsd:string, xsd:string*)"/>
+        <xsl:param name="candidateJoins" as="xsd:string*"/>
+        <xsl:param name="nexts" as="xsd:string*"/>
+        <xsl:choose>
+            <xsl:when test="empty($candidateJoins)">
+                <xsl:sequence select="$nexts"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:variable name="candidateJoin" as="xsd:string" select="$candidateJoins[1]"/>
+                <xsl:variable name="steps" as="xsd:string*" select="$joinSteps($candidateJoin)"/>
+                <xsl:variable name="nextOut" as="xsd:string*">
                     <xsl:choose>
                         <xsl:when test="every $s in $steps satisfies $s=$nexts">
-                            <xsl:sequence select="(generate-id($join), for $n in $nexts return
-                                  if (not($n = $steps)) then $n else ())"/>
+                            <xsl:sequence select="($candidateJoin, for $n in $nexts return
+                                                  if (not($n = $steps)) then $n else ())"/>
                         </xsl:when>
                         <xsl:otherwise>
-                           <xsl:sequence select="$nexts"/>
+                            <xsl:sequence select="$nexts"/>
                         </xsl:otherwise>
                     </xsl:choose>
                 </xsl:variable>
-                <xsl:sequence select="check:getNexts(subsequence($joins, 2),$next_out)"/>
+                <xsl:sequence select="check:replaceJoins($joinSteps, subsequence($candidateJoins, 2), $nextOut)"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:function>
@@ -219,39 +272,42 @@
             template should take as input an entire checker document,
             and it should match on a single connected checker step.
 
-            The template should return a <join /> element with an
-            attribute @steps that contains the steps that may be
-            joined. To this step.
-
+            The template should return a map that maps a new join id
+            with the ids of the state that it joins.
 
             For example, if ID1, ID2, and ID3 may be joined, then the
             following should be emmited.
 
-            <join xmlns="http://www.rackspace.com/repose/wadl/checker"
-                  steps="ID1 ID2 ID3"/>
+            map {
+             'JID1' : ('ID1', 'ID2', 'ID3')
+             }
+
+            Where JID1 is the suggested ID of the new join state.
         -->
     </xsl:template>
 
     <!--
-        A new step is created for every join. You must match a join
-        and generate a step.  The id of the step should be the
-        generate-id of the join for things to work.  You should
-        generate the next attribute.  There is a default template for
-        doing this called joinNext.
+        A new step is created for every join. The context is the id of
+        the new step. There is a default template for doing this
+        called joinNext.
 
         The following parameters are passed to apply templates:
 
         checker     :  The entire checker document
-        joins       :  The entire list of joins
-    -->
-    <xsl:template match="check:join" mode="join">
-        <xsl:param name="checker" as="node()"/>
-        <xsl:param name="joins" as="node()*"/>
+        joins       :  A map from join to all of it's state
+        stepsToJoin :  A map from a state to it's join state
 
-        <step id="{generate-id(.)}">
+    -->
+    <xsl:template name="createJoinStep">
+        <xsl:param name="checker" as="node()"/>
+        <xsl:param name="joins" as="map(xsd:string, xsd:string*)"/>
+        <xsl:param name="stepsToJoin" as="map(xsd:string, xsd:string)"/>
+
+        <step id="{.}">
             <xsl:call-template name="joinNext">
                 <xsl:with-param name="checker" select="$checker"/>
                 <xsl:with-param name="joins" select="$joins"/>
+                <xsl:with-param name="stepsToJoin" select="$stepsToJoin"/>
              </xsl:call-template>
         </step>
     </xsl:template>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerOptSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerOptSpec.scala
@@ -277,7 +277,7 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), XSL,
              XPath("/atom:entry/w_ns17:usage"),
              XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
              XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
@@ -285,14 +285,14 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), XSL,
              XPath("/atom:entry/w_ns18:usage"),
              XPath("/atom:entry/@only_usage"), Accept)
 
 
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), XSL,
              XPath("/atom:entry/w_ns16:usage"),
              XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
              XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
@@ -300,16 +300,16 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), XSL,
              XPath("/atom:entry/w_ns18:usage"),
              XPath("/atom:entry/@only_usage"), Accept)
 
       And ("The Following counts should hold")
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 0")
       assert (checker, "count(/chk:checker/chk:step[@type='REQ_TYPE']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 11")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 9")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry']) = 0")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage/w_ns17:up']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down']) = 1")
@@ -319,6 +319,8 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns18:usage']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/@only_usage']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/atom:entry']) = 2")
     }
 
 
@@ -330,7 +332,7 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), XSL,
              XPath("/atom:entry/w_ns17:usage"),
              XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
              XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
@@ -338,14 +340,14 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), XSL,
              XPath("/atom:entry/w_ns18:usage"),
              XPath("/atom:entry/@only_usage"), Accept)
 
 
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), XSL,
              XPath("/atom:entry/w_ns16:usage"),
              XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
              XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
@@ -353,17 +355,16 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), XSL,
              XPath("/atom:entry/w_ns18:usage"),
              XPath("/atom:entry/@only_usage"), Accept)
 
       And ("The Following counts should hold")
-
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 0")
       assert (checker, "count(/chk:checker/chk:step[@type='REQ_TYPE']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 11")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 9")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry']) = 0")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage/w_ns17:up']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down']) = 1")
@@ -373,6 +374,8 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns18:usage']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/@only_usage']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/atom:entry']) = 2")
     }
 
     scenario ("The sharedXPathWADL is processed checking wellformness, XSD, elemnts, and plain parameters, with remove dups and joinpath optimizations (preserve request body)") {
@@ -517,9 +520,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       Then ("The following paths should hold")
 
-      assert(checker,Start, URL("servers"), URL("entries"),
+            assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
              XPath("/atom:entry/w_ns17:usage"),
              XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
              XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
@@ -527,14 +530,18 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
              XPath("/atom:entry/w_ns18:usage"),
              XPath("/atom:entry/@only_usage"), Accept)
 
+      assert(checker,Start, URL("servers"), URL("entries"),
+             Method("POST"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML,
+             ContentFail)
 
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
              XPath("/atom:entry/w_ns16:usage"),
              XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
              XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
@@ -542,16 +549,21 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
              XPath("/atom:entry/w_ns18:usage"),
              XPath("/atom:entry/@only_usage"), Accept)
+
+      assert(checker,Start, URL("nova"), URL("entries"),
+             Method("POST"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML,
+             ContentFail)
 
       And ("The Following counts should hold")
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
       assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 2")
       assert (checker, "count(/chk:checker/chk:step[@type='REQ_TYPE']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 11")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 9")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry']) = 0")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage/w_ns17:up']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down']) = 1")
@@ -561,6 +573,8 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns18:usage']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/@only_usage']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/atom:entry']) = 2")
     }
 
     scenario ("The sharedXPathWADL is processed checking wellformness, XSD, elemnts, and plain parameters, with remove dups and joinpath optimizations (preserve request body, XPath 3.1)") {
@@ -574,7 +588,7 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
              XPath("/atom:entry/w_ns17:usage"),
              XPath("/atom:entry/w_ns17:usage/w_ns17:up"),
              XPath("/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down"),
@@ -582,14 +596,18 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("servers"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
              XPath("/atom:entry/w_ns18:usage"),
              XPath("/atom:entry/@only_usage"), Accept)
 
+      assert(checker,Start, URL("servers"), URL("entries"),
+             Method("POST"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML,
+             ContentFail)
 
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
              XPath("/atom:entry/w_ns16:usage"),
              XPath("/atom:entry/w_ns16:usage/w_ns16:up"),
              XPath("/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down"),
@@ -597,16 +615,21 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       assert(checker,Start, URL("nova"), URL("entries"),
              Method("POST"),
-             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XPath("/atom:entry"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML, XSL,
              XPath("/atom:entry/w_ns18:usage"),
              XPath("/atom:entry/@only_usage"), Accept)
+
+      assert(checker,Start, URL("nova"), URL("entries"),
+             Method("POST"),
+             ReqType("(application/atom\\+xml)(;.*)?"), WellXML,
+             ContentFail)
 
       And ("The Following counts should hold")
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
       assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 2")
       assert (checker, "count(/chk:checker/chk:step[@type='REQ_TYPE']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 11")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 9")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry']) = 0")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage/w_ns17:up']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns17:usage/w_ns17:up/w_ns17:down']) = 1")
@@ -616,6 +639,8 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns16:usage/w_ns16:up/w_ns16:down']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/w_ns18:usage']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/atom:entry/@only_usage']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/atom:entry']) = 2")
     }
 
 
@@ -781,8 +806,7 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       Then ("The following paths should hold")
 
       assert(checker,Start, URL("y"),  Method("POST"),
-             ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"))
+             ReqType("(application/xml)(;.*)?"), XSL)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
@@ -794,13 +818,16 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       And ("The Following counts should hold")
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='REQ_TYPE']) = 2")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 4")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar/@junk']) = 1")
     }
 
 
@@ -811,8 +838,7 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       Then ("The following paths should hold")
 
       assert(checker,Start, URL("y"),  Method("POST"),
-             ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"))
+             ReqType("(application/xml)(;.*)?"), XSL)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
@@ -824,13 +850,16 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       And ("The Following counts should hold")
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='REQ_TYPE']) = 2")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 4")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar/@junk']) = 1")
     }
 
     scenario ("The sharedXPathWADL2 is processed checking wellformness, elemnts, and plain parameters, with remove dups and joinpath optimizations (preserve request body)") {
@@ -921,12 +950,17 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       Then ("The following paths should hold")
 
       assert(checker,Start, URL("y"),  Method("POST"),
-             ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"))
+             ReqType("(application/xml)(;.*)?"), WellXML, XSL)
+
+      assert(checker,Start, URL("y"),  Method("POST"),
+             ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
              XPath("/foo:bar/@junk"), Accept)
+
+      assert(checker,Start, URL("x"),  Method("POST"),
+             ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:foo"),
@@ -941,6 +975,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar/@junk']) = 1")
     }
 
     scenario ("The sharedXPathWADL2 is processed checking wellformness, elemnts, and plain parameters, with remove dups and joinpath optimizations (preserve request body, XPath 3.1)") {
@@ -953,12 +990,17 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       Then ("The following paths should hold")
 
       assert(checker,Start, URL("y"),  Method("POST"),
-             ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"))
+             ReqType("(application/xml)(;.*)?"), WellXML, XSL)
+
+      assert(checker,Start, URL("y"),  Method("POST"),
+             ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
              XPath("/foo:bar/@junk"), Accept)
+
+      assert(checker,Start, URL("x"),  Method("POST"),
+             ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:foo"),
@@ -973,6 +1015,9 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar/@junk']) = 1")
     }
 
     val sharedXPathWADL3 =
@@ -1381,8 +1426,7 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       val checker = builder.build(sharedXPathWADL3, config)
       Then ("The following paths should hold")
       assert(checker,Start, URL("y"),  Method("POST"),
-             ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
+             ReqType("(application/xml)(;.*)?"), XSL,  SetHeaderAlways("Warning"), Accept)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
@@ -1394,14 +1438,20 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       And ("The Following counts should hold")
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='REQ_TYPE']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='2']) = 3")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 6")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 4")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']) = 3")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='2']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']/xsl:transform/@chk:mergable) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']/xsl:stylesheet) = 1")
     }
 
     scenario ("The sharedXPathWADL3 is processed checking wellformness, elemnts, and plain parameters, with remove dups and joinpath optimizations (XPath 3.1, SaxonHE)") {
@@ -1419,8 +1469,7 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       val checker = builder.build(sharedXPathWADL3, config)
       Then ("The following paths should hold")
       assert(checker,Start, URL("y"),  Method("POST"),
-             ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
+             ReqType("(application/xml)(;.*)?"), XSL,  SetHeaderAlways("Warning"), Accept)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
@@ -1432,14 +1481,20 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
 
       And ("The Following counts should hold")
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='REQ_TYPE']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='2']) = 3")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 6")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 4")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']) = 3")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='2']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']/xsl:transform/@chk:mergable) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']/xsl:stylesheet) = 1")
     }
 
     scenario ("The sharedXPathWADL3 is processed checking wellformness, elemnts, and plain parameters, with remove dups and joinpath optimizations (preserve request body)") {
@@ -1554,12 +1609,17 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       val checker = builder.build(sharedXPathWADL3, config)
       Then ("The following paths should hold")
       assert(checker,Start, URL("y"),  Method("POST"),
-             ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
+             ReqType("(application/xml)(;.*)?"), WellXML, XSL,  SetHeaderAlways("Warning"), Accept)
+
+      assert(checker,Start, URL("y"),  Method("POST"),
+             ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
              XPath("/foo:bar/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
+
+      assert(checker,Start, URL("x"),  Method("POST"),
+             ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:foo"),
@@ -1569,12 +1629,18 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
       assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 2")
       assert (checker, "count(/chk:checker/chk:step[@type='REQ_TYPE']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='2']) = 3")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 6")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 4")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']) = 3")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='2']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']/xsl:transform/@chk:mergable) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']/xsl:stylesheet) = 1")
     }
 
     scenario ("The sharedXPathWADL3 is processed checking wellformness, elemnts, and plain parameters, with remove dups and joinpath optimizations (preserve request body, SaxonHE, XPath 3.1)") {
@@ -1592,12 +1658,17 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       val checker = builder.build(sharedXPathWADL3, config)
       Then ("The following paths should hold")
       assert(checker,Start, URL("y"),  Method("POST"),
-             ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
-             XPath("/foo:bar/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
+             ReqType("(application/xml)(;.*)?"), WellXML, XSL,  SetHeaderAlways("Warning"), Accept)
+
+      assert(checker,Start, URL("y"),  Method("POST"),
+             ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:bar"),
              XPath("/foo:bar/@junk"), XSL,  SetHeaderAlways("Warning"), Accept)
+
+      assert(checker,Start, URL("x"),  Method("POST"),
+             ReqType("(application/xml)(;.*)?"), WellXML, ContentFail)
 
       assert(checker,Start, URL("x"),  Method("POST"),
              ReqType("(application/xml)(;.*)?"), WellXML, XPath("/foo:foo"),
@@ -1607,12 +1678,18 @@ class WADLCheckerOptSpec extends BaseCheckerSpec {
       assert (checker, "count(/chk:checker/chk:step[@type='METHOD' and @match='POST']) = 2")
       assert (checker, "count(/chk:checker/chk:step[@type='WELL_XML']) = 2")
       assert (checker, "count(/chk:checker/chk:step[@type='REQ_TYPE']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='2']) = 3")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 6")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar']) = 2")
-      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 4")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:bar/@junk']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo']) = 1")
       assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @match='/foo:foo/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']) = 3")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='2']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL' and @version='3']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']//xsl:when[@test='/foo:bar/@junk']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']/xsl:transform/@chk:mergable) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']/xsl:stylesheet) = 1")
     }
   }
 }

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerSpec.scala
@@ -1668,16 +1668,15 @@ class WADLCheckerSpec extends BaseCheckerSpec with LogAssertions {
       assert (checker, "count(/chk:checker/chk:step[@type='URL']) = 7")
       And("A single URLXSD node")
       assert (checker, "count(/chk:checker/chk:step[@type='URLXSD']) = 1")
-      assert (checker, "count(/chk:checker/chk:step[@type='URLXSD' and @label='yn']) = 1")
       And ("The checker should contain a GET method")
       assert (checker, "/chk:checker/chk:step[@type='METHOD' and @match='GET']")
       And ("The path from the start should contain all URL and URLXSD nodes")
       And ("it should end in the GET method node")
-      assert (checker, Start, URL("path"), URL("to"), URL("my"), URL("resource"), Label("yn"), Method("GET"))
+      assert (checker, Start, URL("path"), URL("to"), URL("my"), URL("resource"), URLXSD("tst:yesno"), Method("GET"))
       And ("The URLXSD should match a valid QName")
-      assert (checker, "namespace-uri-from-QName(resolve-QName(//chk:step[@label='yn'][1]/@match, //chk:step[@label='yn'][1])) "+
+      assert (checker, "namespace-uri-from-QName(resolve-QName(//chk:step[@type='URLXSD'][1]/@match, //chk:step[@type='URLXSD'][1])) "+
                                            "= 'test://schema/a'")
-      assert (checker, "local-name-from-QName(resolve-QName(//chk:step[@label='yn'][1]/@match, //chk:step[@label='yn'][1])) "+
+      assert (checker, "local-name-from-QName(resolve-QName(//chk:step[@type='URLXSD'][1]/@match, //chk:step[@type='URLXSD'][1])) "+
                                            "= 'yesno'")
       And ("There should not be a duplicate dup node")
       assert (checker, "count(//chk:step[@type='URL' and @match='dup']) = 1")
@@ -1701,8 +1700,6 @@ class WADLCheckerSpec extends BaseCheckerSpec with LogAssertions {
       assert (checker, URL("my"), MethodFail)
       assert (checker, URL("resource"), URLFail)
       assert (checker, URL("resource"), MethodFail)
-      assert (checker, Label("yn"), URLFail)
-      assert (checker, Label("yn"), MethodFail)
       And("The grammar nodes are added to the checker")
       assert (checker, "/chk:checker/chk:grammar[@ns='test://schema/a' and @href='test://app/xsd/simple.xsd' and @type='W3C_XML']")
     }


### PR DESCRIPTION
This change depends on #360 -- you should merge that first.

This is a rewrite of the join optimizations that allows them to execute more quickly.  Additionally, the XPath join optimization can now produce XSLT 3.0 code under Saxon HE since this no longer requires a license.