### PR TITLE
Support sub-representations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,7 @@
 # Releases #
+## In Progress Work ##
+1. Added support for ```rax:representation```, this works like ```wadl:representation``` in that it can make assertions about XML, JSON representations. With ```rax:representation```, the representation may be embedded in another representation (JSON in XML), or in a header.
+
 ## Release 2.5.1 (2017-10-24) ##
 1. Fixed a bug where the removeDups opt sometimes created checkers with missing states.
 

--- a/TODO.org
+++ b/TODO.org
@@ -896,6 +896,94 @@
          8. [X] rax:message
          9. [X] JoinOpt
          10. [X] RemoveDups
+** DONE Compile Performance improvements
+** DONE SubRepresentations[2/2]
+   1. [X] Push Representation step [13/13]
+      1. [X] Extend XSD to support Push Rep step / Pop Rep step
+      2. [X] Config to enable / disable sub representation / should be
+         enabled by default.
+      3. [X] Updated CLIs to support sup rep extension
+      4. [X] Update Builder to support Push Rep / Pop Rep
+      5. [X] Add steps to priority map??
+      6. [X] Check assertions related to new steps.
+      7. [X] Darnit, to match up with WELL_XML and WELL_JSON -- add
+         PUSH_XML_REP and PUSH_JSON_REP.
+      8. [X] Ensure that wadl2checker correctly draws steps
+      9. [X] Ensure optimizations work with the new steps
+      10. [X] Update Servlet Request to include push/pop [3/3]
+          1. [X] PUSH_XML
+          2. [X] PUSH_JSON
+          3. [X] POP
+      11. [X] Create the new step[4/4]
+          1. [X] Pop
+          2. [X] Push_XML
+          3. [X] Push_JSON
+          4. [X] Relevant exceptions
+      12. [X] Place rax:representation outside of wadl:representation [2/2]
+          1. [X] wadl:method
+          2. [X] wadl:representation (nonXML OR nonJSON)
+      13. [X] Update handler for new steps
+   2. [X] Testing [3/3]
+      1. [X] Step [3/3]
+         1. [X] PopRep
+         2. [X] PushXML
+         3. [X] PushJSON
+      2. [X] Builder [12/12]
+         1. [X] Ensure namespaces are set correctly in
+            rax:representation.
+         2. [X] rax:rep in representation XML/JSON
+         3. [X] rax:rep in rax:rep
+         4. [X] At method level mulitple reps
+         5. [X] At resource level multiple methods
+         6. [X] At resource level mulitple methods (apply children false)
+         7. [X] At resource level mulitple methods (apply children true)
+         8. [X] At resources level
+         9. [X] At resources level with resource apply children true
+         10. [X] rax:rep in the wrong place
+         11. [X] rax:rep with wrong media type
+         12. [X] rax:rep with +json and +xml
+      3. [X] Validator [12/12]
+         1. [X] XML with JSON sub resource
+         2. [X] XML with XML sub resource
+         3. [X] JSON with JSON sub resource
+         4. [X] JSON with XML sub resource
+         5. [X] Test plain params and elements
+         6. [X] Test with XSD in sub resource
+         7. [X] Test with JSONSchema in sub resource
+         8. [X] Multiple layers of subresource [2/2]
+            1. [X] Happy
+            2. [X] Failures at multiple layers
+         9. [X] At resource level
+         10. [X] At resources level
+         11. [X] RaxRoles
+         12. [X] RaxRoles Mask
+*** Notes
+   - <rax:representation path="" mediaType="" name=""/>
+   - Works like representation but ebedded within a representation,
+     specifies XPath into the parenet representation.  Support for XML
+     and JSON.
+     - Should support all features of representation.
+     - Achive by pushing, poping representations.
+   - <rax:representation/> can be placed in places outside of a
+     representation.  It may be placed at the method level -- in place
+     of an actual representation -- when no representation is
+     available. Or at the resource or resources level.  This enables
+     parsing a representation outside of the actual body of the HTTP
+     request -- such as a header.
+** TODO Preproc extended for sub resource[0/2]
+   1. [ ] Extend Preproc to take parameters from sub resorurces if
+      AFTER_SUB is specified
+   2. [ ] Extend builder to place AFTER_SUB preprocs in the right
+      place.
+*** Notes
+   - <rax:preproc type="BEFORE_VALIDATE | AFTER_SUB"/>.  The idea is
+      that this can be used to bring back any changes in the
+      subRepresentation into the original rep?  Can we do this
+      automatically...maybe for some changes -- but it's complex so for
+      now you need preproc to compbine.
+      - AFTER_SUB gets all sub representations as parameters.  Name can
+        be used to identify them, else they are passed by number (in an
+        array? or map?)
 ** TODO Extend Support for Capture Header to support standalone element [2/2]
    1. [X] Add CaptureHeader Step [10/10]
       1. [X] Extend XSD to support New Capture Header Step
@@ -926,7 +1014,6 @@
          6. [X] Media types other than XML or JSON
 ** TODO Use Saxon Compile Lib feature to compile shared module.
    - This requires Saxon-EEQ
-** TODO Compile Performance improvements
 ** TODO Assign CONTENT_FAIL to XSL steps in builder
 ** TODO Investigate whether there is an issue with rax:roles with other headers
 ** TODO Cache checker format on load [0/3]

