### PR TITLE
New option to preserve method labels always.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,7 @@
 ## In Progress Work ##
 1. Fixed a bug where method labels were sometimes lost when the rax:roles was used.
 1. Clean up : better handling of error states in optimization stages.
+1. New configuration option ```preserveMethodLabels``` ensures that method labels are always kept in the state machine.
 
 ## Release 2.4.1 (2017-09-01) ##
 1. Fixed a regression where the remove dups optimization was always dropping step labels.

--- a/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
+++ b/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
@@ -87,6 +87,9 @@ object Wadl2Checker {
     val preserveRequestBody = parser.flag[Boolean] (List("b", "preserve-req-body"),
                                                     "Ensure that the request body is preserved after validating the request.")
 
+    val preserveMethodLabels = parser.flag[Boolean] (List("L", "preserve-method-labels"),
+                                                    "Ensure that method labels are always preserved.")
+
     val xsdCheck = parser.flag[Boolean] (List("x", "xsd"),
                                          "Add checks to ensure that XML validates against XSD grammar Default: false")
 
@@ -181,6 +184,7 @@ object Wadl2Checker {
         c.enableAssertExtension = !raxAssert.value.getOrElse(false)
         c.xpathVersion = xpathVersion.value.getOrElse(10)
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
+        c.preserveMethodLabels = preserveMethodLabels.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)
         c.validateChecker = !dontValidate.value.getOrElse(false)
         c.enableWarnHeaders = !warnHeaders.value.getOrElse(false)

--- a/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
+++ b/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
@@ -88,6 +88,9 @@ object Wadl2Dot {
     val preserveRequestBody = parser.flag[Boolean] (List("b", "preserve-req-body"),
                                                     "Ensure that the request body is preserved after validating the request.")
 
+    val preserveMethodLabels = parser.flag[Boolean] (List("L", "preserve-method-labels"),
+                                                    "Ensure that method labels are always preserved.")
+
     val xsdCheck = parser.flag[Boolean] (List("x", "xsd"),
                                          "Add checks to ensure that XML validates against XSD grammar Default: false")
 
@@ -188,6 +191,7 @@ object Wadl2Dot {
         c.enableAssertExtension = !raxAssert.value.getOrElse(false)
         c.xpathVersion = xpathVersion.value.getOrElse(10)
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
+        c.preserveMethodLabels = preserveMethodLabels.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)
         c.validateChecker = !dontValidate.value.getOrElse(false)
         c.enableWarnHeaders = !warnHeaders.value.getOrElse(false)

--- a/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
+++ b/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
@@ -62,6 +62,9 @@ object WadlTest {
   val preserveRequestBody = parser.flag[Boolean] (List("b", "preserve-req-body"),
                                               "Ensure that the request body is preserved after validating the request.")
 
+  val preserveMethodLabels = parser.flag[Boolean] (List("L", "preserve-method-labels"),
+                                                    "Ensure that method labels are always preserved.")
+
   val xsdCheck = parser.flag[Boolean] (List("x", "xsd"),
                                          "Add checks to ensure that XML validates against XSD grammar Default: false")
 
@@ -288,6 +291,7 @@ object WadlTest {
         c.enableAssertExtension = !raxAssert.value.getOrElse(false)
         c.xpathVersion = xpathVersion.value.getOrElse(10)
         c.preserveRequestBody = preserveRequestBody.value.getOrElse(false)
+        c.preserveMethodLabels = preserveMethodLabels.value.getOrElse(false)
         c.doXSDGrammarTransform = xsdGrammarTransform.value.getOrElse(false)
         c.validateChecker = !dontValidate.value.getOrElse(false)
         c.enableWarnHeaders = !warnHeaders.value.getOrElse(false)

--- a/core/src/main/resources/xsl/opt/commonJoin.xsl
+++ b/core/src/main/resources/xsl/opt/commonJoin.xsl
@@ -52,6 +52,18 @@
         exclude-result-prefixes="xsd check"
         version="3.0">
 
+    <xsl:param name="configMetadata" as="node()">
+        <params>
+          <meta>
+            <config option="preserveMethodLabels"
+                    value="false"/>
+          </meta>
+        </params>
+    </xsl:param>
+
+    <xsl:variable name="preserveMethodLabels" as="xsd:boolean" select="xsd:boolean(check:optionValue($configMetadata, 'preserveMethodLabels'))"/>
+
+
     <!--
         Most of the work of joining is done by the following util. The
         purpose of this template is to identify the joins and to

--- a/core/src/main/resources/xsl/opt/commonJoinTemplate.xsl
+++ b/core/src/main/resources/xsl/opt/commonJoinTemplate.xsl
@@ -60,10 +60,30 @@
                 <xslout:variable name="nextStep" as="node()*"
                     select="check:stepsByIds($checker, check:next(.))"/>
                 <xsl:for-each select="$types">
-                    <xslout:call-template name="{$pfx}{.}">
-                        <xslout:with-param name="checker" select="$checker"/>
-                        <xslout:with-param name="nextStep" select="$nextStep"/>
-                    </xslout:call-template>
+                    <xsl:choose>
+                        <xsl:when test=". = 'METHOD'">
+                            <xslout:choose>
+                                <xslout:when test="$preserveMethodLabels">
+                                    <xslout:call-template name="{$pfx}{.}L">
+                                        <xslout:with-param name="checker" select="$checker"/>
+                                        <xslout:with-param name="nextStep" select="$nextStep"/>
+                                    </xslout:call-template>
+                                </xslout:when>
+                                <xslout:otherwise>
+                                    <xslout:call-template name="{$pfx}{.}">
+                                        <xslout:with-param name="checker" select="$checker"/>
+                                        <xslout:with-param name="nextStep" select="$nextStep"/>
+                                    </xslout:call-template>
+                                </xslout:otherwise>
+                            </xslout:choose>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xslout:call-template name="{$pfx}{.}">
+                                <xslout:with-param name="checker" select="$checker"/>
+                                <xslout:with-param name="nextStep" select="$nextStep"/>
+                            </xslout:call-template>
+                        </xsl:otherwise>
+                    </xsl:choose>
                 </xsl:for-each>
             </xslout:template>
             <xsl:for-each select="$types">
@@ -79,6 +99,23 @@
                                 $r,
                         tokenize($rule/@optional, ' '), $error-sink-types)"/>
                 <xsl:variable name="match" as="xs:string?" select="$rule/@match"/>
+                <xsl:if test=". = 'METHOD'">
+                    <xslout:template name="{$pfx}{.}L">
+                        <xslout:param name="checker" as="node()"/>
+                        <xslout:param name="nextStep" as="node()*"/>
+                        <xsl:call-template name="matchJoinTemplates">
+                            <xsl:with-param name="type" select="."/>
+                            <xsl:with-param name="required"
+                                            select="
+                                                    (if (empty($required)) then
+                                                    'type'
+                                                    else
+                                                    $required,'label')"/>
+                            <xsl:with-param name="currentMatch" select="()"/>
+                            <xsl:with-param name="match" select="$match"/>
+                        </xsl:call-template>
+                    </xslout:template>
+                </xsl:if>
                 <xslout:template name="{$pfx}{.}">
                     <xslout:param name="checker" as="node()"/>
                     <xslout:param name="nextStep" as="node()*"/>

--- a/core/src/main/resources/xsl/opt/removeDups.xsl
+++ b/core/src/main/resources/xsl/opt/removeDups.xsl
@@ -57,6 +57,17 @@
 
     <xsl:output indent="yes" method="xml"/>
 
+    <xsl:param name="configMetadata" as="node()">
+        <params>
+          <meta>
+            <config option="preserveMethodLabels"
+                    value="false"/>
+          </meta>
+        </params>
+    </xsl:param>
+
+    <xsl:variable name="preserveMethodLabels" as="xsd:boolean" select="xsd:boolean(check:optionValue($configMetadata, 'preserveMethodLabels'))"/>
+
     <xsl:template match="check:checker" name="replaceAllDups">
         <xsl:param name="checker" select="." as="node()"/>
         <xsl:variable name="dups" as="map(xsd:string, xsd:string*)" select="check:getDups($checker)"/>

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
@@ -320,6 +320,20 @@ class Config extends LazyLogging {
   @AffectsChecker
   var enableAssertExtension : Boolean = true
 
+
+  //
+  // Ensure that method labels are always preserved in the state
+  // machine, even at the cost of having a more complex machine.  If
+  // the value is set to false then method labels may be dropped by
+  // optimization stages in order to consolidate steps.
+  //
+  // Method labels are typically needed for reporting and debugging
+  // purposes, they have no effect on validation.
+  //
+  @BeanProperty
+  @AffectsChecker
+  var preserveMethodLabels : Boolean = false
+
   //
   //  The XSL engine to use.  Possible choices are Xalan, XalanC,
   //  SaxonHE and SaxonEE. SaxonEE requires a Saxon License.

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerBuilder.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerBuilder.scala
@@ -470,8 +470,9 @@ class WADLCheckerBuilder(protected[wadl] var wadl : WADLNormalizer) extends Lazy
   //
   private def joinOptSetup(in : Source, c : Config) : Source = timeFunction("joinOptSetup", {
     if (c.removeDups || c.joinXPathChecks) {
+      val builder = processor.newDocumentBuilder
       val removeErrorStatesTransform = getXsltTransformer(removeErrorStatesXsltExec)
-      val joinTransform = getXsltTransformer(joinSetupXsltExec)
+      val joinTransform = getXsltTransformer(joinSetupXsltExec, Map(new QName(CONFIG_METADATA) -> builder.build(new StreamSource(c.checkerMetaElem))))
       val out = new XdmDestination
       removeErrorStatesTransform.setSource(in)
       removeErrorStatesTransform.setDestination(joinTransform)
@@ -508,7 +509,8 @@ class WADLCheckerBuilder(protected[wadl] var wadl : WADLNormalizer) extends Lazy
   //
   private def joinOpt(in : Source, c : Config) : Source = timeFunction("joinOpt", {
     if (c.removeDups || c.joinXPathChecks) {
-      val joinTransform = getXsltTransformer(joinXsltExec)
+      val builder = processor.newDocumentBuilder
+      val joinTransform = getXsltTransformer(joinXsltExec, Map(new QName(CONFIG_METADATA) -> builder.build(new StreamSource(c.checkerMetaElem))))
       val out = new XdmDestination
       joinTransform.setSource(in)
       joinTransform.setDestination(out)
@@ -524,7 +526,8 @@ class WADLCheckerBuilder(protected[wadl] var wadl : WADLNormalizer) extends Lazy
   //
   private def dupsOpt(in : Source, c : Config) : Source = timeFunction("dupsOpt", {
     if (c.removeDups || c.joinXPathChecks) {
-      val dupsTransform = getXsltTransformer(dupsXsltExec)
+      val builder = processor.newDocumentBuilder
+      val dupsTransform = getXsltTransformer(dupsXsltExec, Map(new QName(CONFIG_METADATA) -> builder.build(new StreamSource(c.checkerMetaElem))))
       val out = new XdmDestination
       dupsTransform.setSource(in)
       dupsTransform.setDestination(out)

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResources.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResources.scala
@@ -24,8 +24,10 @@ import org.scalatest.junit.JUnitRunner
 class GivenAWadlWithNestedResources extends FlatSpec with RaxRolesBehaviors {
 
   val configs = Map[String, Config]("Config With Roles Enabled" -> configWithRolesEnabled,
+    "Config With Roles Enabled and Labels Preserved" -> configWithRolesEnabledAndPreservedLabels,
     "Config With Roles Enabled and Messsage Extensions Disabled" -> configWithRolesEnabledMessageExtDisabled,
     "Config With Roles Enabled and Duplications Removed" -> configWithRolesEnabledDupsRemoved,
+    "Config With Roles Enabled, Duplications Removed and Labels Preserved" -> configWithRolesEnabledDupsRemovedAndPreservedLabels,
     "Config With Roles Enabled and Header Checks Disabled" -> configWithRolesEnabledHeaderCheckDisabled,
     "Config with Roles Enabled and Default Parameters Enabled" -> configWithRaxRolesEnabledDefaultsEnabled,
     "Config with Roles Enabled, Default Parameters Enabled and Duplications Removed" -> configWithRaxRolesEnabledDupsRemovedDefaultsEnabled)

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResourcesMasked.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/GivenAWadlWithNestedResourcesMasked.scala
@@ -24,8 +24,10 @@ import org.scalatest.junit.JUnitRunner
 class GivenAWadlWithNestedResourcesMasked extends FlatSpec with RaxRolesBehaviors {
 
   val configs = Map[String, Config]("Config With Roles Enabled" -> configWithRolesMaskedEnabled,
+    "Config With Roles Enabled and Preserved Labels" -> configWithRolesMaskedEnabledAndPreservedLabels,
     "Config With Roles Enabled and Messsage Extensions Disabled" -> configWithRolesMaskedEnabledMessageExtDisabled,
     "Config With Roles Enabled and Duplications Removed" -> configWithRolesMaskedEnabledDupsRemoved,
+    "Config With Roles Enabled , Duplications Removed, and Preserved Labels" -> configWithRolesMaskedEnabledDupsRemovedAndPreservedLabels,
     "Config With Roles Enabled and Header Checks Disabled" -> configWithRolesMaskedEnabledHeaderCheckDisabled,
     "Config With Roles Enabled and Defaults Enabled" -> configWithRolesMaskedEnabledDefaultsEnabled,
     "Config With Roles Enabled and Dubplications Removed and Defaults Enabled" -> configWithRolesMaskedEnabledDupsRemovedDefaultsEnabled)

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/RaxRolesBehaviors.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/RaxRolesBehaviors.scala
@@ -32,14 +32,39 @@ trait RaxRolesBehaviors {
   def configWithRolesEnabled =
     TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, true)
 
+  def configWithRolesEnabledAndPreservedLabels = { 
+    val tc = TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, true)
+    tc.preserveMethodLabels = true
+    tc
+  }
+
   def configWithRolesEnabledDupsRemoved =
     TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, true)
+
+  def configWithRolesEnabledDupsRemovedAndPreservedLabels = {
+    val tc = TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, true)
+    tc.preserveMethodLabels = true
+    tc
+  }
 
   def configWithRolesMaskedEnabled =
     TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, false, true, true)
 
+  def configWithRolesMaskedEnabledAndPreservedLabels = {
+    val tc = TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, false, true, true)
+    tc.preserveMethodLabels = true
+    tc
+  }
+
   def configWithRolesMaskedEnabledDupsRemoved =
     TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, false, true, true)
+
+  def configWithRolesMaskedEnabledDupsRemovedAndPreservedLabels = {
+    val tc = TestConfig(true, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, true, false, true, true)
+    tc.preserveMethodLabels = true
+    tc
+  }
+
 
   def configWithRolesDisabledMaskedEnabled =
     TestConfig(false, false, true, true, true, 1, true, true, true, "XalanC", true, true, true, true, false, false, false, false, true, true)

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLAssertSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLAssertSuite.scala
@@ -70,6 +70,20 @@ class ValidatorWADLAssertSuite extends BaseValidatorSuite {
   }
 
 
+  val baseWithAssertRemoveDupsMethodLabels = {
+    val c = TestConfig()
+    c.xpathVersion = 31
+    c.removeDups = true
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.preserveMethodLabels = true
+    c
+  }
+
+
   val baseWithAssertParamDefaults = {
     val c = TestConfig()
     c.removeDups = false
@@ -91,6 +105,20 @@ class ValidatorWADLAssertSuite extends BaseValidatorSuite {
     c.setParamDefaults = true
     c.checkHeaders = true
     c.enableAssertExtension = true
+    c
+  }
+
+
+  val baseWithAssertParamDefaultsRemoveDupsMethodLabels = {
+    val c = TestConfig()
+    c.removeDups = true
+    c.checkWellFormed = false
+    c.checkPlainParams = false
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = true
+    c.checkHeaders = true
+    c.enableAssertExtension = true
+    c.preserveMethodLabels = true
     c
   }
 
@@ -120,6 +148,20 @@ class ValidatorWADLAssertSuite extends BaseValidatorSuite {
     c
   }
 
+  val baseAssertWithJoinXPathsMethodLabels = {
+    val c = TestConfig()
+    c.removeDups = false
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.checkElements = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.preserveMethodLabels = true
+    c
+  }
+
   val baseAssertWithJoinXPathsAndRemoveDups = {
     val c = TestConfig()
     c.removeDups = true
@@ -130,6 +172,20 @@ class ValidatorWADLAssertSuite extends BaseValidatorSuite {
     c.enableCaptureHeaderExtension = false
     c.setParamDefaults = false
     c.enableAssertExtension = true
+    c
+  }
+
+  val baseAssertWithJoinXPathsAndRemoveDupsMethodLabels = {
+    val c = TestConfig()
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.checkElements = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.preserveMethodLabels = true
     c
   }
 
@@ -163,6 +219,21 @@ class ValidatorWADLAssertSuite extends BaseValidatorSuite {
     c
   }
 
+  val baseWithRemoveDupsRaxRolesMethodLabels = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.removeDups = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c.preserveMethodLabels = true
+    c
+  }
+
+
   val baseWithJoinXPathsRaxRoles = {
     val c = TestConfig()
     c.enableRaxRolesExtension = true
@@ -188,6 +259,21 @@ class ValidatorWADLAssertSuite extends BaseValidatorSuite {
     c.setParamDefaults = false
     c.enableAssertExtension = true
     c.checkElements = true
+    c
+  }
+
+  val baseWithJoinXPathsAndRemoveDupsRaxRolesMethodLabels = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c.preserveMethodLabels = true
     c
   }
 
@@ -223,6 +309,22 @@ class ValidatorWADLAssertSuite extends BaseValidatorSuite {
     c
   }
 
+  val baseWithRemoveDupsRaxRolesMaskMethodLabels = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c.removeDups = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c.preserveMethodLabels = true
+    c
+  }
+
+
   val baseWithJoinXPathsRaxRolesMask = {
     val c = TestConfig()
     c.enableRaxRolesExtension = true
@@ -252,6 +354,23 @@ class ValidatorWADLAssertSuite extends BaseValidatorSuite {
     c.checkElements = true
     c
   }
+
+  val baseWithJoinXPathsAndRemoveDupsRaxRolesMaskMethodLabels = {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c.checkWellFormed = true
+    c.checkPlainParams = true
+    c.enableCaptureHeaderExtension = false
+    c.setParamDefaults = false
+    c.enableAssertExtension = true
+    c.checkElements = true
+    c.preserveMethodLabels = true
+    c
+  }
+
 
 val WADL_withAsserts = <application xmlns="http://wadl.dev.java.net/2009/02"
              xmlns:rax="http://docs.rackspace.com/api"
@@ -450,24 +569,34 @@ val WADL_withAsserts2 = <application xmlns="http://wadl.dev.java.net/2009/02"
   val assertDisabledConfigs = Map[String, Config]("base config with asserts disabled"->baseConfig)
 
   val assertEnabledConfigs  = Map[String, Config]("Config with asserts enabled"->baseWithAssert,
-                                                  "Config with asserts and remove dups"->baseWithAssertRemoveDups)
+    "Config with asserts and remove dups"->baseWithAssertRemoveDups,
+    "Config with asserts and remove dups preserve method labels "->baseWithAssertRemoveDupsMethodLabels
+  )
 
   val assertEnabledParamDefaultConfigs = Map[String, Config]("Config with asserts enabled, param defaults"->baseWithAssertParamDefaults,
-                                                             "Config with asserts enabled, param defaults and remove dups"->baseWithAssertParamDefaultsRemoveDups)
+    "Config with asserts enabled, param defaults and remove dups"->baseWithAssertParamDefaultsRemoveDups,
+    "Config with asserts enabled, param defaults and remove dups preserve method labels"->baseWithAssertParamDefaultsRemoveDupsMethodLabels
+  )
 
   val assertEnabledPlainParamConfigs = Map[String, Config]("Config with asserts enabled, plain params"->baseAssertWithPlainParams,
-                                                           "Config with asserts enabled, plain params join XPath"->baseAssertWithJoinXPaths,
-                                                           "Config with asserts enabled, plain params join XPath, remove dups"->baseAssertWithJoinXPathsAndRemoveDups)
+    "Config with asserts enabled, plain params join XPath"->baseAssertWithJoinXPaths,
+    "Config with asserts enabled, plain params join XPath, remove dups"->baseAssertWithJoinXPathsAndRemoveDups,
+    "Config with asserts enabled, plain params join XPath preserve method labels"->baseAssertWithJoinXPathsMethodLabels,
+    "Config with asserts enabled, plain params join XPath, remove dups preserve method labels"->baseAssertWithJoinXPathsAndRemoveDupsMethodLabels
+  )
 
   val assertEnabledPlainRaxRoles = Map[String, Config]("Config with asserts enabled, plain params, rax roles"->baseWithPlainParamsRaxRoles,
-                                                       "Config with asserts enabled, plain params, rax roles, remove dups"->baseWithRemoveDupsRaxRoles,
-                                                       "Config with asserts enabled, plain params, rax roles, join xpath"->baseWithJoinXPathsRaxRoles,
-                                                       "Config with asserts enabled, plain params, rax roles, remove dups, join xpath"->baseWithJoinXPathsAndRemoveDupsRaxRoles)
+    "Config with asserts enabled, plain params, rax roles, remove dups"->baseWithRemoveDupsRaxRoles,
+    "Config with asserts enabled, plain params, rax roles, remove dups method labels"->baseWithRemoveDupsRaxRolesMethodLabels,
+    "Config with asserts enabled, plain params, rax roles, join xpath"->baseWithJoinXPathsRaxRoles,
+    "Config with asserts enabled, plain params, rax roles, remove dups, join xpath"->baseWithJoinXPathsAndRemoveDupsRaxRoles,
+    "Config with asserts enabled, plain params, rax roles, remove dups, join xpath, preserve method labels"->baseWithJoinXPathsAndRemoveDupsRaxRolesMethodLabels)
 
   val assertEnabledPlainRaxRolesMask = Map[String, Config]("Config with asserts enabled, plain params, rax roles masked"->baseWithPlainParamsRaxRolesMask,
-                                                           "Config with asserts enabled, plain params, rax roles masked, remove dups"->baseWithRemoveDupsRaxRolesMask,
-                                                           "Config with asserts enabled, plain params, rax roles masked, join xpath"->baseWithJoinXPathsRaxRolesMask,
-                                                           "Config with asserts enabled, plain params, rax roles masked, remove dups, join xpath"->baseWithJoinXPathsAndRemoveDupsRaxRolesMask)
+    "Config with asserts enabled, plain params, rax roles masked, remove dups"->baseWithRemoveDupsRaxRolesMask,
+    "Config with asserts enabled, plain params, rax roles masked, remove dups, preserve method labels"->baseWithRemoveDupsRaxRolesMaskMethodLabels,
+    "Config with asserts enabled, plain params, rax roles masked, join xpath"->baseWithJoinXPathsRaxRolesMask,
+    "Config with asserts enabled, plain params, rax roles masked, remove dups, join xpath, preserve method labels"->baseWithJoinXPathsAndRemoveDupsRaxRolesMaskMethodLabels)
 
 
   //

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLOptSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLOptSuite.scala
@@ -36,6 +36,11 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
   val shardXPathNoRemoveDups = Validator(sharedXPathWADL, TestConfig(false, false, true, true, true, 1, true, true, false, "Xalan", false))
   val shardXPathNoDups = Validator(sharedXPathWADL, TestConfig(true, false, true, true, true, 1, true, true, false, "Xalan", false))
   val shardXPathNoDupsJoinXPath = Validator(sharedXPathWADL, TestConfig(true, false, true, true, true, 1, true, true, false, "Xalan", true))
+  val shardXPathNoDupsJoinXPathMethodLabels = Validator(sharedXPathWADL, {
+    val tc = TestConfig(true, false, true, true, true, 1, true, true, false, "Xalan", true)
+    tc.preserveMethodLabels = true
+    tc
+  })
 
   val good_usage16 =
 <atom:entry xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://docs.rackspace.com/usage/nova/ips" only_usage_up_down="true">
@@ -74,6 +79,11 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
     shardXPathNoDupsJoinXPath.validate(request("POST", "nova/entries", "application/atom+xml", good_rhel), response, chain)
   }
 
+  test("POST of RHEL should work on nova/entries on shardXPathNoDupsJoinXPathMethodLabels") {
+    shardXPathNoDupsJoinXPathMethodLabels.validate(request("POST", "nova/entries", "application/atom+xml", good_rhel), response, chain)
+  }
+
+
   test("POST of RHEL should work on servers/entries on shardXPathNoRemoveDups") {
     shardXPathNoRemoveDups.validate(request("POST", "servers/entries", "application/atom+xml", good_rhel), response, chain)
   }
@@ -84,6 +94,10 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
 
   test("POST of RHEL should work on servers/entries on shardXPathNoDupsJoinXPath") {
     shardXPathNoDupsJoinXPath.validate(request("POST", "servers/entries", "application/atom+xml", good_rhel), response, chain)
+  }
+
+  test("POST of RHEL should work on servers/entries on shardXPathNoDupsJoinXPathMethodLabels") {
+    shardXPathNoDupsJoinXPathMethodLabels.validate(request("POST", "servers/entries", "application/atom+xml", good_rhel), response, chain)
   }
 
   test("POST of good_usage17 should work on servers/entries on shardXPathNoRemoveDups") {
@@ -98,6 +112,10 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
     shardXPathNoDupsJoinXPath.validate(request("POST", "servers/entries", "application/atom+xml", good_usage17), response, chain)
   }
 
+  test("POST of good_usage17 should work on servers/entries on shardXPathNoDupsJoinXPathMethodLabels") {
+    shardXPathNoDupsJoinXPathMethodLabels.validate(request("POST", "servers/entries", "application/atom+xml", good_usage17), response, chain)
+  }
+
   test("POST of good_usage16 should work on nova/entries on shardXPathNoRemoveDups") {
     shardXPathNoRemoveDups.validate(request("POST", "nova/entries", "application/atom+xml", good_usage16), response, chain)
   }
@@ -108,6 +126,10 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
 
   test("POST of good_usage16 should work on nova/entries on shardXPathNoDupsJoinXPath") {
     shardXPathNoDupsJoinXPath.validate(request("POST", "nova/entries", "application/atom+xml", good_usage16), response, chain)
+  }
+
+  test("POST of good_usage16 should work on nova/entries on shardXPathNoDupsJoinXPathMethodLabels") {
+    shardXPathNoDupsJoinXPathMethodLabels.validate(request("POST", "nova/entries", "application/atom+xml", good_usage16), response, chain)
   }
 
 
@@ -126,6 +148,11 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
                                                          good_usage16), response, chain), 400)
   }
 
