### PR TITLE
Fixed bug :method labels were sometimes lost with rax:roles.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,7 @@
 # Releases #
+## In Progress Work ##
+1. Fixed a bug where method labels were sometimes lost when the rax:roles was used.
+
 ## Release 2.4.1 (2017-09-01) ##
 1. Fixed a regression where the remove dups optimization was always dropping step labels.
 

--- a/core/src/main/resources/xsl/raxRoles.xsl
+++ b/core/src/main/resources/xsl/raxRoles.xsl
@@ -78,6 +78,13 @@
           <xsl:choose>
               <xsl:when test="count($allRoles) != 0">
                   <xsl:apply-templates select="@*[not(local-name() = 'id') and not(namespace-uri() = 'http://docs.rackspace.com/api')]"/>
+                  <!--
+                      The label may be based of a rax:id so make sure
+                      we copy it into a doc since we are removing rax:id.
+                  -->
+                  <xsl:if test="not(wadl:doc/@title) and @rax:id">
+                      <wadl:doc title="{@rax:id}"/>
+                  </xsl:if>
                   <xsl:if test="not(wadl:request)">
                       <wadl:request>
                           <xsl:call-template name="generateRoles">

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
@@ -166,6 +166,11 @@ class BaseCheckerSpec extends BaseWADLSpec with LazyLogging {
     stepsWithMatch (checker, methodMatch).filter(n => (n \ "@type").text == "METHOD")
   }
 
+  def stepsWithMethodLabelMatch (checker : NodeSeq, methodMatch  : String, labelMatch : String) : NodeSeq = {
+    stepsWithMatch (checker, methodMatch).filter(n => (n \ "@type").text == "METHOD").filter(n => (n \ "@label").text == labelMatch)
+  }
+
+
   def stepsWithReqTypeMatch (checker : NodeSeq, reqTypeMatch : String) : NodeSeq = {
     stepsWithMatch (checker, reqTypeMatch).filter(n => (n \ "@type").text == "REQ_TYPE")
   }
@@ -384,6 +389,7 @@ class BaseCheckerSpec extends BaseWADLSpec with LazyLogging {
   def URLXSDWithCapture(url : String, captureHeader : String) : (NodeSeq) => NodeSeq = stepsWithURLXSDMatchCapture(_, url, captureHeader)
   def Label(label : String) : (NodeSeq) => NodeSeq = stepsWithLabel(_, label)
   def Method(method : String) : (NodeSeq) => NodeSeq = stepsWithMethodMatch(_, method)
+  def Method(method : String, label : String) : (NodeSeq) => NodeSeq = stepsWithMethodLabelMatch(_, method, label)
   def XPath(expression : String) : (NodeSeq) => NodeSeq = stepsWithXPathMatch (_, expression)
   def XPathWithCapture(expression : String, captureHeader : String) : (NodeSeq) => NodeSeq = stepsWithXPathMatchCapture (_, expression, captureHeader)
   def XPath(expression: String, message : String) : (NodeSeq) => NodeSeq = stepsWithXPathMessageMatch(_, expression, message)


### PR DESCRIPTION
The main issue is that sometimes the method label is derived form the
method ID and by design the method ID is sometimes removed by
rax:roles.