--- a/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
+++ b/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
@@ -69,6 +69,9 @@ object Wadl2Checker {
     val raxRoles = parser.flag[Boolean] (List("r", "rax-roles"),
                                          "Enable Rax-Roles extension. Default: false")
 
+    val raxRepresentation = parser.flag[Boolean] (List("R", "disable-rax-representation"),
+                                         "Disable Rax-Representation extension. Default: false")
+
     val raxRolesMask403 = parser.flag[Boolean] (List("M", "rax-roles-mask-403s"),
                                                 "When Rax-Roles is enable mask 403 errors with 404 or 405s. Default: false")
 
@@ -165,6 +168,7 @@ object Wadl2Checker {
 
         c.removeDups = removeDups.value.getOrElse(false)
         c.enableRaxRolesExtension = raxRoles.value.getOrElse(false)
+        c.enableRaxRepresentationExtension = !raxRepresentation.value.getOrElse(false)
         c.maskRaxRoles403 = raxRolesMask403.value.getOrElse(false)
         c.enableAuthenticatedByExtension = authenticatedBy.value.getOrElse(false)
         c.checkWellFormed = wellFormed.value.getOrElse(false)

--- a/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
+++ b/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
@@ -70,6 +70,9 @@ object Wadl2Dot {
     val raxRoles = parser.flag[Boolean] (List("r", "rax-roles"),
                                          "Enable Rax-Roles extension. Default: false")
 
+    val raxRepresentation = parser.flag[Boolean] (List("R", "disable-rax-representation"),
+                                         "Disable Rax-Representation extension. Default: false")
+
     val raxRolesMask403 = parser.flag[Boolean] (List("M", "rax-roles-mask-403s"),
                                                 "When Rax-Roles is enable mask 403 errors with 404 or 405s. Default: false")
 
@@ -172,6 +175,7 @@ object Wadl2Dot {
 
         c.removeDups = removeDups.value.getOrElse(false)
         c.enableRaxRolesExtension = raxRoles.value.getOrElse(false)
+        c.enableRaxRepresentationExtension = !raxRepresentation.value.getOrElse(false)
         c.maskRaxRoles403 = raxRolesMask403.value.getOrElse(false)
         c.enableAuthenticatedByExtension = authenticatedBy.value.getOrElse(false)
         c.checkWellFormed = wellFormed.value.getOrElse(false)

--- a/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
+++ b/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
@@ -41,6 +41,9 @@ object WadlTest {
   val removeDups = parser.flag[Boolean] (List("d", "remove-dups"),
                                          "Remove duplicate nodes. Default: false")
 
+  val raxRepresentation = parser.flag[Boolean] (List("R", "disable-rax-representation"),
+                                         "Disable Rax-Representation extension. Default: false")
+
   val raxRoles = parser.flag[Boolean] (List("r", "rax-roles"),
                                          "Enable Rax-Roles extension. Default: false")
 
@@ -272,6 +275,7 @@ object WadlTest {
 
         c.removeDups = removeDups.value.getOrElse(false)
         c.enableRaxRolesExtension = raxRoles.value.getOrElse(false)
+        c.enableRaxRepresentationExtension = !raxRepresentation.value.getOrElse(false)
         c.maskRaxRoles403 = raxRolesMask403.value.getOrElse(false)
         c.enableAuthenticatedByExtension = authenticatedBy.value.getOrElse(false)
         c.checkWellFormed = wellFormed.value.getOrElse(false)

--- a/core/src/main/resources/xsd/checker.xsd
+++ b/core/src/main/resources/xsd/checker.xsd
@@ -117,6 +117,9 @@
                 <alternative test="@type eq 'JSON_XPATH'" type="chk:JsonXPathStep"/>
                 <alternative test="@type eq 'ASSERT'" type="chk:AssertStep"/>
                 <alternative test="@type eq 'CAPTURE_HEADER'" type="chk:CaptureHeaderStep"/>
+                <alternative test="@type eq 'PUSH_XML_REP'" type="chk:PushXMLRepStep"/>
+                <alternative test="@type eq 'PUSH_JSON_REP'" type="chk:PushJSONRepStep"/>
+                <alternative test="@type eq 'POP_REP'" type="chk:PopRepStep"/>
             </element>
         </sequence>
         <assert test="if (count(chk:step[@type='START']) = 1) then true() else false()"
@@ -401,6 +404,107 @@
                 <attribute name="version" type="chk:XPathVersion" fixed="31" use="optional"/>
                 <attributeGroup ref="chk:MessageAttributes"/>
             </extension>
+        </complexContent>
+    </complexType>
+
+    <complexType name="PushXMLRepStep">
+        <annotation>
+            <documentation xmlns:html="http://www.w3.org/1999/xhtml">
+                <html:p>
+                    This step pushes a new XML representation into the
+                    representation stack.  This is used to support
+                    representations within representations. The path
+                    is an XPath in the current representation of the
+                    new path.
+                </html:p>
+                <html:p>
+                    Although the intent is to push a representation,
+                    that's found in the body of the request.  This
+                    step supports all XPath features of the AssertStep
+                    (see that step for details). This means that it is
+                    possible to examine headers, URI, the step
+                    context, etc to determine how to get the the JSON
+                    representation.
+                </html:p>
+                <html:p>
+                    As with AssertStep the XPath version is fixed to
+                    be 3.1 since it's the only version that supports
+                    JSON.
+                </html:p>
+                <html:p>
+                    The name attribute can be used as a friendly name
+                    for the representation.
+                </html:p>
+                <html:p>
+                    Since this step is not executing an assertion
+                    rax:message and rax:code extensions do not apply.
+                </html:p>
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="chk:GenContentFailStep">
+                <attribute name="path" type="xsd:string" use="required"/>
+                <attribute name="name" type="xsd:string" use="optional"/>
+                <attribute name="version" type="chk:XPathVersion" fixed="31" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+
+    <complexType name="PushJSONRepStep">
+        <annotation>
+            <documentation xmlns:html="http://www.w3.org/1999/xhtml">
+                <html:p>
+                    This step pushes a new JSON representation into the
+                    representation stack.  This is used to support
+                    representations within representations. The path
+                    is an XPath in the current representation of the
+                    new path.
+                </html:p>
+                <html:p>
+                    Although the intent is to push a representation,
+                    that's found in the body of the request.  This
+                    step supports all XPath features of the AssertStep
+                    (see that step for details). This means that it is
+                    possible to examine headers, URI, the step
+                    context, etc to determine how to get the the JSON
+                    representation.
+                </html:p>
+                <html:p>
+                    As with AssertStep the XPath version is fixed to
+                    be 3.1 since it's the only version that supports
+                    JSON.
+                </html:p>
+                <html:p>
+                    The name attribute can be used as a friendly name
+                    for the representation.
+                </html:p>
+                <html:p>
+                    Since this step is not executing an assertion
+                    rax:message and rax:code extensions do not apply.
+                </html:p>
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="chk:GenContentFailStep">
+                <attribute name="path" type="xsd:string" use="required"/>
+                <attribute name="name" type="xsd:string" use="optional"/>
+                <attribute name="version" type="chk:XPathVersion" fixed="31" use="optional"/>
+            </extension>
+        </complexContent>
+    </complexType>
+
+    <complexType name="PopRepStep">
+        <annotation>
+            <documentation xmlns:html="http://www.w3.org/1999/xhtml">
+                <html:p>
+                    This step pops a representation out of the
+                    representation stack.  This is used to support
+                    representations within representations.
+                </html:p>
+            </documentation>
+        </annotation>
+        <complexContent>
+            <extension base="chk:ConnectedStep"/>
         </complexContent>
     </complexType>
 
@@ -959,6 +1063,9 @@
             <enumeration value="JSON_XPATH" />
             <enumeration value="ASSERT"/>
             <enumeration value="CAPTURE_HEADER"/>
+            <enumeration value="PUSH_XML_REP"/>
+            <enumeration value="PUSH_JSON_REP"/>
+            <enumeration value="POP_REP"/>
         </restriction>
     </simpleType>
 

--- a/core/src/main/resources/xsl/checker2dot.xsl
+++ b/core/src/main/resources/xsl/checker2dot.xsl
@@ -24,7 +24,7 @@
     xmlns="http://www.rackspace.com/repose/wadl/checker"
     xmlns:check="http://www.rackspace.com/repose/wadl/checker"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-    version="2.0">
+    version="3.0">
      
    <xsl:output method="text"/>
    <xsl:param name="ignoreSinks" select="true()" as="xsd:boolean"/>
@@ -145,7 +145,7 @@
                                        <xsl:when test="$label = 'ε'">
                                            <xsl:value-of select="$label"/>
                                        </xsl:when>
-                                       <xsl:when test="$nextStep/@type = 'ACCEPT'">
+                                       <xsl:when test="$nextStep/@type = ('ACCEPT', 'POP_REP')">
                                            <xsl:value-of select="'ε'"/>
                                        </xsl:when>
                                        <xsl:otherwise>
@@ -213,6 +213,9 @@
              <xsl:otherwise>
                  <xsl:value-of select="concat(@id,'[')"/>
                  <xsl:value-of select="'label=&quot;'"/>
+                 <xsl:if test="@type = ('PUSH_XML_REP','PUSH_JSON_REP') and not($nfaMode)">
+                     <xsl:value-of select="@type || '\n'"/>
+                 </xsl:if>
                  <xsl:choose>
                      <xsl:when test="$nfaMode">
                          <xsl:value-of select="@id"/>
@@ -228,6 +231,9 @@
                      </xsl:when>
                      <xsl:when test="@name and @path">
                          <xsl:value-of select="concat(@name,':&#x2190; ',check:escapeRegex(@path))"/>
+                     </xsl:when>
+                     <xsl:when test="@path">
+                         <xsl:value-of select="check:escapeRegex(@path)"/>
                      </xsl:when>
                      <xsl:when test="@match or @matchRegEx">
                          <xsl:value-of select="check:matchValue(.)"/>

--- a/core/src/main/resources/xsl/opt/removeDups-rules.xml
+++ b/core/src/main/resources/xsl/opt/removeDups-rules.xml
@@ -42,6 +42,9 @@
     <rule types="CAPTURE_HEADER" required="next name path" optional="version">
         Rule for the capture header extension.
     </rule>
+    <rule types="PUSH_XML_REP PUSH_JSON_REP" required="next path" optional="name version">
+        Rule for PUSH steps.
+    </rule>
     <rule types="HEADER HEADERXSD HEADER_ANY HEADERXSD_ANY HEADER_SINGLE HEADERXSD_SINGLE" required="next name match" optional="captureHeader code message">
         Rule for Header, HeaderXSD, HeaderAny.
     </rule>
@@ -67,7 +70,7 @@
     <rule types="XSL" required="next href version" match="@href">
         We only merge XSLs with href.
     </rule>
-    <rule types="WELL_XML WELL_JSON JSON_SCHEMA" required="next">
+    <rule types="WELL_XML WELL_JSON JSON_SCHEMA POP_REP" required="next">
         Connected nodes with no match.
     </rule>
     <rule types="CONTENT_FAIL">

--- a/core/src/main/resources/xsl/priority-map.xml
+++ b/core/src/main/resources/xsl/priority-map.xml
@@ -42,6 +42,8 @@
     <map type="REQ_TYPE_FAIL" priority="45000"/>
     <map type="WELL_XML"      priority="50000"/>
     <map type="WELL_JSON"     priority="50000"/>
+    <map type="PUSH_XML_REP"  priority="50000"/>
+    <map type="PUSH_JSON_REP" priority="50000"/>
     <map type="XPATH"         priority="50000"/>
     <map type="JSON_XPATH"    priority="50000"/>
     <map type="XSL"           priority="50000"/>

--- a/core/src/main/resources/xsl/raxGlobalExtn.xsl
+++ b/core/src/main/resources/xsl/raxGlobalExtn.xsl
@@ -3,9 +3,9 @@
   raxGlobalExtn.xsl
 
   The builder.xsl expects certain global extension elements
-  (rax:assert, rax:captureHeader) to live at the method
-  request or representation level.  But these elements are allowed to
-  appear at the resources and resource level.
+  (rax:assert, rax:captureHeader, rax:representation) to live at the
+  method request or representation level.  But these elements are
+  allowed to appear at the resources and resource level.
 
   Additionally there is a @applyToChildren attribute that is applicable
   to these elements at the resource level that specifies that the feature
@@ -34,9 +34,9 @@
   limitations under the License.
 -->
 <!DOCTYPE stylesheet [
-  <!ENTITY extnsMatch "rax:assert|rax:captureHeader">
+  <!ENTITY extnsMatch "rax:assert|rax:captureHeader|rax:representation">
   <!ENTITY extns "(&extnsMatch;)">
-  <!ENTITY extnsNames "rax:assert and rax:captureHader">
+  <!ENTITY extnsNames "rax:assert, rax:captureHader, and rax:representation">
 ]>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
@@ -44,7 +44,7 @@
     xmlns="http://wadl.dev.java.net/2009/02"
     xmlns:wadl="http://wadl.dev.java.net/2009/02"
     exclude-result-prefixes="wadl"
-    version="2.0">
+    version="3.0">
 
     <xsl:output method="xml" indent="yes"/>
 
@@ -156,6 +156,22 @@
                     </xsl:when>
                     <xsl:when test="(local-name($parent) = 'representation') and (local-name($grandparent) = 'request')
                                     and (namespace-uri($grandparent) = 'http://wadl.dev.java.net/2009/02')">
+                        <xsl:call-template name="copy"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:call-template name="badPlacement"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:when>
+            <xsl:when test="namespace-uri($parent) = 'http://docs.rackspace.com/api'">
+                <!--
+                    Special case: rax:representation is allowed to be
+                    recursive. You can put a rax:representation inside
+                    a rax:representation, so in this case we copy it
+                    over.
+                 -->
+                <xsl:choose>
+                    <xsl:when test="(local-name($parent) = 'representation') and (local-name(.) = 'representation')">
                         <xsl:call-template name="copy"/>
                     </xsl:when>
                     <xsl:otherwise>

--- a/core/src/main/resources/xsl/util/funs.xsl
+++ b/core/src/main/resources/xsl/util/funs.xsl
@@ -64,7 +64,8 @@
                                                                    'XPATH', 'XSL', 'HEADER',
                                                                    'HEADERXSD', 'HEADER_ANY', 'HEADERXSD_ANY',
                                                                    'HEADER_SINGLE', 'HEADERXSD_SINGLE', 'HEADER_ALL',
-                                                                   'JSON_SCHEMA', 'JSON_XPATH', 'ASSERT')"/>
+                                                                   'JSON_SCHEMA', 'JSON_XPATH', 'ASSERT','PUSH_XML_REP',
+                                                                   'PUSH_JSON_REP')"/>
 
     <!-- Useful matches -->
     <xsl:variable name="matchAll" select="'(?s).*'"/>

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
@@ -255,6 +255,42 @@ class Config extends LazyLogging {
   var enableRaxRolesExtension : Boolean = false
 
   //
+  //  Enable the rax-representation extension.
+  //
+  //  The extension is intended to validate representations that are
+  //  not in the usual area.  For example representations within
+  //  representations.  For example, JSON content inside XML content
+  //  or vice versa.  A <rax:representation/> works like a
+  //  <wadl:representation> except for 3 major differences:
+  //
+  //
+  //  1. A rax:representation contains an XPath that is expected to
+  //  return a string containing the representation.  Usually this
+  //  XPath points to the parent representation. In XML, the parent
+  //  body is placed in the local contex but can also be accessed via
+  //  the $_ or $body variable.
+  //
+  //  2. In addition to looking at the body a rax:representation may
+  //  look at the uri ($req:uri), method ($req:method), and headers
+  //  (with a call to req:header or req:headers).  The extension may
+  //  be placed in a wadl:method/wadl:request,
+  //  wadl:method/wadl:request/wadl:representation or in another
+  //  rax:representation.  The extension may also be placed in
+  //  wadl:resources where it applies to all methods globally or on
+  //  wadl:resource which applies to all methods of that resource and
+  //  if @applyToChildren is set to true then it will also apply to
+  //  all subresources as well.
+  //
+  //  Note that having the extension on a wadl:representation will
+  //  enable wellformed checks.
+  //
+  //  3. A rax:representation has an optional name.
+  //
+  @BeanProperty
+  @AffectsChecker
+  var enableRaxRepresentationExtension : Boolean = true
+
+  //
   //  Mask rax-roles with 404 and 405 errors. By default rax-roles
   //  response with a 403 if there is a role mismatch, if
   //  maskRaxRoles403 is true then the respose will be 404 if no

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/ParsedJSON.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/ParsedJSON.scala
@@ -1,0 +1,28 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.servlet
+
+import javax.servlet.http.HttpServletRequest
+
+import com.rackspace.com.papi.components.checker.servlet.RequestAttributes._
+
+import com.fasterxml.jackson.databind.JsonNode
+
+class ParsedJSON(val representation : JsonNode) extends ParsedRepresentation {
+  type R = JsonNode
+  override val parameters = List(PARSED_JSON)
+  override val sideEffectParams = List(PARSED_JSON_SEQUENCE, PARSED_JSON_XDM_VALUE)
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/ParsedNIL.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/ParsedNIL.scala
@@ -1,0 +1,33 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.servlet
+
+import javax.servlet.http.HttpServletRequest
+
+import com.rackspace.com.papi.components.checker.servlet.RequestAttributes._
+import org.w3c.dom.Document
+
+//
+//  This is an empty representation. It essentially represents the
+//  fact that a parsed representation does not exist.
+//
+
+object ParsedNIL extends ParsedRepresentation {
+  type R = Any
+  override val representation = null
+  override val parameters = List()
+  override val sideEffectParams = List()
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/ParsedRepresentation.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/ParsedRepresentation.scala
@@ -1,0 +1,35 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.servlet
+
+import javax.servlet.http.HttpServletRequest
+
+abstract class ParsedRepresentation {
+  type R
+
+  val representation : R
+  val parameters : List[String]
+  val sideEffectParams : List[String]
+
+  def setRepresentation (req : HttpServletRequest) : Unit = {
+    parameters.foreach (req.setAttribute(_,representation))
+  }
+
+  def clearRepresentation(req : HttpServletRequest) : Unit = {
+    (parameters ::: sideEffectParams).foreach (req.setAttribute(_,null))
+  }
+
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/ParsedXML.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/ParsedXML.scala
@@ -1,0 +1,27 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.servlet
+
+import javax.servlet.http.HttpServletRequest
+
+import com.rackspace.com.papi.components.checker.servlet.RequestAttributes._
+import org.w3c.dom.Document
+
+class ParsedXML(val representation : Document)  extends ParsedRepresentation {
+  type R = Document
+  override val parameters = List(PARSED_XML)
+  override val sideEffectParams = List(PARSED_XML_SOURCE)
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/RequestAttributes.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/RequestAttributes.scala
@@ -19,6 +19,7 @@ package com.rackspace.com.papi.components.checker.servlet
 //  Request Keys
 //
 object RequestAttributes {
+  val PARSED_REPRESENTATION = "com.rackspace.com.papi.components.checker.servlet.ParsedRepresentation"
   val PARSED_XML    = "com.rackspace.com.papi.components.checker.servlet.ParsedXML"
   val PARSED_XML_SOURCE = "com.rackspace.com.papi.components.checker.servlet.ParsedXMLSource"
   val PARSED_JSON   = "com.rackspace.com.papi.components.checker.servlet.ParsedJSONTokens"

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/PopRep.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/PopRep.scala
@@ -1,0 +1,36 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.step
+
+import javax.servlet.FilterChain
+
+import com.rackspace.com.papi.components.checker.servlet.{CheckerServletRequest, CheckerServletResponse}
+import com.rackspace.com.papi.components.checker.step.base.{ConnectedStep, Step, StepContext}
+
+
+class PopRep(id : String, label : String, next : Array[Step])
+    extends ConnectedStep(id, label, next) {
+
+  override def checkStep(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, context : StepContext) : Option[StepContext] = {
+    //
+    //  We simply pop the representation in this step.  No questions
+    //  asked.  If the repstack is empty a ValidatorException will
+    //  eventually be thrown.
+    //
+    req.popRepresentation
+    Some(context)
+  }
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/PushJSON.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/PushJSON.scala
@@ -1,0 +1,52 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.step
+
+import javax.servlet.FilterChain
+
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+
+import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.step.base.{Step, PushRepresentation, RepresentationException}
+import com.rackspace.com.papi.components.checker.util.ImmutableNamespaceContext
+import com.rackspace.com.papi.components.checker.util.ObjectMapperPool.{borrowParser, returnParser}
+
+
+
+class PushJSON(id : String, label : String, name : String, expression : String,
+               nc : ImmutableNamespaceContext, version : Int, priority : Long,
+               next : Array[Step]) extends
+    PushRepresentation (id, label, name, expression, nc, version, priority, true, "JSON", next) {
+
+  override def pushRepresentation(req : CheckerServletRequest, rep : String) : Unit = {
+    var parser : ObjectMapper = null
+    try {
+      parser = borrowParser
+      val jnode = parser.readTree(rep)
+      //
+      //  Doc says that parser will return null on empty JSON. In
+      //  theory, we should never get to this code path on empty JSON,
+      //  but just in case...
+      //
+      if (jnode == null) {
+        throw new RepresentationException(s"Expecting $repCommonName at $expression but got an empty string.")
+      }
+      req.pushRepresentation(jnode)
+    } finally {
+      if (parser != null) returnParser(parser)
+    }
+  }
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/PushXML.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/PushXML.scala
@@ -1,0 +1,48 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.step
+
+import java.io.ByteArrayInputStream
+
+import java.nio.charset.StandardCharsets
+
+import javax.servlet.FilterChain
+import javax.xml.parsers.DocumentBuilder
+
+import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.step.base.{Step, PushRepresentation}
+import com.rackspace.com.papi.components.checker.util.XMLParserPool.{borrowParser, returnParser}
+import com.rackspace.com.papi.components.checker.util.ImmutableNamespaceContext
+
+class PushXML(id : String, label : String, name : String, expression : String,
+              nc : ImmutableNamespaceContext, version : Int, priority : Long,
+              next : Array[Step]) extends
+    PushRepresentation (id, label, name, expression, nc, version, priority, false, "XML", next) {
+
+  override def pushRepresentation(req : CheckerServletRequest, rep : String) : Unit = {
+    var parser : DocumentBuilder = null
+    val capture = new ErrorCapture
+
+    try {
+      parser = borrowParser
+      parser.setErrorHandler(capture)
+      req.pushRepresentation(parser.parse(new ByteArrayInputStream(rep.getBytes(StandardCharsets.UTF_8.name))))
+    } finally {
+      if (parser != null) returnParser(parser)
+    }
+  }
+
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/base/IllegalStateException.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/base/IllegalStateException.scala
@@ -1,0 +1,19 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.step.base
+
+
+class IllegalStateException(message : String) extends Exception(message)

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/base/PushRepresentation.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/base/PushRepresentation.scala
@@ -1,0 +1,175 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.step.base
+
+
+import java.io.ByteArrayInputStream
+
+import java.nio.charset.StandardCharsets
+
+import javax.servlet.FilterChain
+
+import com.rackspace.com.papi.components.checker.Config
+import com.rackspace.com.papi.components.checker.step.XPathStepUtil
+import com.rackspace.com.papi.components.checker.step.results.{MismatchResult, MultiFailResult, Result}
+import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.util.ImmutableNamespaceContext
+import com.rackspace.com.papi.components.checker.util.XQueryEvaluatorPool._
+
+import net.sf.saxon.s9api.XQueryEvaluator
+
+import net.sf.saxon.value.AtomicValue
+import net.sf.saxon.value.StringValue
+
+import net.sf.saxon.om.Function
+
+import com.typesafe.scalalogging.slf4j.LazyLogging
+
+abstract class PushRepresentation(id : String, label : String, val name : String, val expression : String,
+                                  val nc : ImmutableNamespaceContext, val version : Int, val priority : Long,
+                                  val allowAllAtomic : Boolean, val repCommonName : String, next : Array[Step])
+    extends ConnectedStep(id, label, next) with LazyLogging {
+
+  override val mismatchMessage : String = s"Could not find well formed $repCommonName at $expression"
+
+  private val exec = XPathStepUtil.xqueryExecutableForExpression(expression, nc)
+
+  //
+  //  The function should push the representation given in the current
+  //  string into the CheckerServletRequest.
+  //
+  //
+  def pushRepresentation(req : CheckerServletRequest, rep : String) : Unit
+
+  override def checkStep(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, context : StepContext) : Option[StepContext] = {
+
+    var ret : Option[StepContext] = None
+    var eval : XQueryEvaluator = null
+
+    try {
+      eval = borrowEvaluator(expression, exec)
+      XPathStepUtil.setupXQueryEvaluator(eval, req, context)
+      val res = eval.evaluate
+      //
+      // Check the size of the result
+      //
+      res.size match {
+        case 0 => throw new RepresentationException(s"Expecting $repCommonName at $expression, but got an empty sequence")
+        case 1 => // This is what we want, a single result
+        case _ => throw new RepresentationException(s"Expecting $repCommonName at $expression, but got a sequence of size > 1")
+      }
+
+      //
+      //  We always expect the result to be a string, we do a bit of
+      //  error checking based on the type of the result to avoid
+      //  trying to call the parser unnecessarily and avoid weird
+      //  parse errors.
+      //
+      //  An open question is whether atomic types outside of a string
+      //  can be parsed (int, dateTime, URLs). For representations
+      //  like XML the answer is no, for JSON the answer is yes.
+      //
+      val item = res.getUnderlyingValue.head
+      item match {
+        case sv : StringValue =>
+          //
+          //  A string atomic type, may always be a representation so
+          //  we'll accept that.
+          //
+        case av : AtomicValue if (!allowAllAtomic) =>
+          //
+          //  An atomic type other that a string should fail, if other
+          //  atomic representations are not allowed.
+          //
+          val strValue = av.toString
+          throw new RepresentationException(s"The atomic value '$strValue' cannot be converted into $repCommonName at $expression")
+        case fun : Function =>
+          val itemDesc = fun match {
+            case f if (fun.isArray) => "An array"
+            case f if (fun.isMap) => "A map"
+            case _ => "A Function"
+          }
+          throw new RepresentationException(s"$itemDesc cannot be converted into $repCommonName at $expression")
+        case _ =>
+          //
+          //  Other types (such as nodes) will be treated as strings,
+          //  by getting their string values.
+          //
+      }
+
+      val stringResult = res.itemAt(0).getStringValue
+
+      //
+      //  We can't parse empty strings so don't try...
+      //
+      if (stringResult.trim == "") {
+        throw new RepresentationException (s"Expecting $repCommonName at $expression, but got an empty string")
+      }
+
+      //
+      //  Attempt to parse the string and push the representation
+      //
+      pushRepresentation(req, stringResult)
+      ret = Some(context)
+    } catch {
+      case e : Exception => req.contentError = e
+                            req.contentErrorPriority = priority
+    }
+    finally {
+      returnEvaluator (expression, eval)
+    }
+    ret
+  }
+
+  override def check(req : CheckerServletRequest,
+                     resp : CheckerServletResponse,
+                     chain : FilterChain,
+                     context : StepContext) : Option[Result] = {
+
+    var result : Option[Result] = None
+    val nextContext = checkStep(req, resp, chain, context)
+
+    if (nextContext.isDefined) {
+      //
+      //  if we succeeded the representation in the request should be
+      //  the one we set!
+      //
+      val setRep = req.parsedRepresentation
+      val results : Array[Result] =
+          nextStep (req, resp, chain, nextContext.get.handler.map{ handler => handler.inStep(this, req, resp, nextContext.get) }.getOrElse(nextContext.get))
+      if (results.length == 1) {
+        results(0).addStepId(id)
+        result = Some(results(0))
+      } else {
+        result = Some(new MultiFailResult (results, id))
+      }
+
+      //
+      // If there is an error associated with my particular
+      // representation, then we need to POP the representation out.
+      //
+      if (!result.get.valid && (setRep == req.parsedRepresentation)) {
+        req.popRepresentation
+      }
+
+    } else {
+      result = Some( new MismatchResult( mismatchMessage, context, id) )
+    }
+
+    result
+  }
+
+}

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/base/RepresentationException.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/base/RepresentationException.scala
@@ -1,0 +1,21 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.step.base
+
+
+import java.io.IOException
+
+class RepresentationException(message : String) extends IOException(message)

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/BaseValidatorSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/BaseValidatorSuite.scala
@@ -24,6 +24,8 @@ import javax.xml.parsers.DocumentBuilder
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.rackspace.com.papi.components.checker.servlet.ByteArrayServletInputStream
 import com.rackspace.com.papi.components.checker.servlet.RequestAttributes._
+import com.rackspace.com.papi.components.checker.servlet.ParsedXML
+import com.rackspace.com.papi.components.checker.servlet.ParsedJSON
 import com.rackspace.com.papi.components.checker.step.results.ErrorResult
 import com.rackspace.com.papi.components.checker.util.{ObjectMapperPool, XMLParserPool}
 import org.mockito.Matchers._
@@ -196,10 +198,14 @@ class BaseValidatorSuite extends FunSuite {
         contentType match {
           case "application/xml"  =>
             xmlParser = XMLParserPool.borrowParser
-            req.setAttribute (PARSED_XML, xmlParser.parse(new ByteArrayInputStream(content.getBytes)))
+            val doc = xmlParser.parse(new ByteArrayInputStream(content.getBytes))
+            req.setAttribute (PARSED_XML, doc)
+            req.setAttribute (PARSED_REPRESENTATION, new ParsedXML(doc))
           case "application/json" =>
             jsonParser = ObjectMapperPool.borrowParser
-            req.setAttribute (PARSED_JSON, jsonParser.readValue(content,classOf[JsonNode]))
+            val jnd = jsonParser.readValue(content,classOf[JsonNode])
+            req.setAttribute (PARSED_JSON, jnd)
+            req.setAttribute (PARSED_REPRESENTATION, new ParsedJSON(jnd))
         }
       }
     } finally {

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRAXRepresentationSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRAXRepresentationSuite.scala
@@ -1,0 +1,1387 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+
+import com.rackspace.com.papi.components.checker.RunAssertionsHandler._
+import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.step.results.Result
+import com.rackspace.cloud.api.wadl.Converters._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.collection.JavaConversions._
+
+import scala.xml.Elem
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.JsonNode
+
+@RunWith(classOf[JUnitRunner])
+class ValidatorWADLRAXRepresentationSuite extends BaseValidatorSuite {
+
+  //
+  //  Configs...
+  //
+  val raxRepDisabled = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = false
+    tc.removeDups = false
+    tc.joinXPathChecks = false
+    tc.checkPlainParams = false
+    tc.checkElements = false
+    tc.checkXSDGrammar = false
+    tc.checkJSONGrammar = false
+    tc.enableRaxRolesExtension = false
+    tc.maskRaxRoles403 = false
+    tc
+  }
+
+  val raxRepEnabled = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = false
+    tc.joinXPathChecks = false
+    tc.checkPlainParams = false
+    tc.checkElements = false
+    tc.checkXSDGrammar = false
+    tc.checkJSONGrammar = false
+    tc.enableRaxRolesExtension = false
+    tc.maskRaxRoles403 = false
+    tc
+  }
+
+  val raxRepEnabledRemoveDups = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = true
+    tc.joinXPathChecks = false
+    tc.checkPlainParams = false
+    tc.checkElements = false
+    tc.checkXSDGrammar = false
+    tc.checkJSONGrammar = false
+    tc.enableRaxRolesExtension = false
+    tc.maskRaxRoles403 = false
+    tc
+  }
+
+  val raxRepEnabledPlain = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = false
+    tc.joinXPathChecks = false
+    tc.checkPlainParams = true
+    tc.checkElements = true
+    tc.checkXSDGrammar = false
+    tc.checkJSONGrammar = false
+    tc.enableRaxRolesExtension = false
+    tc.maskRaxRoles403 = false
+    tc
+  }
+
+  val raxRepEnabledPlainRemoveDups = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = true
+    tc.joinXPathChecks = true
+    tc.checkPlainParams = true
+    tc.checkElements = true
+    tc.checkXSDGrammar = false
+    tc.checkJSONGrammar = false
+    tc.enableRaxRolesExtension = false
+    tc.maskRaxRoles403 = false
+    tc
+  }
+
+  val raxRepEnabledPlainGrammar = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = false
+    tc.joinXPathChecks = false
+    tc.checkPlainParams = true
+    tc.checkElements = true
+    tc.checkXSDGrammar = true
+    tc.checkJSONGrammar = true
+    tc.enableRaxRolesExtension = false
+    tc.maskRaxRoles403 = false
+    tc
+  }
+
+  val raxRepEnabledPlainGrammarRemoveDups = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = true
+    tc.joinXPathChecks = true
+    tc.checkPlainParams = true
+    tc.checkElements = true
+    tc.checkXSDGrammar = true
+    tc.checkJSONGrammar = true
+    tc.enableRaxRolesExtension = false
+    tc.maskRaxRoles403 = false
+    tc
+  }
+
+  //
+  //  Configs, rax roles enabled
+  //
+  val raxRepEnabledPlainGrammarRaxRoles = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = false
+    tc.joinXPathChecks = false
+    tc.checkPlainParams = true
+    tc.checkElements = true
+    tc.checkXSDGrammar = true
+    tc.checkJSONGrammar = true
+    tc.enableRaxRolesExtension = true
+    tc.maskRaxRoles403 = false
+    tc
+  }
+
+  val raxRepEnabledPlainGrammarRaxRolesRemoveDups = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = true
+    tc.joinXPathChecks = true
+    tc.checkPlainParams = true
+    tc.checkElements = true
+    tc.checkXSDGrammar = true
+    tc.checkJSONGrammar = true
+    tc.enableRaxRolesExtension = true
+    tc.maskRaxRoles403 = false
+    tc
+  }
+
+  //
+  //  Configs, rax roles mask enbadled
+  //
+  val raxRepEnabledPlainGrammarRaxRolesMask = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = false
+    tc.joinXPathChecks = false
+    tc.checkPlainParams = true
+    tc.checkElements = true
+    tc.checkXSDGrammar = true
+    tc.checkJSONGrammar = true
+    tc.enableRaxRolesExtension = true
+    tc.maskRaxRoles403 = true
+    tc
+  }
+
+  val raxRepEnabledPlainGrammarRaxRolesMaskRemoveDups = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = true
+    tc.joinXPathChecks = true
+    tc.checkPlainParams = true
+    tc.checkElements = true
+    tc.checkXSDGrammar = true
+    tc.checkJSONGrammar = true
+    tc.enableRaxRolesExtension = true
+    tc.maskRaxRoles403 = true
+    tc
+  }
+
+  val jsonSchema = """
+  {
+    "title" : "Test Schemas",
+    "type" : "object",
+    "oneOf" : [
+        {
+            "title" : "firstName and XML",
+            "type" : "object",
+            "properties" : {
+                "firstName" : {
+                    "type" : "string"
+                },
+                "xml" : {
+                    "type" : "string"
+                }
+            },
+            "required" : ["firstName", "xml"],
+            "additionalProperties" : false
+        },
+        {
+            "title" : "first and last",
+            "type" : "object",
+            "properties" : {
+                "firstName" : {
+                    "type" : "string"
+                },
+                "lastName" : {
+                    "type" : "string"
+                }
+            },
+            "required" : ["firstName", "lastName"],
+            "additionalProperties" : false
+        }
+    ]
+  }
+  """
+
+  val testWADL =
+  <application xmlns="http://wadl.dev.java.net/2009/02"
+               xmlns:rax="http://docs.rackspace.com/api"
+               xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+               xmlns:json="http://json-schema.org/schema#"
+               xmlns:tst="test.org">
+      <grammars>
+          <schema elementFormDefault="qualified"
+                  attributeFormDefault="unqualified"
+                  xmlns="http://www.w3.org/2001/XMLSchema"
+                  targetNamespace="test.org">
+
+              <element name="user" type="tst:User"/>
+              <element name="user2" type="tst:User2"/>
+              <element name="some_xml" type="tst:SomeXML"/>
+              <element name="other_xml" type="tst:OtherXML"/>
+
+              <complexType name="User">
+                  <attribute name="firstName" type="xsd:string" use="required"/>
+                  <attribute name="lastName" type="xsd:string" use="required"/>
+              </complexType>
+
+              <complexType name="User2">
+                  <attribute name="fn" type="xsd:string" use="required"/>
+                  <attribute name="ln" type="xsd:string" use="required"/>
+              </complexType>
+
+              <complexType name="SomeXML">
+                  <choice minOccurs="0">
+                      <element name="json"   type="xsd:string" />
+                      <element name="json2"  type="xsd:string" />
+                  </choice>
+              </complexType>
+
+              <complexType name="OtherXML">
+                  <sequence>
+                      <element name="xml" type="xsd:string" minOccurs="0"/>
+                  </sequence>
+              </complexType>
+          </schema>
+          <schema elementFormDefault="qualified"
+                  attributeFormDefault="unqualified"
+                  xmlns="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tst2="test.org/2"
+                  targetNamespace="test.org/2">
+
+              <element name="user" type="tst2:User"/>
+
+              <complexType name="User">
+                  <sequence>
+                      <element name="json" type="xsd:string"/>
+                  </sequence>
+              </complexType>
+          </schema>
+          <json:schema>
+              { jsonSchema }
+          </json:schema>
+      </grammars>
+      <resources base="https://test.api.openstack.com">
+          <resource path="/a" rax:roles="admin">
+              <method name="PUT" rax:roles="allowPUT">
+                  <request>
+                      <representation mediaType="application/xml" element="tst:some_xml">
+                          <rax:representation
+                              mediaType="application/myApp+json"
+                              path="/tst:some_xml/tst:json"
+                              name="jsonContent">
+                              <param name="test" style="plain"
+                                     path="$_?firstName" required="true"
+                                     rax:message="Need a first name" rax:code="403"/>
+                          </rax:representation>
+                          <rax:representation
+                              mediaType="application/myApp+json"
+                              path="/tst:some_xml/tst:json2"
+                              name="jsonContent2">
+                              <param name="test" style="plain"
+                                     path="$_?firstName" required="true"
+                                     rax:message="Need a first name" rax:code="403"/>
+                          </rax:representation>
+                      </representation>
+                      <representation mediaType="application/json">
+                          <param name="test" style="plain"
+                                 path="$_?firstName" required="true"
+                                 rax:message="Need a first name" rax:code="403"/>
+                          <rax:representation
+                              mediaType="application/myApp+xml"
+                              path="$body('xml')"
+                              name="xmlContent" element="tst2:user" xmlns:tst2="test.org/2">
+                              <rax:representation
+                                  mediaType="application/myApp+json"
+                                  path="/tst2:user/tst2:json">
+                                  <param name="test3" style="plain"
+                                         path="$_?lastName" required="true"
+                                         rax:message="Need a last name" rax:code="403"/>
+                                  />
+                              </rax:representation>
+                          </rax:representation>
+                      </representation>
+                  </request>
+              </method>
+              <method name="POST" rax:roles="allowPOST">
+                  <request>
+                      <representation mediaType="application/xml" element="tst:some_xml"/>
+                      <representation mediaType="application/json" />
+                      <representation mediaType="text/yaml"/>
+                      <rax:representation mediaType="application/myApp+json" name="jsonUser"
+                                          path="req:header('X-JSON-USER')">
+                          <param name="test3" style="plain"
+                                 path="$_?firstName" required="true"
+                                 rax:message="Need a first name"
+                                 rax:code="403"/>
+                          <param name="test4" style="plain"
+                                 path="$_?lastName" required="true"
+                                 rax:message="Need a last name" rax:code="403"/>
+                      </rax:representation>
+                  </request>
+              </method>
+              <resource path="b" rax:roles="#all">
+                  <method name="PUT">
+                      <request>
+                          <representation mediaType="application/xml"
+                                          element="tst:other_xml">
+                              <rax:representation mediaType="application/MyApp+xml" name="xmlUser"
+                                                  path="/tst:other_xml/tst:xml" element="tst:user"
+                                                  applyToChildren="true">
+                                  <param name="test5" style="plain"
+                                         path="tst:user/@firstName" required="true"
+                                         rax:message="Need a first name"
+                                         rax:code="403"/>
+                                  <param name="test6" style="plain"
+                                         path="tst:user/@lastName" required="true"
+                                         rax:message="Need a last name"
+                                         rax:code="403"/>
+                              </rax:representation>
+                          </representation>
+                          <representation mediaType="application/json" />
+                          <representation mediaType="text/yaml"/>
+                      </request>
+                  </method>
+              </resource>
+              <rax:representation mediaType="application/MyApp+xml" name="xmlUser"
+                                  path="req:header('X-XML-USER')" element="tst:user"
+                                  applyToChildren="true">
+                  <param name="test5" style="plain"
+                         path="tst:user/@firstName" required="true"
+                         rax:message="Need a first name"
+                         rax:code="403"/>
+                  <param name="test6" style="plain"
+                         path="tst:user/@lastName" required="true"
+                         rax:message="Need a last name"
+                         rax:code="403"/>
+              </rax:representation>
+          </resource>
+          <rax:representation mediaType="application/myApp+xml" name="xmlUser"
+                              path="req:header('X-XML-USER2')" element="tst:user2">
+              <param name="test5" style="plain"
+                     path="tst:user2/@fn" required="true"
+                     rax:message="Need a first name"
+                     rax:code="403"/>
+              <param name="test6" style="plain"
+                     path="tst:user2/@ln" required="true"
+                     rax:message="Need a last name"
+                     rax:code="403"/>
+          </rax:representation>
+      </resources>
+  </application>
+
+  //
+  // Config combinations
+  //
+  val repDisabledConfigs = Map[String, Config](
+    "Config with rax:rep disabled" -> raxRepDisabled)
+
+  val repEnabledConfigs = Map[String, Config](
+    "Config with rax:rep enabled"->raxRepEnabled,
+    "Config with rax:rep enabled and remove dups"->raxRepEnabledRemoveDups)
+
+  val repEnabledPlainConfigs = Map[String, Config](
+    "Config with rax:rep and plain params enabled"->raxRepEnabledPlain,
+    "Config with rax:rep and plain params enabled and remove dups"->raxRepEnabledPlainRemoveDups)
+
+  val repEnabledPlainGrammarConfigs = Map[String, Config](
+    "Config with rax:rep and plain params and grammar enabled"->raxRepEnabledPlainGrammar,
+    "Config with rax:rep and plain params and grammar enabled and remove dups"->raxRepEnabledPlainGrammarRemoveDups)
+
+  val repEnabledPlainGrammarRolesConfigs = Map[String, Config](
+    "Config with rax:rep and plain params and grammar and rax:roles enabled"->raxRepEnabledPlainGrammarRaxRoles,
+    "Config with rax:rep and plain params and grammar and rax:roles enabled and remove dups"->raxRepEnabledPlainGrammarRaxRolesRemoveDups)
+
+  val repEnabledPlainGrammarRolesMaskConfigs = Map[String, Config](
+    "Config with rax:rep and plain params and grammar and rax:roles mask enabled"->raxRepEnabledPlainGrammarRaxRolesMask,
+    "Config with rax:rep and plain params and grammar and rax:roles mask enabled and remove dups"->raxRepEnabledPlainGrammarRaxRolesMaskRemoveDups)
+
+
+  val repWADLs = Map[String, Elem](
+    "WADL with rax:representations"->testWADL)
+
+  //
+  //  Good Samples, these should validate if submited to the right
+  //  resource.
+  //
+  val goodRepJSON1 =
+    """
+   {
+       "firstName" : "Jorge",
+       "xml" : "<user xmlns='test.org/2'><json>{ &quot;lastName&quot; : &quot;Williams&quot;, &quot;firstName&quot; : &quot;Jorge&quot; }</json></user>"
+   }
+
+  """
+
+  val goodRepJSON2 =
+    """
+   {
+       "firstName" : "Jorge",
+       "lastName" : "Williams"
+   }
+
+  """
+
+  val goodRepXML1 =
+   <some_xml xmlns="test.org">
+       <json> {
+         goodRepJSON2
+      }</json>
+    </some_xml>
+
+  val goodRepXML2 =
+   <some_xml xmlns="test.org">
+       <json2>{
+         goodRepJSON2
+       }</json2>
+  </some_xml>
+
+  val goodRepXML3 =
+   <user xmlns="test.org" firstName="Jorge" lastName="Williams"/>
+
+  val goodRepXML4 =
+    <user2 xmlns="test.org" fn="Jorge" ln="Williams"/>
+
+  val goodRepXML5 =
+    <some_xml xmlns="test.org"/>
+
+  val goodRepXML6 =
+    <other_xml xmlns="test.org"/>
+
+  val goodRepXML7 =
+    <other_xml xmlns="test.org">
+      <xml>
+        &lt;user xmlns="test.org" firstName="Jorge" lastName="Williams"/&gt;
+      </xml>
+    </other_xml>
+
+  val goodRepYAML1 =
+    """
+    ---
+    firstName: Jorge
+    lastName: Williams
+
+    """
+
+  //
+  //  Bad samples, these should not validate, unless rax:rep is
+  //  disabled.
+  //
+
+  val badRepJSON1 =
+    """
+   {
+       "firstName" : "Jorge",
+       "xml" : "<user xmlns='test.org/2'><json>{ &quot;lastName&quot; ; &quot;Williams&quot;, &quot;firstName&quot; | &quot;Jorge&quot; }</json></user>"
+   }
+
+  """
+
+  val badRepJSON2 =
+    """
+   {
+       "firstName" : "Jorge",
+       "xml" : "<user xmlns='test.org/2'><json>{ &quot;lastName&quot; : &quot;Williams&quot;, &quot;firstName&quot; : &quot;Jorge&quot; }</json><user>"
+   }
+
+  """
+
+
+  val badRepJSON3 =
+    """
+   {
+       "xml" : "<user xmlns='test.org/2'><json>{ &quot;lastName&quot; : &quot;Williams&quot;, &quot;firstName&quot; : &quot;Jorge&quot; }</json></user>"
+   }
+
+  """
+
+  val badRepJSON4 =
+    """
+   {
+       "firstName" : "Jorge",
+       "xml" : "<user xmlns='test.org/2'><json>{ &quot;firstName&quot; : &quot;Jorge&quot; }</json></user>"
+   }
+
+  """
+
+  val badRepJSON5 =
+    """
+   {
+       "firstName" : "Jorge",
+       "lastName"  : "Williams",
+       "wooga"     : false
+   }
+  """
+
+  val badRepJSON6 =
+    """
+   {
+       "firstName" : "Jorge",
+       "xml" : "<user xmlns='test.org/2'><json>{ &quot;lastName&quot; : &quot;Williams&quot;, &quot;firstName&quot; : &quot;Jorge&quot; }</json></user>",
+       "wooga" : true
+   }
+
+  """
+
+  val badRepJSON7 =
+    """
+   {
+       "firstName" : "Jorge",
+       "xml" : "<user xmlns='test.org/2' wooga='true'><json>{ &quot;lastName&quot; : &quot;Williams&quot;, &quot;firstName&quot; : &quot;Jorge&quot; }</json></user>"
+   }
+
+  """
+
+  val badRepJSON8 =
+    """
+   {
+       "firstName" : "Jorge",
+       "xml" : "<user xmlns='test.org/2'><json>{ &quot;item&quot; : false, &quot;lastName&quot; : &quot;Williams&quot;, &quot;firstName&quot; : &quot;Jorge&quot; }</json></user>"
+   }
+
+  """
+
+  val badRepJSON9 =
+    """
+   {
+       "firstName" : "Jorge",
+       "lastName" : "Williams",
+       "items" : [false, false, true]
+   }
+
+  """
+
+
+
+  val badRepXML1 =
+   <some_xml xmlns="test.org">
+       <json> /booga\  </json>
+  </some_xml>
+
+  val badRepXML2 =
+   <some_xml xmlns="test.org">
+       <json> 42 </json>
+    </some_xml>
+
+  val badRepXML3 =
+   <user xmlns="test.org" firstN="Jorge" lastName="Williams"/>
+
+  val badRepXML4 =
+    <user2 xmlns="test.org" fn="Jorge" lastN="Williams"/>
+
+  val badRepXML5 =
+   <some_xml xmlns="test.org" wooga="true">
+       <json> {
+         goodRepJSON2
+      }</json>
+    </some_xml>
+
+  val badRepXML6 =
+   <some_xml xmlns="test.org">
+       <json> {badRepJSON5} </json>
+  </some_xml>
+
+  val badRepXML7 =
+    <user2 xmlns="test.org" fn="Jorge" ln="Williams" firstName="Jorge"/>
+
+
+  val badRepXML8 =
+    <other_xml xmlns="test.org">
+      <xml>
+        (user :  firstName="Jorge" : lastName="Williams")
+      </xml>
+    </other_xml>
+
+  val badRepXML9 =
+    <other_xml xmlns="test.org">
+      <xml>
+        &lt;user xmlns="test.org" firstName="Jorge" last="Williams"/&gt;
+      </xml>
+    </other_xml>
+
+  val badRepXML10 =
+    <other_xml xmlns="test.org">
+      <xml>
+        &lt;user xmlns="test.org" firstName="Jorge" lastName="Williams" why="yes"/&gt;
+      </xml>
+    </other_xml>
+
+
+
+  //
+  //  Assertions!
+  //
+  def happyPathAssertions(validator : Validator, wadlDesc : String, configDesc : String) {
+    test(s"A PUT on /a should succeed with good XML 1 $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", goodRepXML1, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with good XML 2 $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", goodRepXML2, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with good XML 3 if it is specified in the X-XML-USER header $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+                                 "X-XML-USER"->List(goodRepXML3.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with good XML 4 if it is specified in the X-XML-USER2 header $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+                                 "X-XML-USER2"->List(goodRepXML4.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with good XML 3 if it is specified in the X-XML-USER header (json Rep) $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json", goodRepJSON2, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+                                 "X-XML-USER"->List(goodRepXML3.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with good XML 4 if it is specified in the X-XML-USER2 header (json Rep) $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json", goodRepJSON2, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+                                 "X-XML-USER2"->List(goodRepXML4.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with good JSON 1 $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json", goodRepJSON1, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with good XML 3 if it is specified in the X-XML-USER header $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-XML-USER"->List(goodRepXML3.toString))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with good XML 4 if it is specified in the X-XML-USER2 header $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"),
+                                 "X-XML-USER2"->List(goodRepXML4.toString))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with good JSON 2 if it is specified in the X-JSON_USER header $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-JSON-USER"->List(goodRepJSON2))),response, chain)
+    }
+
+
+    test(s"A POST on /a should succeed with good XML 3 if it is specified in the X-XML-USER header (json) $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/json", goodRepJSON2, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-XML-USER"->List(goodRepXML3.toString))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with good XML 4 if it is specified in the X-XML-USER2 header (json) $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/json", goodRepJSON1, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"),
+                                 "X-XML-USER2"->List(goodRepXML4.toString))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with good JSON 2 if it is specified in the X-JSON_USER header (json) $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/json", goodRepJSON1, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-JSON-USER"->List(goodRepJSON2))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with good XML 3 if it is specified in the X-XML-USER header (yaml) $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "text/yaml", goodRepYAML1, false,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-XML-USER"->List(goodRepXML3.toString))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with good XML 4 if it is specified in the X-XML-USER2 header (yaml) $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "text/yaml", goodRepYAML1, false,
+        Map[String,List[String]]("X-ROLES"->List("admin"),
+                                 "X-XML-USER2"->List(goodRepXML4.toString))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with good JSON 2 if it is specified in the X-JSON_USER header (yaml) $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "text/yaml", goodRepYAML1, false,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-JSON-USER"->List(goodRepJSON2))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed with good XML 7 $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodRepXML7, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"))),response, chain)
+    }
+
+
+    test(s"A PUT on /a/b should succeed with good XML 3 if it is specified in the X-XML-USER header $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodRepXML6, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+                                 "X-XML-USER"->List(goodRepXML3.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed with good XML 4 if it is specified in the X-XML-USER2 header $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodRepXML6, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+                                 "X-XML-USER2"->List(goodRepXML4.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed with good XML 3 if it is specified in the X-XML-USER header (json) $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "application/json", goodRepJSON2, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+                                 "X-XML-USER"->List(goodRepXML3.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed with good XML 4 if it is specified in the X-XML-USER2 header (json) $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "application/json", goodRepJSON1, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+                                 "X-XML-USER2"->List(goodRepXML4.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed with good XML 3 if it is specified in the X-XML-USER header (yaml) $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "text/yaml", goodRepYAML1, false,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+                                 "X-XML-USER"->List(goodRepXML3.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed with good XML 4 if it is specified in the X-XML-USER2 header (yaml) $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "text/yaml", goodRepYAML1, false,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-XML-USER2"->List(goodRepXML4.toString))),response, chain)
+    }
+  }
+
+  //
+  //  Some sanity tests, these assertions should always fail
+  //  regardless of configuration
+  //
+
+  def happySadPaths (validator : Validator, wadlDesc : String, configDesc : String) {
+    test (s"Plain text PUT should fail on /a $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT","/a","plain/text","hello!", false,
+        Map[String,List[String]]("X-Roles"->List("admin"))), response, chain),
+        415, List("content type","application/xml","application/json"))
+    }
+
+    test (s"Plain text POST should fail on /a $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST","/a","plain/text","hello!", false,
+        Map[String,List[String]]("X-Roles"->List("allowPOST"))), response, chain),
+        415, List("content type","application/xml","application/json","text/yaml"))
+    }
+
+    test (s"Plain text PUT should fail on /a/b $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT","/a/b","plain/text","hello!", false,
+        Map[String,List[String]]("X-Roles"->List("user"))), response, chain),
+        415, List("content type","application/xml","application/json","text/yaml"))
+    }
+
+    test (s"A PATCH on /a should fail with a 405 on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PATCH", "/a", "application/xml",goodXML, false,
+        Map[String,List[String]]("a"->List("abba"),
+          "b"->List("ababa"),
+          "X-Auth"->List("foo!"),
+          "X-Roles"->List("admin"))), response, chain),
+        405, List("Method", "POST", "PUT"))
+    }
+
+    test (s"A PATCH on /a/b should fail with a 405 on $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PATCH", "/a/b", "application/xml",goodXML, false,
+        Map[String,List[String]]("a"->List("abba"),
+          "b"->List("ababa"),
+          "X-Auth"->List("foo!"),
+          "X-Roles"->List("admin"))), response, chain),
+        405, List("Method", "PUT"))
+    }
+  }
+
+
+  //
+  //  These assertions will succeed only if rax:rep is disabled.
+  //
+  def happyWhenRaxRepIsDisabled (validator : Validator, wadlDesc : String, configDesc : String) {
+    test(s"A PUT on /a should succeed with bad XML 1 if rax:rep is disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", badRepXML1, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with bad XML in  X-XML-USER header if rax:rep is disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+                                 "X-XML-USER"->List("!This is not XML!"))),response, chain)
+    }
+
+
+    test(s"A PUT on /a should succeed with bad XML in  X-XML-USER2 header if rax:rep is disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+                                 "X-XML-USER2"->List("!This is not XML!"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with bad if it is specified in the X-XML-USER if rax:rep is disabled (json Rep) $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json", goodRepJSON2, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+                                 "X-XML-USER"->List("!This is not XML!"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with bad JSON 1 if rax:rep is disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json", badRepJSON1, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with bad JSON 2 if rax:rep is disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json", badRepJSON2, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed  if bad json is specified in the X-JSON_USER header if rax:rep is disabled $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-JSON-USER"->List("!This is not JSON!"))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed if bad XML is specified in the X-XML-USER header if rax:rep is disabled (yaml) $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "text/yaml", goodRepYAML1, false,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+                                 "X-XML-USER"->List("!This is not XML!"))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed with bad embedded XML if rax:rep is disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "application/xml", badRepXML8, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"))),response, chain)
+    }
+
+  }
+
+  //
+  //  These assertions will fail if rax:rep is enabled
+  //
+  def sadWhenRaxRepIsEnabled (validator : Validator, wadlDesc : String, configDesc : String) {
+
+    test(s"A PUT on /a should fail with bad XML 1 if rax:rep is enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", badRepXML1, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain),
+        400, List("Bad Content"))
+    }
+
+    test(s"A PUT on /a should fail with bad XML in  X-XML-USER header if rax:rep is enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+          "X-XML-USER"->List("!This is not XML!"),
+          "X-XML-USER2"->List("!This is not XML!"))),response, chain),
+        400, List("Bad Content", "not allowed in prolog"))
+    }
+
+    test(s"A PUT on /a should fail with bad if it is specified in the X-XML-USER if rax:rep is enabled (json Rep) $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/json", goodRepJSON2, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+          "X-XML-USER2"->List("!This is not XML!"))),response, chain),
+        400, List("Bad Content", "not allowed in prolog"))
+    }
+
+    test(s"A PUT on /a should fail with bad JSON 1 if rax:rep is enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/json", badRepJSON1, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain),
+        400, List("Bad Content", "unexpected character"))
+    }
+
+    test(s"A PUT on /a should fail with bad JSON 2 if rax:rep is enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/json", badRepJSON2, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain),
+        400, List("Bad Content"))
+    }
+
+    test(s"A POST on /a should fail  if bad json is specified in the X-JSON_USER header if rax:rep is enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+          "X-XML-USER"->List("!This is not XML!"),
+          "X-XML-USER2"->List("!This is not XML!"),
+          "X-JSON-USER"->List("!This is not JSON!"))),response, chain),
+        400, List("Bad Content"))
+    }
+
+    test(s"A PUT on /a/b should fail if bad XML is specified in the X-XML-USER header if rax:rep is enabled (yaml) $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "text/yaml", goodRepYAML1, false,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+          "X-XML-USER"->List("!This is not XML!"),
+          "X-XML-USER2"->List("!This is not XML!"),
+          "X-JSON-USER"->List("!This is not JSON!"))),response, chain),
+        400, List("Bad Content"))
+    }
+
+    test(s"A PUT on /a/b should fail with bad embedded XML if rax:rep is enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", badRepXML8, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"))),response, chain),
+        400, List("Bad Content"))
+    }
+  }
+
+  //
+  //  These checks should succeed when plain params are disabled
+  //
+  def happyWhenPlainParamsAreDisabled (validator : Validator, wadlDesc : String, configDesc : String) {
+    test(s"A PUT on /a should succeed with other_xml if plain params are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", goodRepXML6, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"),
+          "X-XML-USER"->List(goodRepXML3.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with bad params in embedded json if plain params are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", badRepXML2, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with bad JSON 3 if plain params are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json", badRepJSON3, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with bad JSON 4 if plain params are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json", badRepJSON4, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with bad JSON 2 if it is specified in the X-JSON_USER header if plain params are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-JSON-USER"->List(badRepJSON1))),response, chain)
+    }
+
+
+    test(s"A PUT on /a/b should succeed with bad XML 3 in X-XML-USER header (yaml) if plain params are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "text/yaml", goodRepYAML1, false,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+                                 "X-XML-USER"->List(badRepXML3.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed with bad XML 4 in the X-XML-USER2 header if plain params are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodRepXML6, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+                                 "X-XML-USER2"->List(badRepXML4.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed with bad embedded XML if plain params are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "application/xml", badRepXML9, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"))),response, chain)
+    }
+  }
+
+
+  //
+  //  These checks should fail when plain params are enabled
+  //
+  def sadWhenPlainParamsAreEnabled (validator : Validator, wadlDesc : String, configDesc : String) {
+    test(s"A PUT on /a should fail with other_xml if plain params are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", goodRepXML6, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"),
+          "X-XML-USER"->List(goodRepXML3.toString))),response, chain),
+        400, List("Expecting", "some_xml"))
+    }
+
+    test(s"A PUT on /a should fail with bad params in embedded json if plain params are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", badRepXML2, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain),
+        403, List("Need a first name"))
+    }
+
+    test(s"A PUT on /a should fail with bad JSON 3 if plain params are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/json", badRepJSON3, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain),
+        403, List("Need a first name"))
+    }
+
+    test(s"A PUT on /a should fail with bad JSON 4 if plain params are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/json", badRepJSON4, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain),
+        403, List("Need a last name"))
+    }
+
+    test(s"A POST on /a should fail with bad JSON 2 if it is specified in the X-JSON_USER header if plain params are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+          "X-JSON-USER"->List(badRepJSON1))),response, chain),
+        403, List("Need a last name"))
+    }
+
+
+    test(s"A PUT on /a/b should fail with bad XML 3 in X-XML-USER header (yaml) if plain params are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "text/yaml", goodRepYAML1, false,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+          "X-XML-USER"->List(badRepXML3.toString))),response, chain),
+        403, List("Need a first name"))
+    }
+
+    test(s"A PUT on /a/b should fail with bad XML 4 in the X-XML-USER2 header if plain params are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodRepXML6, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+          "X-XML-USER2"->List(badRepXML4.toString))),response, chain),
+        403, List("Need a last name"))
+    }
+
+    test(s"A PUT on /a/b should fail with bad embedded XML if plain params are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", badRepXML9, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"))),response, chain),
+        403, List("Need a last name"))
+    }
+  }
+
+  //
+  //  These checks should succeed when grammar checks are disabled.
+  //
+  def happyWhenGrammarChecksAreDisabled (validator : Validator, wadlDesc : String, configDesc : String) {
+    test(s"A PUT on /a should succeed with bad XML 5 when grammar checks are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", badRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with bad XML 6 when grammar checks are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", badRepXML6, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+
+    test(s"A PUT on /a should succeed with bad JSON 6 when grammar checks are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json", badRepJSON6, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with bad JSON 7 when grammar checks are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json", badRepJSON7, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with bad JSON 8 when grammar checks are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/json", badRepJSON8, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with bad JSON 9 in the X-JSON_USER when grammar checkes are disabled header $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-JSON-USER"->List(badRepJSON9))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed with bad XML 7  in the X-XML-USER2 header whet grammar checks are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "application/xml", goodRepXML6, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+          "X-XML-USER2"->List(badRepXML7.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a/b should succeed with bad embedded XML grammar checks are disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a/b", "application/xml", badRepXML10, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"))),response, chain)
+    }
+
+  }
+
+
+  //
+  //  These checks should fail when grammar checks are enabled
+  //
+  def sadWhenGrammarChecksAreEnabled (validator : Validator, wadlDesc : String, configDesc : String) {
+    test(s"A PUT on /a should fail with bad XML 5 when grammar checks are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", badRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain),
+        400, List("Bad Content", "wooga", "not allowed"))
+    }
+
+    test(s"A PUT on /a should fail with bad XML 6 when grammar checks are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", badRepXML6, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain),
+        400, List("Bad Content", "failed to match","schema"))
+    }
+
+
+    test(s"A PUT on /a should fail with bad JSON 6 when grammar checks are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/json", badRepJSON6, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain),
+        400, List("Bad Content", "failed to match","schema"))
+    }
+
+    test(s"A PUT on /a should fail with bad JSON 7 when grammar checks are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/json", badRepJSON7, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain),
+        400, List("Bad Content","wooga", "not allowed"))
+    }
+
+    test(s"A PUT on /a should fail with bad JSON 8 when grammar checks are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/json", badRepJSON8, true,
+        Map[String,List[String]]("X-ROLES"->List("admin"))),response, chain),
+        400, List("Bad Content", "failed to match","schema"))
+    }
+
+    test(s"A POST on /a should fail with bad JSON 9 in the X-JSON_USER when grammar checkes are enabled header $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+          "X-JSON-USER"->List(badRepJSON9))),response, chain),
+        400, List("Bad Content", "failed to match","schema"))
+    }
+
+    test(s"A PUT on /a/b should fail with bad XML 7  in the X-XML-USER2 header whet grammar checks are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", goodRepXML6, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"),
+          "X-XML-USER2"->List(badRepXML7.toString))),response, chain),
+        400, List("Bad Content","firstName", "not allowed"))
+    }
+
+    test(s"A PUT on /a/b should fail with bad embedded XML grammar checks are enabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a/b", "application/xml", badRepXML10, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"))),response, chain),
+        400, List("Bad Content","why", "not allowed"))
+    }
+
+  }
+
+
+  //
+  //  These checks should succeed when raxroles is disabled
+  //
+  def happyWhenRaxRolesAreDisabled (validator : Validator, wadlDesc : String, configDesc : String) {
+    test(s"A PUT on /a should succeed with good XML 1 with role wooga should if rax:roles is disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", goodRepXML1, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with good XML 1 with roles allowPOST/DELETE if rax:roles is disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", goodRepXML1, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST", "allowDELETE"))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with good XML 3 if it is specified in the X-XML-USER header with role allowPOST with rax:roles disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-XML-USER"->List(goodRepXML3.toString))),response, chain)
+    }
+
+    test(s"A PUT on /a should succeed with good XML 4 if it is specified in the X-XML-USER2 header with role booga and rax:roles disabled $wadlDesc with $configDesc") {
+      validator.validate(request("PUT", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("booga"),
+                                 "X-XML-USER2"->List(goodRepXML4.toString))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with good JSON 2 if it is specified in the X-JSON_USER header with role allowPUT and rax:roles disabled $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+                                 "X-JSON-USER"->List(goodRepJSON2))),response, chain)
+    }
+
+    test(s"A POST on /a should succeed with good JSON 2 if it is specified in the X-JSON_USER header (json) with roles bugga / allowPUT with rax:roles disabled $wadlDesc with $configDesc") {
+      validator.validate(request("POST", "/a", "application/json", goodRepJSON1, true,
+        Map[String,List[String]]("X-ROLES"->List("bugga", "allowPUT"),
+                                 "X-JSON-USER"->List(goodRepJSON2))),response, chain)
+    }
+  }
+
+  //
+  //  These checks should fail when raxroles is enabled
+  //
+  def sadWhenRaxRolesAreEnabled (validator : Validator, wadlDesc : String, configDesc : String) {
+    test(s"A PUT on /a should succeed with good XML 1 with role wooga should if rax:roles is disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", goodRepXML1, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"))),response, chain),
+        403, List("You are forbidden to perform the operation"))
+    }
+
+    test(s"A PUT on /a should succeed with good XML 1 with roles allowPOST/DELETE if rax:roles is disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", goodRepXML1, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST", "allowDELETE"))),response, chain),
+        403, List("You are forbidden to perform the operation"))
+    }
+
+    test(s"A PUT on /a should succeed with good XML 3 if it is specified in the X-XML-USER header with role allowPOST with rax:roles disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-XML-USER"->List(goodRepXML3.toString))),response, chain),
+        403, List("You are forbidden to perform the operation"))
+    }
+
+    test(s"A PUT on /a should succeed with good XML 4 if it is specified in the X-XML-USER2 header with role booga and rax:roles disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("booga"),
+                                 "X-XML-USER2"->List(goodRepXML4.toString))),response, chain),
+        403, List("You are forbidden to perform the operation"))
+    }
+
+    test(s"A POST on /a should succeed with good JSON 2 if it is specified in the X-JSON_USER header with role allowPUT and rax:roles disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+                                 "X-JSON-USER"->List(goodRepJSON2))),response, chain),
+        403, List("You are forbidden to perform the operation"))
+    }
+
+    test(s"A POST on /a should succeed with good JSON 2 if it is specified in the X-JSON_USER header (json) with roles bugga / allowPUT with rax:roles disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/json", goodRepJSON1, true,
+        Map[String,List[String]]("X-ROLES"->List("bugga", "allowPUT"),
+                                 "X-JSON-USER"->List(goodRepJSON2))),response, chain),
+        403, List("You are forbidden to perform the operation"))
+    }
+  }
+
+  //
+  //  These checks should fail when raxroles mask is enabled
+  //
+  def sadWhenRaxRolesMaskAreEnabled (validator : Validator, wadlDesc : String, configDesc : String) {
+    test(s"A PUT on /a should succeed with good XML 1 with role wooga should if rax:roles is disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", goodRepXML1, true,
+        Map[String,List[String]]("X-ROLES"->List("wooga"))),response, chain),
+        405, List("Bad Method","PUT"))
+    }
+
+    test(s"A PUT on /a should succeed with good XML 1 with roles allowPOST/DELETE if rax:roles is disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", goodRepXML1, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST", "allowDELETE"))),response, chain),
+        405, List("Bad Method","PUT","does not match","POST"))
+    }
+
+    test(s"A PUT on /a should succeed with good XML 3 if it is specified in the X-XML-USER header with role allowPOST with rax:roles disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPOST"),
+                                 "X-XML-USER"->List(goodRepXML3.toString))),response, chain),
+        405, List("Bad Method","PUT","does not match","POST"))
+    }
+
+    test(s"A PUT on /a should succeed with good XML 4 if it is specified in the X-XML-USER2 header with role booga and rax:roles disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("PUT", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("booga"),
+                                 "X-XML-USER2"->List(goodRepXML4.toString))),response, chain),
+        405, List("Bad Method","PUT"))
+    }
+
+    test(s"A POST on /a should succeed with good JSON 2 if it is specified in the X-JSON_USER header with role allowPUT and rax:roles disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/xml", goodRepXML5, true,
+        Map[String,List[String]]("X-ROLES"->List("allowPUT"),
+                                 "X-JSON-USER"->List(goodRepJSON2))),response, chain),
+        405, List("Bad Method","PUT","does not match","POST"))
+    }
+
+    test(s"A POST on /a should succeed with good JSON 2 if it is specified in the X-JSON_USER header (json) with roles bugga / allowPUT with rax:roles disabled $wadlDesc with $configDesc") {
+      assertResultFailed(validator.validate(request("POST", "/a", "application/json", goodRepJSON1, true,
+        Map[String,List[String]]("X-ROLES"->List("bugga", "allowPUT"),
+                                 "X-JSON-USER"->List(goodRepJSON2))),response, chain),
+        405, List("Bad Method","PUT","does not match","POST"))
+    }
+  }
+
+  //
+  //  With assertions disabled
+  //
+  for ((wadlDesc, wadl) <- repWADLs) {
+    for ((configDesc, config) <- repDisabledConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths(validator, wadlDesc, configDesc)
+      happyWhenRaxRepIsDisabled(validator, wadlDesc, configDesc)
+      happyWhenPlainParamsAreDisabled(validator, wadlDesc, configDesc)
+      happyWhenGrammarChecksAreDisabled(validator, wadlDesc, configDesc)
+      happyWhenRaxRolesAreDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+  //
+  //  With rax:rep enabled
+  //
+  for ((wadlDesc, wadl) <- repWADLs) {
+    for ((configDesc, config) <- repEnabledConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths(validator, wadlDesc, configDesc)
+      sadWhenRaxRepIsEnabled(validator, wadlDesc, configDesc)
+      happyWhenPlainParamsAreDisabled(validator, wadlDesc, configDesc)
+      happyWhenGrammarChecksAreDisabled(validator, wadlDesc, configDesc)
+      happyWhenRaxRolesAreDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+  //
+  //  With rax:rep, plain enabled
+  //
+  for ((wadlDesc, wadl) <- repWADLs) {
+    for ((configDesc, config) <- repEnabledPlainConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths(validator, wadlDesc, configDesc)
+      sadWhenRaxRepIsEnabled(validator, wadlDesc, configDesc)
+      sadWhenPlainParamsAreEnabled(validator, wadlDesc, configDesc)
+      happyWhenGrammarChecksAreDisabled(validator, wadlDesc, configDesc)
+      happyWhenRaxRolesAreDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+  //
+  //  With rax:rep, plain, grammars enabled
+  //
+  for ((wadlDesc, wadl) <- repWADLs) {
+    for ((configDesc, config) <- repEnabledPlainGrammarConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths(validator, wadlDesc, configDesc)
+      sadWhenRaxRepIsEnabled(validator, wadlDesc, configDesc)
+      sadWhenPlainParamsAreEnabled(validator, wadlDesc, configDesc)
+      sadWhenGrammarChecksAreEnabled(validator, wadlDesc, configDesc)
+      happyWhenRaxRolesAreDisabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+  //
+  //  With rax:rep, plain, grammars, rax:roles enabled
+  //
+  for ((wadlDesc, wadl) <- repWADLs) {
+    for ((configDesc, config) <- repEnabledPlainGrammarRolesConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths(validator, wadlDesc, configDesc)
+      sadWhenRaxRepIsEnabled(validator, wadlDesc, configDesc)
+      sadWhenPlainParamsAreEnabled(validator, wadlDesc, configDesc)
+      sadWhenGrammarChecksAreEnabled(validator, wadlDesc, configDesc)
+      sadWhenRaxRolesAreEnabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+  //
+  //  With rax:rep, plain enabled, grammars, rax:roles mask
+  //
+  for ((wadlDesc, wadl) <- repWADLs) {
+    for ((configDesc, config) <- repEnabledPlainGrammarRolesMaskConfigs) {
+      val validator = Validator(wadl, config)
+
+      happyPathAssertions(validator, wadlDesc, configDesc)
+      happySadPaths(validator, wadlDesc, configDesc)
+      sadWhenRaxRepIsEnabled(validator, wadlDesc, configDesc)
+      sadWhenPlainParamsAreEnabled(validator, wadlDesc, configDesc)
+      sadWhenGrammarChecksAreEnabled(validator, wadlDesc, configDesc)
+      sadWhenRaxRolesMaskAreEnabled(validator, wadlDesc, configDesc)
+    }
+  }
+
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/step/BaseStepSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/step/BaseStepSuite.scala
@@ -25,8 +25,11 @@ import com.github.fge.jsonschema.main.JsonSchemaFactory
 import com.github.fge.jsonschema.report.{ListReportProvider, LogLevel}
 import com.rackspace.com.papi.components.checker.BaseValidatorSuite
 import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.util.XMLParserPool._
 import com.rackspace.com.papi.components.checker.step.results.{BadMediaTypeResult, MismatchResult, Result}
 import com.rackspace.com.papi.components.checker.util.ObjectMapperPool
+
+import org.w3c.dom.Document
 
 import scala.xml._
 
@@ -42,6 +45,25 @@ class BaseStepSuite extends BaseValidatorSuite {
 
   val xsl1Templates = xsl1Factory.newTemplates (new StreamSource(getClass.getResourceAsStream("/xsl/testXSL1.xsl")))
   val xsl2Templates = xsl2Factory.newTemplates (new StreamSource(getClass.getResourceAsStream("/xsl/testXSL2.xsl")))
+
+  val EMPTY_DOC = {
+    val parser = borrowParser
+    try {
+      parser.newDocument
+    } finally {
+      returnParser(parser)
+    }
+  }
+
+  val EMPTY_JSON = {
+    var om : ObjectMapper = null
+    try {
+      om = ObjectMapperPool.borrowParser
+      om.readTree("null")
+    } finally {
+      if (om != null) ObjectMapperPool.returnParser(om)
+    }
+  }
 
 
   //

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/BaseCheckerSpec.scala
@@ -162,6 +162,22 @@ class BaseCheckerSpec extends BaseWADLSpec with LazyLogging {
     stepsWithType(checker, "CAPTURE_HEADER").filter( n => (n \ "@name").text == name).filter( n => (n \ "@path").text == expression)
   }
 
+  def stepsWithPushXML (checker : NodeSeq, expression : String) : NodeSeq = {
+    stepsWithType(checker, "PUSH_XML_REP").filter(n => (n \ "@path").text == expression)
+  }
+
+  def stepsWithPushXML (checker : NodeSeq, name : String, expression : String) : NodeSeq = {
+    stepsWithPushXML(checker, expression).filter(n => (n \ "@name").text == name)
+  }
+
+  def stepsWithPushJSON (checker : NodeSeq, expression : String) : NodeSeq = {
+    stepsWithType(checker, "PUSH_JSON_REP").filter(n => (n \ "@path").text == expression)
+  }
+
+  def stepsWithPushJSON (checker : NodeSeq, name : String, expression : String) : NodeSeq = {
+    stepsWithPushJSON(checker, expression).filter(n => (n \ "@name").text == name)
+  }
+
   def stepsWithMethodMatch (checker : NodeSeq, methodMatch  : String) : NodeSeq = {
     stepsWithMatch (checker, methodMatch).filter(n => (n \ "@type").text == "METHOD")
   }
@@ -405,6 +421,11 @@ class BaseCheckerSpec extends BaseWADLSpec with LazyLogging {
   def RaxAssert(expression : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithAssertCodeMatch(_, expression, code)
   def RaxAssert(expression : String, message : String, code : Int) : (NodeSeq) => NodeSeq = stepsWithAssertMessageCodeMatch(_, expression, message, code)
   def RaxCaptureHeader(name : String, expression : String) : (NodeSeq) => NodeSeq = stepsWithCaptureHeader(_, name, expression)
+  def RaxPopRep : (NodeSeq) => NodeSeq = stepsWithType(_, "POP_REP")
+  def RaxPushXML (expression : String) : (NodeSeq) => NodeSeq = stepsWithPushXML(_, expression)
+  def RaxPushXML (name : String, expression : String) : (NodeSeq) => NodeSeq = stepsWithPushXML(_, name, expression)
+  def RaxPushJSON (expression : String) : (NodeSeq) => NodeSeq = stepsWithPushJSON(_, expression)
+  def RaxPushJSON (name : String, expression : String) : (NodeSeq) => NodeSeq = stepsWithPushJSON(_, name, expression)
   def ReqType(reqType : String) : (NodeSeq) => NodeSeq = stepsWithReqTypeMatch (_, "(?i)"+reqType)
   def AnyReqType : (NodeSeq) => NodeSeq = stepsWithReqTypeMatch (_, "(.*)()")
   def HeaderWithCapture(name : String, headerMatch : String, captureHeader : String) : (NodeSeq) => NodeSeq = stepsWithHeaderMatchCapture(_, name, headerMatch, captureHeader)

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerRaxRepStepSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerRaxRepStepSpec.scala
@@ -1,0 +1,1402 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import com.rackspace.com.papi.components.checker.{LogAssertions, TestConfig}
+import org.apache.logging.log4j.Level
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml._
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerRaxRepStepSpec extends BaseCheckerSpec with LogAssertions {
+  //
+  //  Register some common prefixes, you'll need the for XPath
+  //  assertions.
+  //
+  register ("xsd", "http://www.w3.org/2001/XMLSchema")
+  register ("wadl","http://wadl.dev.java.net/2009/02")
+  register ("xsl","http://www.w3.org/1999/XSL/Transform")
+  register ("chk","http://www.rackspace.com/repose/wadl/checker")
+  register ("tst","http://www.rackspace.com/repose/wadl/checker/step/test")
+
+  //
+  //  Configs...
+  //
+  val raxRepDisabled = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = false
+    tc.removeDups = false
+    tc.checkPlainParams = false
+    tc.checkElements = false
+    tc
+  }
+
+  val raxRepEnabled = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = false
+    tc.checkPlainParams = true
+    tc.checkElements = true
+    tc
+  }
+
+  val raxRepEnabledRemoveDups = {
+    val tc = TestConfig()
+    tc.enableRaxRepresentationExtension = true
+    tc.removeDups = true
+    tc.checkPlainParams = true
+    tc.checkElements = true
+    tc
+  }
+
+
+  //
+  //  WADLs...
+  //
+  val raxRepAtRepresentationLevel =
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:tst="test.org">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/a">
+            <method name="PUT">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml">
+                        <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json"
+                            name="jsonContent">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                         </rax:representation>
+                         <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json2"
+                            name="jsonContent2">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                        </rax:representation>
+
+                    </representation>
+                    <representation mediaType="application/json">
+                        <param name="test" style="plain"
+                              path="$_?firstName" required="true"
+                              rax:message="Need a first name" rax:code="403"/>
+                        <rax:representation
+                            mediaType="application/xml"
+                            path="$body('xml')"
+                            name="xmlContent" element="tst2:user" xmlns:tst2="test.org/2"/>
+                    </representation>
+                </request>
+            </method>
+        </resource>
+    </resources>
+  </application>
+
+  val raxRepAtRepresentationMultiLevel =
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:tst="test.org">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/a">
+            <method name="PUT">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml">
+                        <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json"
+                            name="jsonContent">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                         </rax:representation>
+                         <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json2"
+                            name="jsonContent2">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                        </rax:representation>
+
+                    </representation>
+                    <representation mediaType="application/json">
+                        <param name="test" style="plain"
+                              path="$_?firstName" required="true"
+                              rax:message="Need a first name" rax:code="403"/>
+                        <rax:representation
+                            mediaType="application/xml"
+                            path="$body('xml')"
+                            name="xmlContent" element="tst2:user" xmlns:tst2="test.org/2">
+                          <rax:representation
+                              mediaType="application/json"
+                              path="/tst2:user/tst2:json">
+                               <param name="test3" style="plain"
+                                 path="$_?lastName" required="true"
+                                 rax:message="Need a first name" rax:code="403"/>
+                               />
+                          </rax:representation>
+                        </rax:representation>
+                    </representation>
+                </request>
+            </method>
+        </resource>
+    </resources>
+  </application>
+
+  val raxRepAtRepresentationMultiLevelAndMethodLevel =
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:tst="test.org">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/a">
+            <method name="PUT">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml">
+                        <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json"
+                            name="jsonContent">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                         </rax:representation>
+                         <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json2"
+                            name="jsonContent2">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                        </rax:representation>
+
+                    </representation>
+                    <representation mediaType="application/json">
+                        <param name="test" style="plain"
+                              path="$_?firstName" required="true"
+                              rax:message="Need a first name" rax:code="403"/>
+                        <rax:representation
+                            mediaType="application/xml"
+                            path="$body('xml')"
+                            name="xmlContent" element="tst2:user" xmlns:tst2="test.org/2">
+                          <rax:representation
+                              mediaType="application/json"
+                              path="/tst2:user/tst2:json">
+                               <param name="test3" style="plain"
+                                 path="$_?lastName" required="true"
+                                 rax:message="Need a last name" rax:code="403"/>
+                               />
+                          </rax:representation>
+                        </rax:representation>
+                    </representation>
+                </request>
+            </method>
+            <method name="POST">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml"/>
+                    <representation mediaType="application/json" />
+                    <representation mediaType="text/yaml"/>
+                    <rax:representation mediaType="application/json" name="jsonUser"
+                                        path="req:header('X-JSON-USER')">
+                        <param name="test3" style="plain"
+                               path="$_?firstName" required="true"
+                               rax:message="Need a first name"
+                               rax:code="403"/>
+                        <param name="test4" style="plain"
+                               path="$_?lastName" required="true"
+                               rax:message="Need a last name" rax:code="403"/>
+                    </rax:representation>
+                </request>
+           </method>
+        </resource>
+    </resources>
+  </application>
+
+  val raxRepAtRepresentationMultiLevelAndMethodResourceLevel =
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:tst="test.org">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/a">
+            <method name="PUT">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml">
+                        <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json"
+                            name="jsonContent">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                         </rax:representation>
+                         <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json2"
+                            name="jsonContent2">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                        </rax:representation>
+
+                    </representation>
+                    <representation mediaType="application/json">
+                        <param name="test" style="plain"
+                              path="$_?firstName" required="true"
+                              rax:message="Need a first name" rax:code="403"/>
+                        <rax:representation
+                            mediaType="application/xml"
+                            path="$body('xml')"
+                            name="xmlContent" element="tst2:user" xmlns:tst2="test.org/2">
+                          <rax:representation
+                              mediaType="application/json"
+                              path="/tst2:user/tst2:json">
+                               <param name="test3" style="plain"
+                                 path="$_?lastName" required="true"
+                                 rax:message="Need a last name" rax:code="403"/>
+                               />
+                          </rax:representation>
+                        </rax:representation>
+                    </representation>
+                </request>
+            </method>
+            <method name="POST">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml"/>
+                    <representation mediaType="application/json" />
+                    <representation mediaType="text/yaml"/>
+                    <rax:representation mediaType="application/json" name="jsonUser"
+                                        path="req:header('X-JSON-USER')">
+                        <param name="test3" style="plain"
+                               path="$_?firstName" required="true"
+                               rax:message="Need a first name"
+                               rax:code="403"/>
+                        <param name="test4" style="plain"
+                               path="$_?lastName" required="true"
+                               rax:message="Need a last name" rax:code="403"/>
+                    </rax:representation>
+                </request>
+            </method>
+            <resource path="b">
+                <method name="PUT">
+                    <request>
+                        <representation mediaType="application/xml" element="tst:other_xml"/>
+                        <representation mediaType="application/json" />
+                        <representation mediaType="text/yaml"/>
+                    </request>
+                </method>
+            </resource>
+            <rax:representation mediaType="application/xml" name="xmlUser"
+                                path="req:header('X-XML-USER')" element="tst:user">
+                <param name="test5" style="plain"
+                       path="tst:user/@firstName" required="true"
+                       rax:message="Need a first name"
+                       rax:code="403"/>
+                <param name="test6" style="plain"
+                       path="tst:user/@lastName" required="true"
+                       rax:message="Need a last name"
+                       rax:code="403"/>
+            </rax:representation>
+        </resource>
+    </resources>
+  </application>
+
+
+  val raxRepAtRepresentationMultiLevelAndMethodResourceLevelApplyChildrenFalse =
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:tst="test.org">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/a">
+            <method name="PUT">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml">
+                        <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json"
+                            name="jsonContent">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                         </rax:representation>
+                         <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json2"
+                            name="jsonContent2">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                        </rax:representation>
+
+                    </representation>
+                    <representation mediaType="application/json">
+                        <param name="test" style="plain"
+                              path="$_?firstName" required="true"
+                              rax:message="Need a first name" rax:code="403"/>
+                        <rax:representation
+                            mediaType="application/xml"
+                            path="$body('xml')"
+                            name="xmlContent" element="tst2:user" xmlns:tst2="test.org/2">
+                          <rax:representation
+                              mediaType="application/json"
+                              path="/tst2:user/tst2:json">
+                               <param name="test3" style="plain"
+                                 path="$_?lastName" required="true"
+                                 rax:message="Need a last name" rax:code="403"/>
+                               />
+                          </rax:representation>
+                        </rax:representation>
+                    </representation>
+                </request>
+            </method>
+            <method name="POST">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml"/>
+                    <representation mediaType="application/json" />
+                    <representation mediaType="text/yaml"/>
+                    <rax:representation mediaType="application/json" name="jsonUser"
+                                        path="req:header('X-JSON-USER')">
+                        <param name="test3" style="plain"
+                               path="$_?firstName" required="true"
+                               rax:message="Need a first name"
+                               rax:code="403"/>
+                        <param name="test4" style="plain"
+                               path="$_?lastName" required="true"
+                               rax:message="Need a last name" rax:code="403"/>
+                    </rax:representation>
+                </request>
+            </method>
+            <resource path="b">
+                <method name="PUT">
+                    <request>
+                        <representation mediaType="application/xml" element="tst:other_xml"/>
+                        <representation mediaType="application/json" />
+                        <representation mediaType="text/yaml"/>
+                    </request>
+                </method>
+            </resource>
+            <rax:representation mediaType="application/xml" name="xmlUser"
+                                path="req:header('X-XML-USER')" element="tst:user"
+                                applyToChildren="false">
+                <param name="test5" style="plain"
+                       path="tst:user/@firstName" required="true"
+                       rax:message="Need a first name"
+                       rax:code="403"/>
+                <param name="test6" style="plain"
+                       path="tst:user/@lastName" required="true"
+                       rax:message="Need a last name"
+                       rax:code="403"/>
+            </rax:representation>
+        </resource>
+    </resources>
+  </application>
+
+  val raxRepAtRepresentationMultiLevelAndMethodResourceLevelApplyChildrenTrue =
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:tst="test.org">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/a">
+            <method name="PUT">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml">
+                        <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json"
+                            name="jsonContent">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                         </rax:representation>
+                         <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json2"
+                            name="jsonContent2">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                        </rax:representation>
+
+                    </representation>
+                    <representation mediaType="application/json">
+                        <param name="test" style="plain"
+                              path="$_?firstName" required="true"
+                              rax:message="Need a first name" rax:code="403"/>
+                        <rax:representation
+                            mediaType="application/xml"
+                            path="$body('xml')"
+                            name="xmlContent" element="tst2:user" xmlns:tst2="test.org/2">
+                          <rax:representation
+                              mediaType="application/json"
+                              path="/tst2:user/tst2:json">
+                               <param name="test3" style="plain"
+                                 path="$_?lastName" required="true"
+                                 rax:message="Need a last name" rax:code="403"/>
+                               />
+                          </rax:representation>
+                        </rax:representation>
+                    </representation>
+                </request>
+            </method>
+            <method name="POST">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml"/>
+                    <representation mediaType="application/json" />
+                    <representation mediaType="text/yaml"/>
+                    <rax:representation mediaType="application/json" name="jsonUser"
+                                        path="req:header('X-JSON-USER')">
+                        <param name="test3" style="plain"
+                               path="$_?firstName" required="true"
+                               rax:message="Need a first name"
+                               rax:code="403"/>
+                        <param name="test4" style="plain"
+                               path="$_?lastName" required="true"
+                               rax:message="Need a last name" rax:code="403"/>
+                    </rax:representation>
+                </request>
+            </method>
+            <resource path="b">
+                <method name="PUT">
+                    <request>
+                        <representation mediaType="application/xml" element="tst:other_xml"/>
+                        <representation mediaType="application/json" />
+                        <representation mediaType="text/yaml"/>
+                    </request>
+                </method>
+            </resource>
+            <rax:representation mediaType="application/xml" name="xmlUser"
+                                path="req:header('X-XML-USER')" element="tst:user"
+                                applyToChildren="true">
+                <param name="test5" style="plain"
+                       path="tst:user/@firstName" required="true"
+                       rax:message="Need a first name"
+                       rax:code="403"/>
+                <param name="test6" style="plain"
+                       path="tst:user/@lastName" required="true"
+                       rax:message="Need a last name"
+                       rax:code="403"/>
+            </rax:representation>
+        </resource>
+    </resources>
+  </application>
+
+
+  val raxRepAtRepresentationMultiLevelAndMethodResourceAndResourcesLevel =
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:tst="test.org">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/a">
+            <method name="PUT">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml">
+                        <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json"
+                            name="jsonContent">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                         </rax:representation>
+                         <rax:representation
+                            mediaType="application/json"
+                            path="/tst:some_xml/tst:json2"
+                            name="jsonContent2">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                        </rax:representation>
+
+                    </representation>
+                    <representation mediaType="application/json">
+                        <param name="test" style="plain"
+                              path="$_?firstName" required="true"
+                              rax:message="Need a first name" rax:code="403"/>
+                        <rax:representation
+                            mediaType="application/xml"
+                            path="$body('xml')"
+                            name="xmlContent" element="tst2:user" xmlns:tst2="test.org/2">
+                          <rax:representation
+                              mediaType="application/json"
+                              path="/tst2:user/tst2:json">
+                               <param name="test3" style="plain"
+                                 path="$_?lastName" required="true"
+                                 rax:message="Need a last name" rax:code="403"/>
+                               />
+                          </rax:representation>
+                        </rax:representation>
+                    </representation>
+                </request>
+            </method>
+            <method name="POST">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml"/>
+                    <representation mediaType="application/json" />
+                    <representation mediaType="text/yaml"/>
+                    <rax:representation mediaType="application/json" name="jsonUser"
+                                        path="req:header('X-JSON-USER')">
+                        <param name="test3" style="plain"
+                               path="$_?firstName" required="true"
+                               rax:message="Need a first name"
+                               rax:code="403"/>
+                        <param name="test4" style="plain"
+                               path="$_?lastName" required="true"
+                               rax:message="Need a last name" rax:code="403"/>
+                    </rax:representation>
+                </request>
+            </method>
+            <resource path="b">
+                <method name="PUT">
+                    <request>
+                        <representation mediaType="application/xml" element="tst:other_xml"/>
+                        <representation mediaType="application/json" />
+                        <representation mediaType="text/yaml"/>
+                    </request>
+                </method>
+            </resource>
+            <rax:representation mediaType="application/xml" name="xmlUser"
+                                path="req:header('X-XML-USER')" element="tst:user">
+                <param name="test5" style="plain"
+                       path="tst:user/@firstName" required="true"
+                       rax:message="Need a first name"
+                       rax:code="403"/>
+                <param name="test6" style="plain"
+                       path="tst:user/@lastName" required="true"
+                       rax:message="Need a last name"
+                       rax:code="403"/>
+            </rax:representation>
+        </resource>
+        <rax:representation mediaType="application/xml" name="xmlUser"
+                            path="req:header('X-XML-USER2')" element="tst:user2">
+            <param name="test5" style="plain"
+                   path="tst:user2/@fn" required="true"
+                   rax:message="Need a first name"
+                   rax:code="403"/>
+            <param name="test6" style="plain"
+                   path="tst:user2/@ln" required="true"
+                   rax:message="Need a last name"
+                   rax:code="403"/>
+        </rax:representation>
+    </resources>
+  </application>
+
+
+  val raxRepAtRepresentationMultiLevelAndMethodResourceApplyChildrenTrueAndResourcesLevel =
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:tst="test.org">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/a">
+            <method name="PUT">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml">
+                        <rax:representation
+                            mediaType="application/myApp+json"
+                            path="/tst:some_xml/tst:json"
+                            name="jsonContent">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                         </rax:representation>
+                         <rax:representation
+                            mediaType="application/myApp+json"
+                            path="/tst:some_xml/tst:json2"
+                            name="jsonContent2">
+                            <param name="test" style="plain"
+                                   path="$_?firstName" required="true"
+                                   rax:message="Need a first name" rax:code="403"/>
+                        </rax:representation>
+
+                    </representation>
+                    <representation mediaType="application/json">
+                        <param name="test" style="plain"
+                              path="$_?firstName" required="true"
+                              rax:message="Need a first name" rax:code="403"/>
+                        <rax:representation
+                            mediaType="application/myApp+xml"
+                            path="$body('xml')"
+                            name="xmlContent" element="tst2:user" xmlns:tst2="test.org/2">
+                          <rax:representation
+                              mediaType="application/myApp+json"
+                              path="/tst2:user/tst2:json">
+                               <param name="test3" style="plain"
+                                 path="$_?lastName" required="true"
+                                 rax:message="Need a last name" rax:code="403"/>
+                               />
+                          </rax:representation>
+                        </rax:representation>
+                    </representation>
+                </request>
+            </method>
+            <method name="POST">
+                <request>
+                    <representation mediaType="application/xml" element="tst:some_xml"/>
+                    <representation mediaType="application/json" />
+                    <representation mediaType="text/yaml"/>
+                    <rax:representation mediaType="application/myApp+json" name="jsonUser"
+                                        path="req:header('X-JSON-USER')">
+                        <param name="test3" style="plain"
+                               path="$_?firstName" required="true"
+                               rax:message="Need a first name"
+                               rax:code="403"/>
+                        <param name="test4" style="plain"
+                               path="$_?lastName" required="true"
+                               rax:message="Need a last name" rax:code="403"/>
+                    </rax:representation>
+                </request>
+            </method>
+            <resource path="b">
+                <method name="PUT">
+                    <request>
+                        <representation mediaType="application/xml" element="tst:other_xml"/>
+                        <representation mediaType="application/json" />
+                        <representation mediaType="text/yaml"/>
+                    </request>
+                </method>
+            </resource>
+            <rax:representation mediaType="application/MyApp+xml" name="xmlUser"
+                                path="req:header('X-XML-USER')" element="tst:user"
+                                applyToChildren="true">
+                <param name="test5" style="plain"
+                       path="tst:user/@firstName" required="true"
+                       rax:message="Need a first name"
+                       rax:code="403"/>
+                <param name="test6" style="plain"
+                       path="tst:user/@lastName" required="true"
+                       rax:message="Need a last name"
+                       rax:code="403"/>
+            </rax:representation>
+        </resource>
+        <rax:representation mediaType="application/myApp+xml" name="xmlUser"
+                            path="req:header('X-XML-USER2')" element="tst:user2">
+            <param name="test5" style="plain"
+                   path="tst:user2/@fn" required="true"
+                   rax:message="Need a first name"
+                   rax:code="403"/>
+            <param name="test6" style="plain"
+                   path="tst:user2/@ln" required="true"
+                   rax:message="Need a last name"
+                   rax:code="403"/>
+        </rax:representation>
+    </resources>
+  </application>
+
+
+  feature ("The WADLCheckerBuilder can correctly transform a WADL into checker format") {
+
+    info ("As a developer")
+    info ("I want to be able to transform a WADL which references rax:representation extensions into a ")
+    info ("a description of a machine that can validate the API in checker format")
+    info ("so that an API validator can process validate representations in different areas of the request")
+
+    scenario ("The WADL contains a misplaced rax:representation") {
+      Given("A WADL with a misplaced rax:representation")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+         <resources base="https://test.api.openstack.com">
+           <resource path="/a/b">
+               <method name="POST">
+                  <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                  </request>
+                  <!-- Notice the representation at method level, but not request level -->
+                  <rax:representation
+                       mediaType="application/xml"
+                       path="$body('xml')"
+                       name="xmlContent">
+                       <param name="test" style="plain"
+                              path="/firstName" required="true"
+                              rax:message="Need a first name" rax:code="403"/>
+                  </rax:representation>
+               </method>
+            </resource>
+           </resources>
+          </application>
+
+      When("the wadl is translated")
+      val checkerLog = log (Level.WARN) {
+        val checker = builder.build (inWADL, raxRepEnabled)
+        Then("No push or pop reqs should exist in the checker format")
+        assert(checker,"count(/chk:checker/chk:step[@type=('PUSH_XML_REP','PUSH_JSON_REP','POP_REP')]) = 0")
+      }
+      And ("There should be a warning in the log that denotes that denotes the bad placement")
+      assert(checkerLog, "bad placement for <rax:representation")
+    }
+
+    scenario ("The WADL contains a rax:representation with unsupported media type") {
+      Given("A WADL with an unsupported media type")
+      val inWADL =
+        <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api">
+            <resources base="https://test.api.openstack.com">
+                <resource path="/a/b">
+                    <method name="POST">
+                        <request>
+                            <representation mediaType="application/xml"/>
+                            <representation mediaType="application/json"/>
+                            <!--
+                                Note that YAML is not a supported mediaType!
+                            -->
+                            <rax:representation
+                                mediaType="text/yaml"
+                                path="$body('xml')"
+                                name="xmlContent">
+                                <param name="test" style="plain"
+                                       path="/firstName" required="true"
+                                       rax:message="Need a first name" rax:code="403"/>
+                            </rax:representation>
+                        </request>
+                    </method>
+                </resource>
+            </resources>
+        </application>
+
+      When("the wadl is translated")
+      val checkerLog = log (Level.ERROR) {
+        Then("A WADLException is thrown")
+        intercept[WADLException] {
+          val checker = builder.build (inWADL, raxRepEnabled)
+        }
+      }
+      And ("There should be an error in the log that denotes that the mediatype is not supported")
+      assert(checkerLog, "Only XML and JSON mediaTypes are allowed")
+    }
+
+    scenario ("The WADL contains rax:rep at the representation level (rax:representation disabled)") {
+      Given("A WADL with rax:representation at the representation level, but rax:representation disabled")
+      val inWADL = raxRepAtRepresentationLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepDisabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type=('PUSH_XML_REP','PUSH_JSON_REP','POP_REP')]) = 0")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation level (rax:representation enabled)") {
+      Given("A WADL with rax:representation at the representation level, but rax:representation enabled")
+      val inWADL = raxRepAtRepresentationLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 1")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 2")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 2")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@match,'tst:')]) = 'tst'")
+      assert(checker, "namespace-uri-for-prefix('tst', /chk:checker/chk:step[contains(@match,'tst:')]) = 'test.org'")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@match,'tst2:')]) = 'tst2'")
+      assert(checker, "namespace-uri-for-prefix('tst2', /chk:checker/chk:step[contains(@match,'tst2:')]) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPopRep, Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation level (rax:representation enabled, removeDups enabled)") {
+      Given("A WADL with rax:representation at the representation level, but rax:representation enabled, removeDups enabled")
+      val inWADL = raxRepAtRepresentationLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 1")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 2")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 1")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@match,'tst:')]) = 'tst'")
+      assert(checker, "namespace-uri-for-prefix('tst', /chk:checker/chk:step[contains(@match,'tst:')]) = 'test.org'")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@match,'tst2:')]) = 'tst2'")
+      assert(checker, "namespace-uri-for-prefix('tst2', /chk:checker/chk:step[contains(@match,'tst2:')]) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPopRep, Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels (rax:representation enabled)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, but rax:representation enabled")
+      val inWADL = raxRepAtRepresentationMultiLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 1")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 3")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 3")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@match,'tst:')]) = 'tst'")
+      assert(checker, "namespace-uri-for-prefix('tst', /chk:checker/chk:step[contains(@match,'tst:')]) = 'test.org'")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@match,'tst2:')]) = 'tst2'")
+      assert(checker, "namespace-uri-for-prefix('tst2', /chk:checker/chk:step[contains(@match,'tst2:')]) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels (rax:representation enabled, removeDups enabled)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, but rax:representation enabled, removeDups enabled")
+      val inWADL = raxRepAtRepresentationMultiLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 1")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 3")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 2")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@match,'tst:')]) = 'tst'")
+      assert(checker, "namespace-uri-for-prefix('tst', /chk:checker/chk:step[contains(@match,'tst:')]) = 'test.org'")
+      assert(checker, "in-scope-prefixes(/chk:checker/chk:step[contains(@match,'tst2:')]) = 'tst2'")
+      assert(checker, "namespace-uri-for-prefix('tst2', /chk:checker/chk:step[contains(@match,'tst2:')]) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels and at method with multiple reps (rax:representation enabled)") {
+      Given("A WADL with rax:representation at the representation at multiple levels and at method with multiple reps but rax:representation enabled")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 1")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 6")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 6")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels and at method with multiple reps (rax:representation enabled, romoveDupsEnabled)") {
+      Given("A WADL with rax:representation at the representation at multiple levels and at method with multiple reps but rax:representation enabled, removeDupsEnabled")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 1")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 4")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 2")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels, at method with multiple reps, and at the resource level (rax:representation enabled)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, method with multiple reps, and at the resource level  but rax:representation enabled")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodResourceLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 6")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 6")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 6")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels, at method with multiple reps, and at the resource level (rax:representation enabled, removeDups)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, method with multiple reps, and at the resource level  but rax:representation enabled, removeDups")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodResourceLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 2")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 4")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 2")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels, at method with multiple reps, and at the resource level, applyChildrenFalse  (rax:representation enabled)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, method with multiple reps, and at the resource level, applyChlidrenFalse but rax:representation enabled")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodResourceLevelApplyChildrenFalse
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 6")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 6")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 6")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels, at method with multiple reps, and at the resource level, applyChildrenFalse (rax:representation enabled, removeDups)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, method with multiple reps, and at the resource level, applyChildredFalse  but rax:representation enabled, removeDups")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodResourceLevelApplyChildrenFalse
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 2")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 4")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 2")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels, at method with multiple reps, and at the resource level, applyChildrenTrue  (rax:representation enabled)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, method with multiple reps, and at the resource level, applyChlidrenTrue but rax:representation enabled")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodResourceLevelApplyChildrenTrue
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 9")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 6")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 9")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels, at method with multiple reps, and at the resource level, applyChildrenTrue (rax:representation enabled, removeDups)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, method with multiple reps, and at the resource level, applyChildredTrue  but rax:representation enabled, removeDups")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodResourceLevelApplyChildrenTrue
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 2")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 4")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 2")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels, at method with multiple reps, and at the resource level, and resources level  (rax:representation enabled)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, method with multiple reps, and at the resource level, and resources level but rax:representation enabled")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodResourceAndResourcesLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 14")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 6")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 9")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels, at method with multiple reps, and at the resource level, and resources level  (rax:representation enabled, removeDups)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, method with multiple reps, and at the resource level, and resources level but rax:representation enabled, removeDups")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodResourceAndResourcesLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 3")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 4")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 2")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels, at method with multiple reps, and at the resource level, and resources level applyChildren  (rax:representation enabled)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, method with multiple reps, and at the resource level, and resources level applyChildren but rax:representation enabled")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodResourceApplyChildrenTrueAndResourcesLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabled)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 17")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 6")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 9")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+    }
+
+    scenario ("The WADL contains rax:rep at the representation at multiple levels, at method with multiple reps, and at the resource level, and resources level applyChildren  (rax:representation enabled, removeDups)") {
+      Given("A WADL with rax:representation at the representation at multiple levels, method with multiple reps, and at the resource level, and resources level applyChildren but rax:representation enabled, removeDups")
+      val inWADL = raxRepAtRepresentationMultiLevelAndMethodResourceApplyChildrenTrueAndResourcesLevel
+      When("the wadl is translated")
+      val checker = builder.build (inWADL, raxRepEnabledRemoveDups)
+      Then ("The following assertions should hold")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_XML_REP']) = 3")
+      assert(checker,"count(/chk:checker/chk:step[@type='PUSH_JSON_REP']) = 4")
+      assert(checker,"count(/chk:checker/chk:step[@type='POP_REP']) = 2")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies in-scope-prefixes($s) = 'tst'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst:')] satisfies namespace-uri-for-prefix('tst', $s) = 'test.org'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies in-scope-prefixes($s) = 'tst2'")
+      assert(checker, "every $s in /chk:checker/chk:step[contains(@match,'tst2:')] satisfies namespace-uri-for-prefix('tst2', $s) = 'test.org/2'")
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent","/tst:some_xml/tst:json"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonContent2","/tst:some_xml/tst:json2"),
+        JsonXPath("$_?firstName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlContent", "$body('xml')"),
+        XPath("/tst2:user"), RaxPushJSON("/tst2:user/tst2:json"), JsonXPath("$_?lastName"), RaxPopRep, RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, JsonXPath("$_?firstName"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushJSON("jsonUser","req:header('X-JSON-USER')"),
+        JsonXPath("$_?firstName"), JsonXPath("$_?lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:some_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), Method("POST"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER2')"),
+        XPath("/tst:user2"), XPath("tst:user2/@fn"), XPath("tst:user2/@ln"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/xml)(;.*)?"), WellXML, XPath("/tst:other_xml"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(application/json)(;.*)?"), WellJSON, RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+      assert(checker, Start, URL("a"), URL("b"), Method("PUT"), ReqType("(text/yaml)(;.*)?"), RaxPushXML("xmlUser","req:header('X-XML-USER')"),
+        XPath("/tst:user"), XPath("tst:user/@firstName"), XPath("tst:user/@lastName"), RaxPopRep, Accept)
+    }
+
+  }
+}


### PR DESCRIPTION
Allow a representation within a representation. This is a sub representation.

````xml
<wadl:representation mediaType="application/xml" >
     <rax:representation mediaType="application/json" path="/path/to/json" name="embeddedjson">
        <wadl:param style="plain" path="$_?name='foo'" /> 
      </rax:representation> 
</wadl:representation>
````

In the example above json is in XML at /path/to/json.

The following rules will apply:

1. ```rax:represantation``` can only live inside a ```wadl:representation``` or another ```rax:representation``` -- notice ```rax:``` instead of ```wadl:``` this is because wadl doesn't allow sub-representation -- it's an extension.
2. works exactly like wadl:representation  all features of representation are supported:
     1. plain parameters
     2. XSD / JSON Schema check
     3. Assertions
     4. Catpture header
3. Changes made to a subrepresntation are not carried over to the origin service...this will be handled in another PR.
4.  Only XML and JSON representations are supported...other mediaTypes are ignored.