+  test("POST of good_usage16 on servers/entries  should fail on shardXPathNoDupsJoinXPathMethodLabels") {
+    assertResultFailed(shardXPathNoDupsJoinXPathMethodLabels.validate(request("POST", "servers/entries", "application/atom+xml",
+                                                         good_usage16), response, chain), 400)
+  }
+
   test("POST of good_usage17 on nova/entries should fail on shardXPathNoRemoveDups") {
     assertResultFailed(shardXPathNoRemoveDups.validate(request("POST", "nova/entries", "application/atom+xml",
                                                                good_usage17), response, chain), 400)
@@ -138,6 +165,11 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
 
   test("POST of good_usage17 on servers/entries  should fail on shardXPathNoDupsJoinXPath") {
     assertResultFailed(shardXPathNoDupsJoinXPath.validate(request("POST", "nova/entries", "application/atom+xml",
+                                                         good_usage17), response, chain), 400)
+  }
+
+  test("POST of good_usage17 on nova/entries  should fail on shardXPathNoDupsJoinXPathMethodLabels") {
+    assertResultFailed(shardXPathNoDupsJoinXPathMethodLabels.validate(request("POST", "nova/entries", "application/atom+xml",
                                                          good_usage17), response, chain), 400)
   }
 
@@ -157,6 +189,11 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
                                                          bad_usage), response, chain), 400)
   }
 
+  test("POST of bad_usage on nova/entries  should fail on shardXPathNoDupsJoinXPathMethodLabels") {
+    assertResultFailed(shardXPathNoDupsJoinXPathMethodLabels.validate(request("POST", "nova/entries", "application/atom+xml",
+                                                         bad_usage), response, chain), 400)
+  }
+
   test("POST of bad_usage on servers/entries should fail on shardXPathNoRemoveDups") {
     assertResultFailed(shardXPathNoRemoveDups.validate(request("POST", "servers/entries", "application/atom+xml",
                                                                bad_usage), response, chain), 400)
@@ -171,6 +208,12 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
     assertResultFailed(shardXPathNoDupsJoinXPath.validate(request("POST", "servers/entries", "application/atom+xml",
                                                          bad_usage), response, chain), 400)
   }
+
+  test("POST of bad_usage on servers/entries  should fail on shardXPathNoDupsJoinXPathMethodLabels") {
+    assertResultFailed(shardXPathNoDupsJoinXPathMethodLabels.validate(request("POST", "servers/entries", "application/atom+xml",
+                                                         bad_usage), response, chain), 400)
+  }
+
 
     val sharedXPathWADL2 =
 <application xmlns="http://wadl.dev.java.net/2009/02"
@@ -210,6 +253,11 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
   val shardXPath2NoRemoveDups = Validator(sharedXPathWADL2, TestConfig(false, false, true, true, true, 1, true, true, false, "Xalan", false))
   val shardXPath2NoDups = Validator(sharedXPathWADL2, TestConfig(true, false, true, true, true, 1, true, true, false, "Xalan", false))
   val shardXPath2NoDupsJoinXPath = Validator(sharedXPathWADL2, TestConfig(true, false, true, true, true, 1, true, true, false, "Xalan", true))
+  val shardXPath2NoDupsJoinXPathMethodLabels = Validator(sharedXPathWADL2, {
+    val tc=TestConfig(true, false, true, true, true, 1, true, true, false, "Xalan", true)
+    tc.preserveMethodLabels = true
+    tc
+  })
 
   val good_bar = <bar xmlns="http://www.rackspace.com/foo/bar" junk="true"/>
   val good_foo = <foo xmlns="http://www.rackspace.com/foo/bar" junk="true"/>
@@ -229,6 +277,10 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
     shardXPath2NoDupsJoinXPath.validate(request("POST", "y", "application/xml", good_bar), response, chain)
   }
 
+  test("POST of good_bar should work on y on shardXPath2NoDupsJoinXPathMethodLabels") {
+    shardXPath2NoDupsJoinXPathMethodLabels.validate(request("POST", "y", "application/xml", good_bar), response, chain)
+  }
+
   test("POST of good_bar should work on x on shardXPath2NoRemoveDups") {
     shardXPath2NoRemoveDups.validate(request("POST", "x", "application/xml", good_bar), response, chain)
   }
@@ -241,6 +293,10 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
     shardXPath2NoDupsJoinXPath.validate(request("POST", "x", "application/xml", good_bar), response, chain)
   }
 
+  test("POST of good_bar should work on x on shardXPath2NoDupsJoinXPathMethodLabels") {
+    shardXPath2NoDupsJoinXPathMethodLabels.validate(request("POST", "x", "application/xml", good_bar), response, chain)
+  }
+
   test("POST of good_foo should work on x on shardXPath2NoRemoveDups") {
     shardXPath2NoRemoveDups.validate(request("POST", "x", "application/xml", good_foo), response, chain)
   }
@@ -251,6 +307,10 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
 
   test("POST of good_foo should work on x on shardXPath2NoDupsJoinXPath") {
     shardXPath2NoDupsJoinXPath.validate(request("POST", "x", "application/xml", good_foo), response, chain)
+  }
+
+  test("POST of good_foo should work on x on shardXPath2NoDupsJoinXPathMethodLabels") {
+      shardXPath2NoDupsJoinXPathMethodLabels.validate(request("POST", "x", "application/xml", good_foo), response, chain)
   }
 
   test("POST of good_foo on y should fail on shardXPath2NoRemoveDups") {
@@ -268,6 +328,12 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
                                                           good_foo), response, chain), 400)
   }
 
+  test("POST of good_foo on y should fail on shardXPath2NoDupsJoinXPathMethodLabels") {
+    assertResultFailed(shardXPath2NoDupsJoinXPathMethodLabels.validate(request("POST", "y", "application/xml",
+                                                          good_foo), response, chain), 400)
+  }
+
+
   test("POST of bad_bar on y should fail on shardXPath2NoRemoveDups") {
     assertResultFailed(shardXPath2NoRemoveDups.validate(request("POST", "y", "application/xml",
                                                                 bad_bar), response, chain), 400)
@@ -280,6 +346,11 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
 
   test("POST of bad_bar on y should fail on shardXPath2NoDupsJoinXPath") {
     assertResultFailed(shardXPath2NoDupsJoinXPath.validate(request("POST", "y", "application/xml",
+                                                          bad_bar), response, chain), 400)
+  }
+
+  test("POST of bad_bar on y should fail on shardXPath2NoDupsJoinXPathMethodLabels") {
+    assertResultFailed(shardXPath2NoDupsJoinXPathMethodLabels.validate(request("POST", "y", "application/xml",
                                                           bad_bar), response, chain), 400)
   }
 
@@ -298,6 +369,12 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
                                                           bad_foo), response, chain), 400)
   }
 
+  test("POST of bad_foo on y should fail on shardXPath2NoDupsJoinXPathMethodLabels") {
+    assertResultFailed(shardXPath2NoDupsJoinXPathMethodLabels.validate(request("POST", "y", "application/xml",
+                                                          bad_foo), response, chain), 400)
+  }
+
+
   test("POST of bad_foo_bar on y should fail on shardXPath2NoRemoveDups") {
     assertResultFailed(shardXPath2NoRemoveDups.validate(request("POST", "y", "application/xml",
                                                                 bad_foo_bar), response, chain), 400)
@@ -312,6 +389,12 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
     assertResultFailed(shardXPath2NoDupsJoinXPath.validate(request("POST", "y", "application/xml",
                                                           bad_foo_bar), response, chain), 400)
   }
+
+  test("POST of bad_foo_bar on y should fail on shardXPath2NoDupsJoinXPathMethodLabels") {
+    assertResultFailed(shardXPath2NoDupsJoinXPathMethodLabels.validate(request("POST", "y", "application/xml",
+                                                          bad_foo_bar), response, chain), 400)
+  }
+
 
   test("POST of bad_bar on x should fail on shardXPath2NoRemoveDups") {
     assertResultFailed(shardXPath2NoRemoveDups.validate(request("POST", "x", "application/xml",
@@ -328,6 +411,12 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
                                                           bad_bar), response, chain), 400)
   }
 
+  test("POST of bad_bar on x should fail on shardXPath2NoDupsJoinXPathMethodLabels") {
+    assertResultFailed(shardXPath2NoDupsJoinXPathMethodLabels.validate(request("POST", "x", "application/xml",
+                                                          bad_bar), response, chain), 400)
+  }
+
+
   test("POST of bad_foo on x should fail on shardXPath2NoRemoveDups") {
     assertResultFailed(shardXPath2NoRemoveDups.validate(request("POST", "x", "application/xml",
                                                                 bad_foo), response, chain), 400)
@@ -343,6 +432,12 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
                                                           bad_foo), response, chain), 400)
   }
 
+  test("POST of bad_foo on x should fail on shardXPath2NoDupsJoinXPathMethodLabels") {
+    assertResultFailed(shardXPath2NoDupsJoinXPathMethodLabels.validate(request("POST", "x", "application/xml",
+                                                          bad_foo), response, chain), 400)
+  }
+
+
   test("POST of bad_foo_bar on x should fail on shardXPath2NoRemoveDups") {
     assertResultFailed(shardXPath2NoRemoveDups.validate(request("POST", "x", "application/xml",
                                                                 bad_foo_bar), response, chain), 400)
@@ -355,6 +450,11 @@ class ValidatorWADLOptSuite extends BaseValidatorSuite {
 
   test("POST of bad_foo_bar on x should fail on shardXPath2NoDupsJoinXPath") {
     assertResultFailed(shardXPath2NoDupsJoinXPath.validate(request("POST", "x", "application/xml",
+                                                          bad_foo_bar), response, chain), 400)
+  }
+
+  test("POST of bad_foo_bar on x should fail on shardXPath2NoDupsJoinXPathMethodLabels") {
+    assertResultFailed(shardXPath2NoDupsJoinXPathMethodLabels.validate(request("POST", "x", "application/xml",
                                                           bad_foo_bar), response, chain), 400)
   }
 }


### PR DESCRIPTION
A new configuration option preserveMethodLabels instructs api-checker
to always ensure that method labels are preserved in the state
machine.  If false, method labels may be removed to enable the
creation of smaller state machines.  The default is false.