### PR TITLE
Extends rax:roles extensions to implement multi-tenant check.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,8 @@
 # Releases #
 ## In Progress Work ##
 1. Added support for ```rax:representation```, this works like ```wadl:representation``` in that it can make assertions about XML, JSON representations. With ```rax:representation```, the representation may be embedded in another representation (JSON in XML), or in a header.
+1. Added support for multi-tenant role checks to rax:roles. These checks follow the pattern ```rolename/{tenantId}``` in ```rax:roles``` where ```rolename``` is the name of the role and ```tenantId``` is the name of a Header, Plain (Body), Template (URL), or CaptureHeader WADL parameter that captures the tenant.
+   1. Added support for ```rax:isTenant```, this can be specified on a Header, Plain (Body), Tempalte (URL), or CaptureHeader parameter to denote that it is a tenant. This feature is used internally by rax:roles internally to achieve multi-tenant checks.
 
 ## Release 2.5.1 (2017-10-24) ##
 1. Fixed a bug where the removeDups opt sometimes created checkers with missing states.

--- a/TODO.org
+++ b/TODO.org
@@ -897,6 +897,34 @@
          9. [X] JoinOpt
          10. [X] RemoveDups
 ** DONE Compile Performance improvements
+** DONE Extend Support for Capture Header to support standalone element [2/2]
+   1. [X] Add CaptureHeader Step [10/10]
+      1. [X] Extend XSD to support New Capture Header Step
+      2. [X] Extend / Generalize raxAssert.xsl to handle new Capture
+         Header Step
+      3. [X] Updated raxAssert call in checker builder
+      4. [X] Update builder to include Capture Header Step [3/3]
+         1. [X] Handle in method / request
+         2. [X] In representation other than XML or JSON :
+            (wadl:request/wadl:representation[@mediaType] template)
+         3. [X] In representation with XML or JSON (in
+            check:addWellForm template)
+      5. [X] Add step to priority map
+      6. [X] Check assertions related to capture header step
+      7. [X] Update WADL2Dot to display steps correctly
+      8. [X] Ensure optimizations work with the new step
+      9. [X] Create new step
+      10. [X] Update handler for new step
+   2. [X] Testing [3/3]
+      1. [X] Step
+      2. [X] Bulider
+      3. [X] Validator [6/6]
+         1. [X] At resources level
+         2. [X] At resource level
+         3. [X] At method level
+         4. [X] No representation
+         5. [X] XML / JSON representation
+         6. [X] Media types other than XML or JSON
 ** DONE SubRepresentations[2/2]
    1. [X] Push Representation step [13/13]
       1. [X] Extend XSD to support Push Rep step / Pop Rep step
@@ -984,34 +1012,168 @@
       - AFTER_SUB gets all sub representations as parameters.  Name can
         be used to identify them, else they are passed by number (in an
         array? or map?)
-** TODO Extend Support for Capture Header to support standalone element [2/2]
-   1. [X] Add CaptureHeader Step [10/10]
-      1. [X] Extend XSD to support New Capture Header Step
-      2. [X] Extend / Generalize raxAssert.xsl to handle new Capture
-         Header Step
-      3. [X] Updated raxAssert call in checker builder
-      4. [X] Update builder to include Capture Header Step [3/3]
-         1. [X] Handle in method / request
-         2. [X] In representation other than XML or JSON :
-            (wadl:request/wadl:representation[@mediaType] template)
-         3. [X] In representation with XML or JSON (in
-            check:addWellForm template)
-      5. [X] Add step to priority map
-      6. [X] Check assertions related to capture header step
-      7. [X] Update WADL2Dot to display steps correctly
-      8. [X] Ensure optimizations work with the new step
-      9. [X] Create new step
-      10. [X] Update handler for new step
-   2. [X] Testing [3/3]
-      1. [X] Step
-      2. [X] Bulider
-      3. [X] Validator [6/6]
-         1. [X] At resources level
-         2. [X] At resource level
-         3. [X] At method level
-         4. [X] No representation
-         5. [X] XML / JSON representation
-         6. [X] Media types other than XML or JSON
+** TODO Support tenant based role check[2/3]
+   1. [X] Support RAX-Roles [16/16]
+      1. [X] Extend state machine to support checkTenant flag (XSD).
+      2. [X] Create tenantChecker util.
+      3. [X] Support multiple tenant values in tenantChecker.
+      4. [X] Add support for checkTenant flag in steps[12/12]
+         1. [X] XPath
+         2. [X] JSONXPath
+         3. [X] URI
+         4. [X] URIXSD
+         5. [X] HEADER
+         6. [X] HEADERXSD
+         7. [X] HEADER_SINGLE
+         8. [X] HEADERXSD_SINGLE
+         9. [X] HEADER_ANY
+         10. [X] HEADERXSD_ANY
+         11. [X] HEADER_ALL
+         12. [X] CAPTURE_HEADER
+      5. [X] Modify step handler to load isTenant  flag correctly[12/12]
+         1. [X] XPath
+         2. [X] JSONXPath
+         3. [X] URI
+         4. [X] URIXSD
+         5. [X] HEADER
+         6. [X] HEADERXSD
+         7. [X] HEADER_SINGLE
+         8. [X] HEADERXSD_SINGLE
+         9. [X] HEADER_ANY
+         10. [X] HEADERXSD_ANY
+         11. [X] HEADER_ALL
+         12. [X] CAPTURE_HEADER
+      6. [X] Modify builder to ensure param name is always captured (as label) [12/12]
+         1. [X] XPath
+         2. [X] JSONXPath
+         3. [X] URI
+         4. [X] URIXSD
+         5. [X] HEADER
+         6. [X] HEADERXSD
+         7. [X] HEADER_SINGLE
+         8. [X] HEADERXSD_SINGLE
+         9. [X] HEADER_ANY
+         10. [X] HEADERXSD_ANY
+         11. [X] HEADER_ALL
+         12. [X] CAPTURE_HEADER
+      7. [X] Make sure that wadl2dot works with new labeled steps
+      8. [X] Damn it.  Use "name" instead of label [12/12]
+         1. [X] XPath
+         2. [X] JSONXPath
+         3. [X] URI
+         4. [X] URIXSD
+         5. [X] HEADER
+         6. [X] HEADERXSD
+         7. [X] HEADER_SINGLE
+         8. [X] HEADERXSD_SINGLE
+         9. [X] HEADER_ANY
+         10. [X] HEADERXSD_ANY
+         11. [X] HEADER_ALL
+         12. [X] CAPTURE_HEADER
+      9. [X] Look over wadl2dot to make sure things work.
+      10. [X] Modify builder to correctly capture isTenant flag[12/12]
+          1. [X] XPath
+          2. [X] JSONXPath
+          3. [X] URI
+          4. [X] URIXSD
+          5. [X] HEADER
+          6. [X] HEADERXSD
+          7. [X] HEADER_SINGLE
+          8. [X] HEADERXSD_SINGLE
+          9. [X] HEADER_ANY
+          10. [X] HEADERXSD_ANY
+          11. [X] HEADER_ALL
+          12. [X] CAPTURE_HEADER
+      11. [X] Ensure that new steps take isTenant and name into
+          account when handling optimizations
+      12. [X] Make sure opts copy over isTenant [4/4]
+          1. [X] Header Join : Works!
+          2. [X] Common Join : Works!
+          3. [X] Remove Dups : Works!
+          4. [X] XPath Join : Should not join if isTenant=true
+      13. [X] Add config option for isTenant extension [5/5]
+          1. [X] Implement config option
+          2. [X] Enable support in builder
+          3. [X] Fix checker tests to include approprate configs
+          4. [X] Add checker tests to check the flag works
+          5. [X] Add flag to cli tools [3/3]
+             1. [X] wadl2checker
+             2. [X] wadl2dot
+             3. [X] wadltest
+      14. [X] Ensure that HEADER_ANY header checks can occur after other isTenant params [5/5]
+          1. [X] URL, URLXSD
+          2. [X] XPATH, JSONXPATH
+          3. [X] CAPTURE_HEADER
+          4. [X] HEADER_ALL
+          5. [X] HEADER_SINGLE, HEADERXSD_SINGLE, HEADER, HEADERXSD,
+             HEADER_ANY, HEADERXSD_ANY
+      15. [X] Modify rax:roles to correctly handle role/{param} [5/5]
+          1. [X] Should support all supported param types
+          2. [X] Ensure header any check occurs after other params
+          3. [X] Should error check param
+          4. [X] Hint to builder to set handleTenant flag by setting rax:isTenant.
+          5. [X] Initial fail if mask raxroles
+      16. [X] Rewrite params that can handle multiple tenant match [3/3]
+          1. [X] Should be able to take allowed matches into account [7/7]
+             1. [X] XSD Changes
+             2. [X] Opt changes
+             3. [X] TenantUtil changes (test updates)
+             4. [X] Step Changes (test updates)
+             5. [X] Load Handler changes
+             6. [X] Dot changes
+             7. [X] Cleanup RAX templates.
+          2. [X] Transform to move items to place [2/2]
+             1. [X] Stage 1 : copy steps after Method
+             2. [X] Add allowed Roles
+          3. [X] Regression...
+   2. [X] Test for setup and RAX-ROLES [9/9]
+      1. [X] Get/set mapped roles on checker servlet request
+      2. [X] TenantUtil addTenantRoles
+      3. [X] TenantUtil addTenantRoles (multi-value)
+      4. [X] Test checkTenant flags in steps [12/12]
+         1. [X] XPath
+         2. [X] JSONXPath
+         3. [X] URI
+         4. [X] URIXSD
+         5. [X] HEADER_SINGLE
+         6. [X] HEADERXSD_SINGLE
+         7. [X] HEADER
+         8. [X] HEADERXSD
+         9. [X] HEADER_ANY
+         10. [X] HEADERXSD_ANY
+         11. [X] HEADER_ALL
+         12. [X] CAPTURE_HEADER
+      5. [X] Test checkTenant falgs (multi-value)
+      6. [X] Test isTenant in checker
+      7. [X] Test that step names in checker
+      8. [X] Validator Tests[9/9]
+         1. [X] URL, URLXSD
+         2. [X] XPATH, JSON_XPATH
+         3. [X] CAPTURE_HEADER at method level
+         4. [X] CAPTURE_HEADER at resource level
+         5. [X] CAPTURE_HEADER at resources level
+         6. [X] HEADER (Single, Any, All) at method level
+         7. [X] HEADER (Single, Any, All) at resource level
+         8. [X] Test to check releveant roles
+         9. [X] Test role with spaces
+      9. [X] Builder Tests[2/2]
+         1. [X] Fail scenarios[2/2]
+            1. [X] Mask Rax-Roles enabled
+            2. [X] Missing Param
+         2. [X] Other misc[2/2]
+            1. [X] Test param with \ in the role name.
+            2. [X] Test roles with spaces
+   3. [ ] Support RAX-Roles mask[0/0]
+*** Notes
+    The idea is that one can specify any WADL param as the tenant. RAX
+    roles can then be specified in the form role/{param}, which means
+    the method requires role on the teant specified by the param.
+
+    All param types should work.  For now, however, that means header,
+    URI, and plain.
+
+    There are two main chunks of work because this should support
+    RAX-ROLES and RAX-ROLES Mask.
 ** TODO Use Saxon Compile Lib feature to compile shared module.
    - This requires Saxon-EEQ
 ** TODO Assign CONTENT_FAIL to XSL steps in builder

--- a/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
+++ b/cli/wadl2checker/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Checker.scala
@@ -69,6 +69,9 @@ object Wadl2Checker {
     val raxRoles = parser.flag[Boolean] (List("r", "rax-roles"),
                                          "Enable Rax-Roles extension. Default: false")
 
+    val raxIsTenant = parser.flag[Boolean] (List("T", "rax-is-tenant"),
+                                         "Enable Rax-Is-Tenant extension. Default: false")
+
     val raxRepresentation = parser.flag[Boolean] (List("R", "disable-rax-representation"),
                                          "Disable Rax-Representation extension. Default: false")
 
@@ -168,6 +171,7 @@ object Wadl2Checker {
 
         c.removeDups = removeDups.value.getOrElse(false)
         c.enableRaxRolesExtension = raxRoles.value.getOrElse(false)
+        c.enableRaxIsTenantExtension = raxIsTenant.value.getOrElse(false)
         c.enableRaxRepresentationExtension = !raxRepresentation.value.getOrElse(false)
         c.maskRaxRoles403 = raxRolesMask403.value.getOrElse(false)
         c.enableAuthenticatedByExtension = authenticatedBy.value.getOrElse(false)

--- a/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
+++ b/cli/wadl2dot/src/main/scala/com/rackspace/com/papi/components/checker/cli/Wadl2Dot.scala
@@ -70,6 +70,9 @@ object Wadl2Dot {
     val raxRoles = parser.flag[Boolean] (List("r", "rax-roles"),
                                          "Enable Rax-Roles extension. Default: false")
 
+    val raxIsTenant = parser.flag[Boolean] (List("T", "rax-is-tenant"),
+                                         "Enable Rax-Is-Tenant extension. Default: false")
+
     val raxRepresentation = parser.flag[Boolean] (List("R", "disable-rax-representation"),
                                          "Disable Rax-Representation extension. Default: false")
 
@@ -175,6 +178,7 @@ object Wadl2Dot {
 
         c.removeDups = removeDups.value.getOrElse(false)
         c.enableRaxRolesExtension = raxRoles.value.getOrElse(false)
+        c.enableRaxIsTenantExtension = raxIsTenant.value.getOrElse(false)
         c.enableRaxRepresentationExtension = !raxRepresentation.value.getOrElse(false)
         c.maskRaxRoles403 = raxRolesMask403.value.getOrElse(false)
         c.enableAuthenticatedByExtension = authenticatedBy.value.getOrElse(false)

--- a/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
+++ b/cli/wadltest/src/main/scala/com/rackspace/com/papi/components/checker/cli/WadlTest.scala
@@ -47,6 +47,9 @@ object WadlTest {
   val raxRoles = parser.flag[Boolean] (List("r", "rax-roles"),
                                          "Enable Rax-Roles extension. Default: false")
 
+  val raxIsTenant = parser.flag[Boolean] (List("T", "rax-is-tenant"),
+                                         "Enable Rax-Is-Tenant extension. Default: false")
+
   val raxRolesMask403 = parser.flag[Boolean] (List("M", "rax-roles-mask-403s"),
                                               "When Rax-Roles is enable mask 403 errors with 404 or 405s. Default: false")
 
@@ -275,6 +278,7 @@ object WadlTest {
 
         c.removeDups = removeDups.value.getOrElse(false)
         c.enableRaxRolesExtension = raxRoles.value.getOrElse(false)
+        c.enableRaxIsTenantExtension = raxIsTenant.value.getOrElse(false)
         c.enableRaxRepresentationExtension = !raxRepresentation.value.getOrElse(false)
         c.maskRaxRoles403 = raxRolesMask403.value.getOrElse(false)
         c.enableAuthenticatedByExtension = authenticatedBy.value.getOrElse(false)

--- a/core/src/main/resources/xq/assert.xq
+++ b/core/src/main/resources/xq/assert.xq
@@ -24,7 +24,8 @@ declare %private variable $req:__JSON__    as map(*)? external;
 declare %private variable $req:__REQUEST__ as map(*) external;
 declare %private variable $req:__CONTEXT__ as map(*) external;
 
-declare variable $req:_           := if (not(empty($req:__JSON__))) then $req:__JSON__ else /;
+declare variable $req:_           := if (not(empty($req:__JSON__))) then $req:__JSON__ else
+                                     if (not(empty(/element()))) then (/) else ();
 declare variable $req:body        := $req:_;
 declare variable $req:method      := $req:__REQUEST__?method;
 declare variable $req:uri         := $req:__REQUEST__?uri;

--- a/core/src/main/resources/xsd/checker.xsd
+++ b/core/src/main/resources/xsd/checker.xsd
@@ -55,16 +55,29 @@
         <attribute name="code" type="xsd:int" use="optional"/>
     </attributeGroup>
 
-    <attributeGroup name="ToRequestHeaderAttributes">
+    <attributeGroup name="RequestParamAttributes">
         <annotation>
             <documentation xmlns:html="http://www.w3.org/1999/xhtml">
                 <html:p>
-                    Attributes used by steps that support the
-                    toRequestHeader extension.
+                    Attributes used by steps that implement WADL
+                    request parameters.
                 </html:p>
             </documentation>
         </annotation>
         <attribute name="captureHeader" type="xsd:string" use="optional"/>
+        <attribute name="isTenant" type="xsd:boolean" use="optional" default="false"/>
+    </attributeGroup>
+
+    <attributeGroup name="MultiValueRequestParamAttributes">
+        <annotation>
+            <documentation xmlns:html="http://www.w3.org/1999/xhtml">
+                <html:p>
+                    Additional attributes used by request parameter
+                    steps when they accept multiple values.
+                </html:p>
+            </documentation>
+        </annotation>
+        <attribute name="matchingRoles" type="chk:StringList" use="optional"/>
     </attributeGroup>
 
     <!-- Complex Types -->
@@ -297,8 +310,12 @@
             <extension base="chk:GenContentFailStep">
                 <attribute name="match" type="xsd:string" use="required"/>
                 <attribute name="version" type="chk:XPathVersion" use="optional"/>
+                <attribute name="name" type="xsd:string" use="optional"/>
                 <attributeGroup ref="chk:MessageAttributes"/>
-                <attributeGroup ref="chk:ToRequestHeaderAttributes"/>
+                <attributeGroup ref="chk:RequestParamAttributes"/>
+                <assert test="if (xsd:boolean(@isTenant)) then @name else true()"
+                        saxon:message="If isTenant is true, then the name should also have a name."
+                        xerces:message="If isTenant is true, then the name should also have a name."/>
             </extension>
         </complexContent>
     </complexType>
@@ -325,8 +342,12 @@
             <extension base="chk:GenContentFailStep">
                 <attribute name="match" type="xsd:string" use="required"/>
                 <attribute name="version" type="chk:XPathVersion" fixed="31" use="optional"/>
+                <attribute name="name" type="xsd:string" use="optional"/>
                 <attributeGroup ref="chk:MessageAttributes"/>
-                <attributeGroup ref="chk:ToRequestHeaderAttributes"/>
+                <attributeGroup ref="chk:RequestParamAttributes"/>
+                <assert test="if (xsd:boolean(@isTenant)) then @name else true()"
+                        saxon:message="If isTenant is true, then the step should also have a name."
+                        xerces:message="If isTenant is true, then the step should also have a name."/>
             </extension>
         </complexContent>
     </complexType>
@@ -530,6 +551,11 @@
                     Since this step is not executing an assertion
                     rax:message and rax:code extensions do not apply.
                 </html:p>
+                <html:p>
+                    This step can be treated as a Request parameter,
+                    it can point to tenant values if isTenant is set
+                    to true.
+                </html:p>
             </documentation>
         </annotation>
         <complexContent>
@@ -537,6 +563,8 @@
                 <attribute name="name" type="xsd:string" use="required"/>
                 <attribute name="path" type="xsd:string" use="required"/>
                 <attribute name="version" type="chk:XPathVersion" fixed="31" use="optional"/>
+                <attribute name="isTenant" type="xsd:boolean" use="optional"/>
+                <attributeGroup ref="chk:MultiValueRequestParamAttributes"/>
             </extension>
         </complexContent>
     </complexType>
@@ -568,7 +596,11 @@
         <complexContent>
             <extension base="chk:ConnectedStep">
                 <attribute name="match" type="xsd:string" use="required"/>
-                <attributeGroup ref="chk:ToRequestHeaderAttributes"/>
+                <attribute name="name" type="xsd:string" use="optional"/>
+                <attributeGroup ref="chk:RequestParamAttributes"/>
+                <assert test="if (xsd:boolean(@isTenant)) then @name else true()"
+                        saxon:message="If isTenant is true, then the name should also have a name."
+                        xerces:message="If isTenant is true, then the name should also have a name."/>
             </extension>
         </complexContent>
     </complexType>
@@ -592,7 +624,11 @@
         <complexContent>
             <extension base="chk:ConnectedStep">
                 <attribute name="match" type="xsd:QName" use="required"/>
-                <attributeGroup ref="chk:ToRequestHeaderAttributes"/>
+                <attribute name="name" type="xsd:string" use="optional"/>
+                <attributeGroup ref="chk:RequestParamAttributes"/>
+                <assert test="if (xsd:boolean(@isTenant)) then @name else true()"
+                        saxon:message="If isTenant is true, then the name should also have a name."
+                        xerces:message="If isTenant is true, then the name should also have a name."/>
             </extension>
         </complexContent>
     </complexType>
@@ -664,7 +700,8 @@
                 <attribute name="name" type="xsd:string" use="required"/>
                 <attribute name="match" type="xsd:string" use="required"/>
                 <attributeGroup ref="chk:MessageAttributes"/>
-                <attributeGroup ref="chk:ToRequestHeaderAttributes"/>
+                <attributeGroup ref="chk:RequestParamAttributes"/>
+                <attributeGroup ref="chk:MultiValueRequestParamAttributes"/>
             </extension>
         </complexContent>
     </complexType>
@@ -683,7 +720,12 @@
             </documentation>
         </annotation>
         <complexContent>
-            <extension base="chk:HeaderStep"/>
+            <extension base="chk:GenContentFailStep">
+                <attribute name="name" type="xsd:string" use="required"/>
+                <attribute name="match" type="xsd:string" use="required"/>
+                <attributeGroup ref="chk:MessageAttributes"/>
+                <attributeGroup ref="chk:RequestParamAttributes"/>
+            </extension>
         </complexContent>
     </complexType>
 
@@ -724,7 +766,8 @@
                 <attribute name="match" type="chk:QNameList" use="optional"/>
                 <attribute name="matchRegEx" type="xsd:string" use="optional"/>
                 <attributeGroup ref="chk:MessageAttributes"/>
-                <attributeGroup ref="chk:ToRequestHeaderAttributes"/>
+                <attributeGroup ref="chk:RequestParamAttributes"/>
+                <attributeGroup ref="chk:MultiValueRequestParamAttributes"/>
                 <assert test="@match or @matchRegEx"
                         saxon:message="A HEADER_ALL step must contain a match or matchRegEx attribute."
                         xerces:message="A HEADER_ALL step must contain a match or matchRegEx attribute."/>
@@ -749,7 +792,8 @@
                 <attribute name="name" type="xsd:string" use="required"/>
                 <attribute name="match" type="xsd:QName" use="required"/>
                 <attributeGroup ref="chk:MessageAttributes"/>
-                <attributeGroup ref="chk:ToRequestHeaderAttributes"/>
+                <attributeGroup ref="chk:RequestParamAttributes"/>
+                <attributeGroup ref="chk:MultiValueRequestParamAttributes"/>
             </extension>
         </complexContent>
     </complexType>
@@ -768,7 +812,12 @@
             </documentation>
         </annotation>
         <complexContent>
-            <extension base="chk:HeaderXSDStep"/>
+            <extension base="chk:GenContentFailStep">
+                <attribute name="name" type="xsd:string" use="required"/>
+                <attribute name="match" type="xsd:QName" use="required"/>
+                <attributeGroup ref="chk:MessageAttributes"/>
+                <attributeGroup ref="chk:RequestParamAttributes"/>
+            </extension>
         </complexContent>
     </complexType>
 
@@ -1096,5 +1145,9 @@
 
     <simpleType name="QNameList">
         <list itemType="xsd:QName"/>
+    </simpleType>
+
+    <simpleType name="StringList">
+        <list itemType="xsd:string"/>
     </simpleType>
 </schema>

--- a/core/src/main/resources/xsl/checker2dot.xsl
+++ b/core/src/main/resources/xsl/checker2dot.xsl
@@ -220,7 +220,7 @@
                      <xsl:when test="$nfaMode">
                          <xsl:value-of select="@id"/>
                      </xsl:when>
-                     <xsl:when test="@label">
+                     <xsl:when test="@label and (@match or @matchRegEx)">
                          <xsl:value-of select="concat(check:matchValue(.),' \n(',@label,')')"/>
                      </xsl:when>
                      <xsl:when test="@name and (@match or @matchRegEx)">
@@ -252,6 +252,11 @@
                      </xsl:otherwise>
                  </xsl:choose>
                  <xsl:if test="not($nfaMode)">
+                     <xsl:if test="exists(@matchingRoles)">
+                         <xsl:value-of select="'\n('"/>
+                         <xsl:value-of select="tokenize(@matchingRoles,' ')" separator=", "/>
+                         <xsl:value-of select="')'"/>
+                     </xsl:if>
                      <xsl:if test="exists(@priority)">
                          <xsl:value-of select="concat('\n[',@priority,']')"/>
                      </xsl:if>

--- a/core/src/main/resources/xsl/opt/headerJoin.xsl
+++ b/core/src/main/resources/xsl/opt/headerJoin.xsl
@@ -96,6 +96,12 @@
             <xsl:if test="$joinSteps[1]/@captureHeader">
                 <xsl:attribute name="captureHeader" select="$joinSteps[1]/@captureHeader"/>
             </xsl:if>
+            <xsl:if test="$joinSteps[1]/@isTenant">
+                <xsl:attribute name="isTenant" select="$joinSteps[1]/@isTenant"/>
+            </xsl:if>
+            <xsl:if test="$joinSteps/@priority">
+                <xsl:attribute name="priority" select="max($joinSteps/@priority)"/>
+            </xsl:if>
             <xsl:copy-of select="$joinSteps[1]/@*[name() = $error-sink-types]"/>
         </step>
     </xsl:template>

--- a/core/src/main/resources/xsl/opt/removeDups-rules.xml
+++ b/core/src/main/resources/xsl/opt/removeDups-rules.xml
@@ -29,26 +29,29 @@
    limitations under the License.
 -->
 <rules xmlns="http://www.rackspace.com/repose/wadl/checker/opt/removeDups/rules">
-    <rule types="URL URLXSD" required="next match" optional="captureHeader">
+    <rule types="URL URLXSD" required="next match" optional="captureHeader name isTenant">
         Rule for URI and URIXSDs.  These may optionally have a
         captureHeader.
     </rule>
-    <rule types="XPATH JSON_XPATH" required="next match" optional="captureHeader version code message">
+    <rule types="XPATH JSON_XPATH" required="next match" optional="captureHeader version code message name isTenant">
         Rule for XPath states.
     </rule>
     <rule types="ASSERT" required="next match" optional="version code message">
         Rule for Assert state.
     </rule>
-    <rule types="CAPTURE_HEADER" required="next name path" optional="version">
+    <rule types="CAPTURE_HEADER" required="next name path" optional="version isTenant matchingRoles">
         Rule for the capture header extension.
     </rule>
     <rule types="PUSH_XML_REP PUSH_JSON_REP" required="next path" optional="name version">
         Rule for PUSH steps.
     </rule>
-    <rule types="HEADER HEADERXSD HEADER_ANY HEADERXSD_ANY HEADER_SINGLE HEADERXSD_SINGLE" required="next name match" optional="captureHeader code message">
+    <rule types="HEADER_SINGLE HEADERXSD_SINGLE" required="next name match" optional="captureHeader code message isTenant">
+        Rule for Single match headers
+    </rule>
+    <rule types="HEADER HEADERXSD HEADER_ANY HEADERXSD_ANY" required="next name match" optional="captureHeader code message isTenant matchingRoles">
         Rule for Header, HeaderXSD, HeaderAny.
     </rule>
-    <rule types="HEADER_ALL" required="next name" optional="match matchRegEx captureHeader code message">
+    <rule types="HEADER_ALL" required="next name" optional="match matchRegEx captureHeader code message isTenant matchingRoles">
         Rule for HEADER_ALL.  Although both match and matchRegEx are
         optional at least one of these should be specified.
     </rule>

--- a/core/src/main/resources/xsl/opt/xpathJoin.xsl
+++ b/core/src/main/resources/xsl/opt/xpathJoin.xsl
@@ -105,7 +105,8 @@
         <xsl:variable name="rightType" as="xsd:boolean" select="$step/@type='XPATH'"/>
         <xsl:variable name="rightVersion" as="xsd:boolean" select="($step/@version &lt;= 31) or ($xpathVersion &lt;= 31)"/>
         <xsl:variable name="noCaptureHeader" as="xsd:boolean" select="not($step/@captureHeader)"/>
-        <xsl:sequence select="$rightType and $rightVersion and $noCaptureHeader"/>
+        <xsl:variable name="noIsTenant" as="xsd:boolean" select="not(xsd:boolean($step/@isTenant))"/>
+        <xsl:sequence select="$rightType and $rightVersion and $noCaptureHeader and $noIsTenant"/>
     </xsl:function>
     <!--
         Produce joined steps

--- a/core/src/main/resources/xsl/raxRolesCommon.xsl
+++ b/core/src/main/resources/xsl/raxRolesCommon.xsl
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   raxRolesCommon.xsl
+
+   This transfrom simply contains common functions, templates, and
+   variables used by rax:roles templates.
+
+   Copyright 2018 Rackspace US, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<xsl:transform  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:check="http://www.rackspace.com/repose/wadl/checker"
+                xmlns:util="http://www.rackspace.com/repose/wadl/checker/util"
+                xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                xmlns:err="http://www.w3.org/2005/xqt-errors"
+                exclude-result-prefixes="xs"
+                version="3.0">
+
+    <!--
+        Although not explicitly used here, prunning is needed by
+        transforms that depend on this transform, so convienent to
+        import here.
+    -->
+    <xsl:import href="util/pruneSteps.xsl"/>
+
+    <!-- Roles header name -->
+    <xsl:variable name="ROLES_HEADER" as="xs:string" select="'X-ROLES'"/>
+
+    <!-- Roles type -->
+    <xsl:variable name="ROLES_TYPE" as="xs:string" select="'HEADER_ANY'"/>
+
+    <!-- Regex for matching a tenant role -->
+    <xsl:variable name="tenantRoleRegex" as="xs:string"
+                  select="'^(.+)/\\\{(.+)\\\}$'"/>
+
+    <!-- Tenant Parameter Types -->
+    <xsl:variable name="param-types-single" as="xs:string*" select="(
+                                                                     'XPATH', 'JSON_XPATH', 'URL', 'URLXSD',
+                                                                     'HEADER_SINGLE','HEADERXSD_SINGLE'
+                                                                     )"/>
+
+    <xsl:variable name="param-types-multi" as="xs:string*" select="(
+                                                                    'HEADER', 'HEADERXSD', 'HEADER_ANY',
+                                                                    'HEADERXSD_ANY', 'HEADER_ALL',
+                                                                    'CAPTURE_HEADER'
+                                                                   )"/>
+    <xsl:variable name="param-types" as="xs:string*" select="(
+                                                               $param-types-single,
+                                                               $param-types-multi
+                                                               )"/>
+
+    <!--
+        Given a sequence of next steps and a map with steps to cull as
+        keys, returns a new sequence with steps culled out if they are
+        contained in the map.
+    -->
+    <xsl:function name="check:cullFromNext" as="xs:string*">
+        <xsl:param name="next" as="xs:string*"/>
+        <xsl:param name="cullMap" as="map(xs:string, xs:string*)"/>
+        <xsl:param name="checker" as="node()"/>
+        <xsl:choose>
+            <xsl:when test="some $n in $next satisfies map:contains($cullMap,$n)">
+                <xsl:sequence select="
+                    (for $n in $next return if (map:contains($cullMap, $n)) then
+                    check:next(key('checker-by-id', $n, $checker)) else $n) =>
+                    distinct-values() =>
+                    check:cullFromNext($cullMap, $checker)
+                    "/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="$next"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!--
+        This version of cullFromNext removes existing URL_FAIL,
+        METHOD_FAIL and CONTENT_FAIL error states and replaces these
+        with new IDs, which will be the combination of the current
+        steps id (currentId) with '_u_', '_m_', and '_c_' added.
+
+        You can use check:generateErrorStatesFromNext to generate the
+        appropriate error states with those IDs.
+    -->
+    <xsl:function name="check:cullFromNext" as="xs:string*">
+        <xsl:param name="next" as="xs:string*"/>
+        <xsl:param name="cullMap" as="map(xs:string, xs:string*)"/>
+        <xsl:param name="currentId" as="xs:string"/>
+        <xsl:param name="checker" as="node()"/>
+
+        <xsl:variable name="cullNext" as="xs:string*"
+            select="check:cullFromNext($next, $cullMap, $checker)"/>
+
+        <xsl:variable name="currentStep" as="node()" select="check:stepsByIds($checker, $currentId)"/>
+        <xsl:variable name="nextSteps" as="node()*" select="check:stepsByIds($checker, $cullNext)"/>
+        <xsl:variable name="NFIDs" as="xs:string*" select="$nextSteps[not(@type=('CONTENT_FAIL','METHOD_FAIL','URL_FAIL'))]/@id"/>
+
+        <xsl:sequence select="(
+                              $NFIDs,
+                              if ($nextSteps[@type=$cont-error-types]) then check:contentFailId($currentId) else (),
+                              if ($nextSteps[@type='METHOD'] or ($currentStep/@type=('URL','URLXSD'))) then check:methodFailId($currentId) else (),
+                              if ($nextSteps[@type=('URL', 'URLXSD')] or ($currentStep/@type=('URL','URLXSD'))) then  check:urlFailId($currentId) else ()
+                              )"/>
+    </xsl:function>
+
+
+    <!--
+        Generates appropriate error states after next steps have been
+        culled.  The function assumes that next is the result of
+        cullFromNext(next, cullMap, currentId) and that currentId is the
+        same baseID passed to that function.
+    -->
+    <xsl:function name="check:generateErrorStatesFromNext" as="node()*">
+        <xsl:param name="next" as="xs:string*"/>
+        <xsl:param name="currentId" as="xs:string"/>
+        <xsl:param name="checker" as="node()"/>
+
+        <xsl:variable name="nextSteps" as="node()*" select="check:stepsByIds($checker, $next)"/>
+        <xsl:variable name="cfid" as="xs:string" select="check:contentFailId($currentId)"/>
+        <xsl:variable name="mfid" as="xs:string" select="check:methodFailId($currentId)"/>
+        <xsl:variable name="ufid" as="xs:string" select="check:urlFailId($currentId)"/>
+
+        <!-- Generate Content Fail -->
+        <xsl:if test="$cfid = $next">
+            <check:step type="CONTENT_FAIL" id="{$cfid}" />
+        </xsl:if>
+
+        <!-- Generate Method Fail -->
+        <xsl:if test="$mfid = $next">
+            <xsl:variable name="nextMethodMatch" as="xs:string*" select="sort($nextSteps[@type='METHOD']/@match)"/>
+            <check:step type="METHOD_FAIL" id="{$mfid}">
+                <xsl:if test="exists($nextMethodMatch)">
+                    <xsl:attribute name="notMatch">
+                        <xsl:value-of select="$nextMethodMatch" separator="|"/>
+                    </xsl:attribute>
+                </xsl:if>
+            </check:step>
+        </xsl:if>
+
+        <!-- Generate URL Fail -->
+        <xsl:if test="$ufid = $next">
+            <xsl:variable name="nextURLMatch" as="xs:string*" select="sort($nextSteps[@type='URL']/@match)"/>
+            <xsl:variable name="nextURLXSDMatch" as="xs:string*" select="sort($nextSteps[@type='URLXSD']/@match)"/>
+            <check:step type="URL_FAIL" id="{$ufid}">
+                <xsl:if test="exists($nextURLMatch)">
+                    <xsl:attribute name="notMatch">
+                        <xsl:value-of select="$nextURLMatch" separator="|"/>
+                    </xsl:attribute>
+                </xsl:if>
+                <xsl:if test="exists($nextURLXSDMatch)">
+                    <xsl:attribute name="notTypes">
+                        <xsl:value-of select="$nextURLXSDMatch" separator=" "/>
+                    </xsl:attribute>
+                </xsl:if>
+            </check:step>
+        </xsl:if>
+    </xsl:function>
+
+    <xsl:function name="check:contentFailId" as="xs:string">
+        <xsl:param name="baseId" as="xs:string"/>
+        <xsl:value-of select="$baseId || '_c_'"/>
+    </xsl:function>
+
+    <xsl:function name="check:methodFailId" as="xs:string">
+        <xsl:param name="baseId" as="xs:string"/>
+        <xsl:value-of select="$baseId || '_m_'"/>
+    </xsl:function>
+
+    <xsl:function name="check:urlFailId" as="xs:string">
+        <xsl:param name="baseId" as="xs:string"/>
+        <xsl:value-of select="$baseId || '_u_'"/>
+    </xsl:function>
+
+    <!--
+        Converts a match regular expression for a role into a regular
+        string.
+    -->
+    <xsl:function name="check:roleFromMatch" as="xs:string">
+        <xsl:param name="match" as="xs:string"/>
+        <xsl:value-of select="replace(replace($match,'\\(.)','$1'),' ','&#xA0;')"/>
+    </xsl:function>
+
+    <!--
+        Inverses a map
+    -->
+    <xsl:function name="check:inverseMap" as="map(xs:string, xs:string*)">
+        <xsl:param name="inMap" as="map(xs:string, xs:string*)"/>
+        <xsl:sequence select="map:merge(
+                              for $k in map:keys($inMap) return
+                              for $t in $inMap($k) return
+                                map{ $t : $k }
+                              ,map{'duplicates' : 'combine'})"/>
+    </xsl:function>
+
+    <!--
+        Copies a step, but replaces an the id and next attributes
+    -->
+    <xsl:function name="check:copyStep" as="node()">
+        <xsl:param name="step" as="node()" />
+        <xsl:param name="newID" as="xs:string"/>
+        <xsl:param name="newNext" as="xs:string*"/>
+        <xsl:param name="setIsTenant" as="xs:boolean"/>
+        <xsl:param name="matchingRoles" as="xs:string*"/>
+
+        <xsl:variable name="excludeAttribs" as="xs:string*"
+                      select="('next', 'id', 'isTenant',
+                              if (exists($matchingRoles)) then 'matchingRoles' else ())"/>
+
+        <check:step>
+            <xsl:attribute name="id" select="$newID"/>
+            <xsl:attribute name="next" select="string-join($newNext,' ')"/>
+            <xsl:if test="$setIsTenant or exists($matchingRoles)">
+                <xsl:attribute name="isTenant" select="'true'"/>
+            </xsl:if>
+            <xsl:if test="exists($matchingRoles)">
+                <xsl:attribute name="matchingRoles">
+                    <xsl:value-of select="$matchingRoles" separator=" "/>
+                </xsl:attribute>
+            </xsl:if>
+            <xsl:apply-templates select="$step/@*[not(name() = $excludeAttribs)] | $step/node()" mode="copy"/>
+        </check:step>
+    </xsl:function>
+
+    <!-- Copy Template -->
+    <xsl:template match="node() | @*" mode="copy processTemplateRoles">
+        <xsl:copy>
+            <xsl:apply-templates select="@* | node()" mode="#current"/>
+        </xsl:copy>
+    </xsl:template>
+
+
+</xsl:transform>

--- a/core/src/main/resources/xsl/raxRolesMultiTenants.xsl
+++ b/core/src/main/resources/xsl/raxRolesMultiTenants.xsl
@@ -1,0 +1,339 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   raxRolesMultiTenants.xsl
+
+   This transform is responsible for making sure that tenant checks
+   that handle multiple tenant values function correctly. It performs
+   the following tasks if a role tenant check is used (ex
+   admin/{tenant}) on a parameter type that can accept multiple values
+   ($param-types-multi).
+
+   1. If a multi-value param type is performed before the method
+   check, it moves the check until after the method check. This
+   ensures that there is a separate check per method.
+
+   2. Multi-value param types contain an matchingRoles attribute which
+   list the possible roles to match, this transforms fills these with
+   appropriate values.
+
+   If role tenant checks are not used, or they don't rely on
+   multi-value params, then the transform just passes the checker
+   through unchanged.
+
+   It is a requirement that the raxRolesTenants transform occurs
+   before this transform is executed.
+
+   Copyright 2018 Rackspace US, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<xsl:transform  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:check="http://www.rackspace.com/repose/wadl/checker"
+                xmlns:util="http://www.rackspace.com/repose/wadl/checker/util"
+                xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                xmlns:err="http://www.w3.org/2005/xqt-errors"
+                exclude-result-prefixes="xs"
+                version="3.0">
+
+    <xsl:import href="raxRolesCommon.xsl"/>
+
+    <xsl:output method="xml"/>
+
+    <!-- The input checker -->
+    <xsl:variable name="checker" as="node()" select="/"/>
+
+    <!--
+        Possible Checker Changes:
+
+        SET  : We must set matching roles attributes on the param, but
+               leave role check in place.
+        MOVE : We must move the param to occur after a method. Move
+               always implies SET, for the sake of simplicity.
+    -->
+    <xsl:variable name="SET" as="xs:string" select="'set'"/>
+    <xsl:variable name="MOVE" as="xs:string" select="'move'"/>
+
+
+    <xsl:template match="/">
+        <xsl:choose>
+            <!--
+                We check to make sure that this transform is even
+                applicable. If it is we processMultiTemplateChecks.
+            -->
+            <xsl:when test="check:containsMultiTenantRoleCheck()">
+                <xsl:call-template name="check:processMultiTemplateChecks"/>
+            </xsl:when>
+            <!--
+                If the transform is not applicable then we simply pass
+                the checker through unchanged.
+            -->
+            <xsl:otherwise>
+                <xsl:copy-of select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!--
+        Scans the document for appropriate multiTemplate changes and
+        actives if changes need to be made.
+    -->
+    <xsl:template name="check:processMultiTemplateChecks">
+        <!--
+            Look for changes related to multi-tenant checks.
+        -->
+        <xsl:variable name="multiTenantChanges" as="map(xs:string, item())"
+                      select="check:findMultiTenantChanges()"/>
+
+        <xsl:variable name="tenantMethodMap" as="map(xs:string, xs:string*)"
+                      select="$multiTenantChanges($MOVE)"/>
+
+        <xsl:variable name="tenantRoleMap" as="map(xs:string, xs:string*)"
+                      select="$multiTenantChanges($SET)"/>
+        <xsl:choose>
+            <!--
+                In this case we have tenant map changes (MOVE) or
+                tenant role changes (SET), so we activete the
+                processTemplateRoles templates to perform the changes.
+            -->
+            <xsl:when test="(map:size($tenantMethodMap) &gt; 0) or (map:size($tenantRoleMap) &gt; 0)">
+                <xsl:variable name="multiTenantChecker" as="node()">
+                    <xsl:copy>
+                        <xsl:apply-templates select="$checker" mode="processTemplateRoles">
+                            <xsl:with-param name="tenantMethodMap" select="$tenantMethodMap" tunnel="yes"/>
+                            <xsl:with-param name="methodTenantMap" select="check:inverseMap($tenantMethodMap)" tunnel="yes"/>
+                            <xsl:with-param name="tenantRoleMap" select="$tenantRoleMap" tunnel="yes"/>
+                        </xsl:apply-templates>
+                    </xsl:copy>
+                </xsl:variable>
+                <xsl:sequence select="util:pruneSteps($multiTenantChecker)"/>
+            </xsl:when>
+            <!--
+                No relevant actions were nessesary, so we copy through
+                the checker unchanged.
+            -->
+            <xsl:otherwise>
+                <xsl:copy-of select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <xsl:template match="check:step[@next]" mode="processTemplateRoles" priority="2">
+        <xsl:param name="tenantMethodMap" as="map(xs:string, xs:string*)" tunnel="yes"/>
+        <xsl:param name="methodTenantMap" as="map(xs:string, xs:string*)" tunnel="yes"/>
+        <xsl:param name="tenantRoleMap"   as="map(xs:string, xs:string*)" tunnel="yes"/>
+
+        <xsl:variable name="this" as="node()" select="."/>
+        <xsl:variable name="id" as="xs:string" select="@id"/>
+        <xsl:variable name="next" as="xs:string*" select="check:next(.)"/>
+        <xsl:variable name="movedTenant" as="xs:boolean" select="some $n in $next satisfies map:contains($tenantMethodMap, $n)"/>
+
+        <!--
+            Cull out tenant params that come before METHOD checks.
+        -->
+        <xsl:variable name="newNexts" as="xs:string*">
+            <xsl:choose>
+                <xsl:when test="$movedTenant">
+                    <xsl:sequence select="check:cullFromNext($next, $tenantMethodMap, $id, $checker)"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:sequence select="$next"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:sequence select="if ($movedTenant) then check:generateErrorStatesFromNext($newNexts, $id, $checker) else ()"/>
+
+        <xsl:choose>
+            <!--
+                If we are at an appropriate methed, rewrite it so that
+                the tenant check occurs right after the method check.
+            -->
+            <xsl:when test="map:contains($methodTenantMap,$id)">
+                <xsl:variable name="cfid" as="xs:string" select="$id || 'CFID'"/>
+                <xsl:variable name="newIds" as="xs:string*"
+                              select="for $oid in $methodTenantMap($id) return $id || $oid"/>
+                <xsl:sequence select="check:copyStep($this, $id, ($newIds, $cfid), false(), ())"/>
+                <xsl:for-each select="$methodTenantMap($id)">
+                    <xsl:variable name="oldId" as="xs:string" select="."/>
+                    <xsl:variable name="newId" as="xs:string" select="$id || $oldId"/>
+                    <xsl:variable name="oldTenant" as="node()" select="key('checker-by-id', $oldId, $checker)"/>
+                    <xsl:sequence select="check:copyStep($oldTenant, $newId, $newNexts, false(), check:roleCheckIdsToMatchStrings($tenantRoleMap($id)))"/>
+                </xsl:for-each>
+                <check:step type="CONTENT_FAIL" id="{$cfid}"/>
+            </xsl:when>
+            <!--
+                If we need to add matchingRoles attribute to a tenant
+                check, then rewrite the tenant check so that it
+                includes the appropriate matching roles, here...
+            -->
+            <xsl:when test="map:contains($tenantRoleMap, $id)">
+                <xsl:sequence select="check:copyStep($this, $id, $newNexts, false(), check:roleCheckIdsToMatchStrings($tenantRoleMap($id)))"/>
+            </xsl:when>
+            <!--
+                Otherwise simply copy the step over, adjusting next as
+                nessessary.
+            -->
+            <xsl:otherwise>
+                <xsl:sequence select="check:copyStep($this, $id, $newNexts,if (exists($this/@isTenant)) then xs:boolean($this/@isTenant) else false(), ())"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!--
+        Given a list of IDs for role checks, return the appropriate
+        matching role names.
+    -->
+    <xsl:function name="check:roleCheckIdsToMatchStrings" as="xs:string*">
+        <xsl:param name="roleCheckIds" as="xs:string*"/>
+        <xsl:sequence select="distinct-values(for $s in check:stepsByIds($checker, $roleCheckIds) return check:roleFromMatch($s/@match))"/>
+    </xsl:function>
+
+    <!--
+        Scan the current checker and find changes for this template to
+        make.  There are two possible changes.
+
+        1. We have multi-tenant params before method params and we need to
+        move them after a method. (MOVE)
+
+        2. We have multi-tenat params (after a method) and we need to
+        set an appropriate list of values for the matchingRoles
+        attribute.
+
+        The return value is a map in this format:
+
+        {
+        $MOVE : {
+              'paramID'  : ['methodID','methodID2'],
+              'paramID2' : ['methodID3','methodID4']
+             },
+        $SET : {
+               'paramID3' : ['raxRoleID1', 'raxRoleID2'],
+               'paramID4' : ['raxRoleID3'],
+               'methedID' : ['raxRoleID4']
+             }
+       }
+
+       $MOVE : contains a map of param IDs with the list of method IDs
+       that are shared with this param.
+
+       $SET : contains a map of param, and methodIDs with the list of
+       apporpriate matching roles for these.  Note that you see both
+       param and method ids to account for the fact that some methods
+       need to move, before setting matching roles.
+    -->
+    <xsl:function name="check:findMultiTenantChanges" as="map(xs:string, item())">
+        <xsl:sequence select="check:findMultiTenantChanges(
+                              $checker/check:checker/check:step[@type=$param-types-multi and xs:boolean(@isTenant)],
+                              map{}, map{})"/>
+    </xsl:function>
+
+    <xsl:function name="check:findMultiTenantChanges" as="map(xs:string, item())">
+        <xsl:param name="tenantChecks" as="node()*"/>
+        <xsl:param name="moveMap" as="map(xs:string, xs:string*)"/>
+        <xsl:param name="setMap" as="map(xs:string, xs:string*)"/>
+        <xsl:choose>
+            <xsl:when test="empty($tenantChecks)">
+                <xsl:sequence select="map {
+                                      $SET : $setMap,
+                                      $MOVE : $moveMap
+                                      }"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:variable name="currentStep" as="node()"  select="$tenantChecks[1]"/>
+                <xsl:variable name="methodSteps" as="node()*" select="check:findMethodSteps($currentStep)"/>
+                <xsl:variable name="methodMoveItems" as="map(xs:string, xs:string*)*"
+                              select="for $m in $methodSteps return map { string($currentStep/@id) : string($m/@id) }"/>
+                <xsl:variable name="methodSetItems" as="map(xs:string, xs:string*)*"
+                              select="for $m in $methodSteps return
+                                      for $r in check:findRoleSteps($m) return map{ string($m/@id) : string($r/@id) }
+                                      "/>
+                <xsl:variable name="roleSetItems" as="map(xs:string, xs:string*)*"
+                              select="
+                                      if (empty($methodMoveItems)) then
+                                        for $r in check:findRoleSteps($currentStep) return map{ string($currentStep/@id) : string($r/@id) }
+                                      else ()
+                                      "/>
+                <xsl:sequence select="check:findMultiTenantChanges($tenantChecks[position() != 1],
+                                      map:merge(($moveMap, $methodMoveItems), map{'duplicates' : 'combine'}),
+                                      map:merge(($setMap, $methodSetItems, $roleSetItems), map{'duplicates' : 'combine'}))"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!--
+        Given a step returns all Method steps that are children of
+        this step.
+    -->
+    <xsl:function name="check:findMethodSteps" as="node()*">
+        <xsl:param name="step" as="node()"/>
+        <xsl:choose>
+            <xsl:when test="empty($step/@next)">
+                <!--
+                    Made it to accept or a non-connected step, return
+                    nothing.
+                -->
+                <xsl:sequence select="()"/>
+            </xsl:when>
+            <xsl:when test="$step/@type='METHOD'">
+                <!--
+                    Found a method step, return it!
+                -->
+                <xsl:sequence select="$step"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <!--
+                    Keep looking!!
+                -->
+                <xsl:sequence select="for $s in check:stepsByIds($checker, check:next($step)) return check:findMethodSteps($s)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!--
+        Given a step returns all ROLE Checkes that are children of
+        this step.
+    -->
+    <xsl:function name="check:findRoleSteps" as="node()*">
+        <xsl:param name="step" as="node()"/>
+        <xsl:choose>
+            <xsl:when test="empty($step/@next)">
+                <!--
+                    Made it to accept or non-connected step, return
+                    nothing.
+                -->
+                <xsl:sequence select="()"/>
+            </xsl:when>
+            <xsl:when test="($step/@name=$ROLES_HEADER) and ($step/@type=$ROLES_TYPE)">
+                <!--
+                    Found a role header!
+                -->
+                <xsl:sequence select="$step"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:sequence select="for $s in check:stepsByIds($checker, check:next($step)) return check:findRoleSteps($s)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!--
+        Returns true if the checker contains at least one tenant check
+        of type $param-types-multi
+    -->
+    <xsl:function name="check:containsMultiTenantRoleCheck"
+                  as="xs:boolean">
+        <xsl:sequence
+            select="exists($checker/check:checker/check:step[@type=$param-types-multi
+                    and xs:boolean(@isTenant)][1])"/>
+    </xsl:function>
+
+</xsl:transform>

--- a/core/src/main/resources/xsl/raxRolesTenants.xsl
+++ b/core/src/main/resources/xsl/raxRolesTenants.xsl
@@ -1,0 +1,565 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   raxRolesTenants.xsl
+
+   This transform is responsible for rewriting a checker to make sure
+   that role tenant checks work properly.  It performs the following
+   tasks if a role tenant check is used (ex admin/{tenant}).
+
+   1. It ensures that maskRaxRoles is not enabled, as role tenant
+   checks are currently not supported with that option. If maskRaxRoles is
+   enabled this transform fails with an error message.
+
+   2. It ensures that the {tenant} exists, if not this transform fails
+   with an appropriate error message.
+
+   3. It ensures that the {tenant} has isTenant set to true, if not it
+   rewrites the tenant so it is set to true.
+
+   4. In ensures that rax roles checks occur *after* the {tenant}
+   param has been processed. If not, it moves role checks to
+   appropriate location.
+
+   If role tenant checks are not used, this transform just passes the
+   checker through unchanged.
+
+   Copyright 2018 Rackspace US, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<xsl:transform  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:check="http://www.rackspace.com/repose/wadl/checker"
+                xmlns:util="http://www.rackspace.com/repose/wadl/checker/util"
+                xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                xmlns:err="http://www.w3.org/2005/xqt-errors"
+                exclude-result-prefixes="xs"
+                version="3.0">
+
+    <xsl:import href="raxRolesCommon.xsl"/>
+
+    <xsl:output method="xml"/>
+
+    <!-- config -->
+    <xsl:param name="configMetadata" as="node()">
+        <check:params>
+          <check:meta>
+            <check:config option="maskRaxRoles403" value="false"/>
+          </check:meta>
+        </check:params>
+    </xsl:param>
+
+    <!-- Are we masking roles? -->
+    <xsl:variable name="maskRaxRoles" as="xs:boolean"
+                  select="xs:boolean(check:optionValue($configMetadata, 'maskRaxRoles403'))"/>
+
+    <!-- The input checker -->
+    <xsl:variable name="checker" as="node()" select="/"/>
+
+    <!-- Errors -->
+    <xsl:variable name="MISSING_TENANT" as="xs:QName" static="yes" select="xs:QName('check:MissingTenant')"/>
+    <xsl:variable name="MISSING_REL_ROLE" as="xs:QName" static="yes" select="xs:QName('check:MissingRelRole')"/>
+    <xsl:variable name="BAD_REL_ROLE" as="xs:QName" static="yes" select="xs:QName('check:BadRelRole')"/>
+
+    <!--
+        SET isTenantID : A magic ID that shouldn't conflict with
+        regular step IDs, The purpose of which is to avoiding making
+        multiple passes at the checker to look for $MOVEs and $SETs.
+    -->
+    <xsl:variable name="SET_IS_TENANT_ID" as="xs:string" select="'0000IS_TENANT9999'"/>
+
+    <!--
+        Possible Checker Changes:
+
+        SET  : We must set isTenant=true on the param, but leave role check in place.
+        MOVE : We must move the role check to occur after a param is set.
+               Move always implies SET, for the sake of simplicity.
+    -->
+    <xsl:variable name="SET" as="xs:string" select="'set'"/>
+    <xsl:variable name="MOVE" as="xs:string" select="'move'"/>
+
+    <xsl:template match="/">
+        <xsl:choose>
+            <!--
+                First thing we want to do is check to make sure this
+                template is even applicable.  We look for RAX-ROLES
+                checks that reference a tenant param.
+
+                If we find the right kind of role we check to make
+                sure maskRaxRoles isn't set then we
+                processTemplateRoles.
+            -->
+            <xsl:when test="check:containsTenantRoleCheck()">
+                <xsl:call-template name="check:checkMaskRaxRoles"/>
+                <xsl:call-template name="check:processTemplateRoles"/>
+            </xsl:when>
+            <!--
+                If this transform is not applicable, we simply pass
+                the checker through unchanged.
+            -->
+            <xsl:otherwise>
+                <xsl:copy-of select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+    <!--
+        This is a stop-gap to enable delivery of the feature before
+        MaskRaxRoles support is implemented.  The template simply
+        checks to see if the mask rax roles feature is enabled and if
+        it is, it fails with a not implement message.
+    -->
+    <xsl:template name="check:checkMaskRaxRoles">
+        <xsl:if test="$maskRaxRoles">
+            <xsl:message terminate="yes">[ERROR] Support for per-tenant roles is not implemented when the maskRaxRoles403 feature is enabled!</xsl:message>
+        </xsl:if>
+    </xsl:template>
+
+    <!--
+        Scans the checker document for instances where capturing the
+        tenant occurs *after* the role check.
+    -->
+    <xsl:template name="check:processTemplateRoles">
+        <!--
+            Look for changes related to tenant roles
+        -->
+        <xsl:variable name="tenantChanges" as="map(xs:string, item())"
+                      select="check:findTenantChanges()"/>
+        <!--
+            A map from X-ROLES header step id to the IDs of locations
+            that capture the tenant.
+        -->
+        <xsl:variable name="roleTenantMap" as="map(xs:string, xs:string*)"
+                      select="$tenantChanges($MOVE)"/>
+
+        <xsl:variable name="setTenantMap" as="map(xs:string, xs:boolean)"
+                      select="$tenantChanges($SET)"/>
+
+        <xsl:choose>
+            <xsl:when test="(map:size($roleTenantMap) &gt; 0) or (map:size($setTenantMap) &gt; 0)">
+                <xsl:variable name="tenantRoleMap" as="map(xs:string, xs:string*)"
+                              select="check:inverseMap($roleTenantMap)"/>
+                <xsl:variable name="roleRelRoleMap" as="map(xs:string, xs:string)"
+                              select="check:createRelRoleMap($roleTenantMap)"/>
+                <xsl:variable name="relRoleRoleMap" as="map(xs:string, xs:string*)"
+                              select="check:inverseMap($roleRelRoleMap)"/>
+                <xsl:variable name="movedRoleChecker" as="node()">
+                    <xsl:copy>
+                        <xsl:apply-templates select="$checker" mode="processTemplateRoles">
+                            <xsl:with-param name="roleTenantMap" select="$roleTenantMap" tunnel="yes"/>
+                            <xsl:with-param name="tenantRoleMap" select="$tenantRoleMap" tunnel="yes"/>
+                            <xsl:with-param name="roleRelRoleMap" select="$roleRelRoleMap" tunnel="yes"/>
+                            <xsl:with-param name="relRoleRoleMap" select="$relRoleRoleMap" tunnel="yes"/>
+                            <xsl:with-param name="setTenantMap" select="$setTenantMap" tunnel="yes"/>
+                        </xsl:apply-templates>
+                    </xsl:copy>
+                </xsl:variable>
+                <xsl:sequence select="util:pruneSteps($movedRoleChecker)"/>
+            </xsl:when>
+            <!--
+                In this case we found no reason to make changes to the
+                checker so we just pass the checker through unchanged.
+            -->
+            <xsl:otherwise>
+                <xsl:copy-of select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+
+    <xsl:template match="check:step[@next]" mode="processTemplateRoles" priority="2">
+        <xsl:param name="roleTenantMap" as="map(xs:string, xs:string*)" tunnel="yes"/>
+        <xsl:param name="tenantRoleMap" as="map(xs:string, xs:string*)" tunnel="yes"/>
+        <xsl:param name="roleRelRoleMap" as="map(xs:string, xs:string)" tunnel="yes"/>
+        <xsl:param name="relRoleRoleMap" as="map(xs:string, xs:string*)" tunnel="yes"/>
+        <xsl:param name="setTenantMap" as="map(xs:string, xs:boolean)" tunnel="yes"/>
+
+        <xsl:variable name="id" as="xs:string" select="@id"/>
+        <xsl:variable name="next" as="xs:string*" select="check:next(.)"/>
+        <xsl:variable name="cullFromNext" as="xs:boolean" select="some $n in $next satisfies
+                                                                  (map:contains($roleTenantMap, $n) or
+                                                                  map:contains($relRoleRoleMap, $n))"/>
+
+
+        <!--
+            Cull out the X-ROLES checks and X-Relevent-Role captures
+            from next, if we have to.
+        -->
+        <xsl:variable name="newNexts" as="xs:string*">
+            <xsl:variable name="next" as="xs:string*" select="check:next(.)"/>
+            <xsl:choose>
+                <xsl:when test="$cullFromNext">
+                    <xsl:sequence select="check:cullFromNext($next,
+                                          map:merge(($roleTenantMap, $relRoleRoleMap),
+                                          map { 'duplicates' :
+                                          'use-any'}), $id, $checker)"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:sequence select="$next"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+
+        <!-- Generate errors that resulted from the culling -->
+        <xsl:sequence select="if ($cullFromNext) then check:generateErrorStatesFromNext($newNexts, $id, $checker) else ()"/>
+
+        <!--
+            If we are a tenant step, we must create new role checks, with their appropriate
+            X-RELEVENT-ROLE sets.
+
+            If not simply copy over adjusting next and isTenant as nessesary.
+        -->
+        <xsl:try>
+            <xsl:choose>
+                <xsl:when test="map:contains($tenantRoleMap, $id)">
+                    <xsl:variable name="xroles" as="xs:string*"
+                                  select="distinct-values($tenantRoleMap($id))"/>
+                    <xsl:variable name="cfid" as="xs:string" select="$id || 'CFID'"/>
+                    <xsl:variable name="xroleNexts" as="xs:string*"
+                                  select="(for $r in $xroles return concat($id,$r), $cfid)"/>
+                    <xsl:variable name="relRoleSteps" as="node()"
+                                  select="check:stepsByIds($checker, distinct-values(for $r in $xroles return $roleRelRoleMap($r)))"/>
+                    <!--
+                        We're making an assumption here that there is a single X-RELEVANT-ROLE step
+                        that captures the logic for all of these related role steps, because
+                        they are all siblings of each other.
+
+                        I can't think of a reason why this wouldn't be true. Just to be on the extream
+                        safe side, we throw an error here if my assumption is off.
+
+                        How would we fix if this were not the case? Well, we'd need to create a new
+                        relevant role step here that covered the logic
+                        for this set of roles.
+                    -->
+                    <xsl:sequence select="if (count($relRoleSteps) != 1) then
+                                          error($BAD_REL_ROLE,'No REL ROLE to cover this case',$xroles) else ()
+                                          "/>
+                    <xsl:sequence select="check:copyStep(., xs:string(@id), $xroleNexts, true(), ())"/>
+                    <xsl:for-each select="check:stepsByIds($checker, $xroles)">
+                        <xsl:sequence select="check:copyStep(., concat($id,xs:string(@id)), concat($id,xs:string($relRoleSteps[1]/@id)), false(), ())"/>
+                    </xsl:for-each>
+                    <xsl:sequence select="check:copyStep($relRoleSteps[1], concat($id,xs:string($relRoleSteps[1]/@id)), $newNexts, false(), ())"/>
+                    <check:step type="CONTENT_FAIL" id="{$cfid}"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:variable name="doTenantMap" as="xs:boolean"
+                                  select="(map:contains($setTenantMap, $id) or
+                                          (if (exists(./@isTenant)) then xs:boolean(./@isTenant) else false()))"/>
+                    <xsl:sequence select="check:copyStep(.,xs:string(@id), $newNexts, $doTenantMap, ())"/>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:catch _errors="{$BAD_REL_ROLE}">
+                <!-- This Should Never Happen ® -->
+                <xsl:variable name="roles" as="node()*" select="check:stepsByIds($checker, xs:string*($err:value))"/>
+                <xsl:message terminate="yes">[ERROR] That's odd, I made a bad assumption, I can't find a X-RELEVENT-ROLE step for these set of roles:
+                <xsl:for-each select="$roles">
+                    <xsl:variable name="role" as="node()" select="."/>
+                    <xsl:text expand-text="yes">{$role/@match} ({$role/@id}) </xsl:text>
+                </xsl:for-each>
+                </xsl:message>
+            </xsl:catch>
+        </xsl:try>
+    </xsl:template>
+
+    <!--
+        Given the tenat role map, create a map from X-ROLE check to
+        the releveant role capture header, that must also be moved.
+    -->
+    <xsl:function name="check:createRelRoleMap" as="map(xs:string, xs:string)">
+        <xsl:param name="roleTenantMap" as="map(xs:string, xs:string*)"/>
+        <xsl:try>
+            <xsl:sequence select="map:merge(
+                                  for $k in map:keys($roleTenantMap) return
+                                  map { $k : for $rr in check:findRelRole(key('checker-by-id', $k, $checker), $k)
+                                             return if (exists($rr)) then $rr else error($MISSING_REL_ROLE, '', $k) },
+                                  map { 'duplicates' : 'use-any'})
+                                  "/>
+            <xsl:catch _errors="{$MISSING_REL_ROLE}">
+                <!-- This Should Never Happen ® -->
+                <xsl:variable name="roleStep" as="node()" select="key('checker-by-id', xs:string($err:value), $checker)"/>
+                <xsl:message terminate="yes" expand-text="yes">[ERROR] That's odd, I'm in a bad state: role {$roleStep/@match} with id {$err:value} has no X-RELEVANT-ROLE set!  Please report this error!</xsl:message>
+            </xsl:catch>
+        </xsl:try>
+    </xsl:function>
+
+
+    <!--
+        Given a map from role check id to one or more decendant
+        params, extends the map to include sibling role checks as
+        siblings must stay together to properly secure the call.
+    -->
+    <xsl:function name="check:addSiblingMapRoles" as="map(xs:string, xs:string*)">
+        <xsl:param name="initMap" as="map(xs:string, xs:string*)"/>
+        <xsl:sequence select="map:merge((
+                              $initMap,
+                              for $k in map:keys($initMap) return
+                              for $s in check:stepsByIds($checker, check:siblings($checker, key('checker-by-id', $k, $checker))) return
+                                if ($s/@name=$ROLES_HEADER and $s/@type=$ROLES_TYPE) then map{xs:string($s/@id) : $initMap($k)} else ()
+                              ), map{'duplicates' : 'combine'})"/>
+    </xsl:function>
+
+    <!--
+        Finds tetant changes that must be made to the checker. There
+        are two passible changes that we can process.
+
+        1.  We have a valid tenant param, but isTenant attribute is
+        not set to true.  In this case, we simply want to set the
+        value to true.
+
+        2. We have a tenant param that is set *after* the rax role
+        header check is performed (rax role check is performed before
+        the tenat param is even set.) In this case we want to set
+        things up so that we move the rax role check to occur after
+        the tenant param.
+
+        The return value is a map, with this format:
+
+        {
+        $SET : {
+             'paramID' : true,
+             'paramID2' : true,
+             },
+        $MOVE : {
+             'raxroleId' : 'paramId3',
+             'raxroleId2' : 'paramId4'
+         }
+       }
+
+       $SET  : contains a *set* of paramIDs where we simply must set
+       isTenat to true.
+
+       $MOVE : contains a map between a role check and and
+       tenanID. In this case we want to move the role check to to move
+       after param check.
+    -->
+    <xsl:function name="check:findTenantChanges" as="map(xs:string, item())">
+        <xsl:variable name="results" as="map(xs:string, xs:string*)"
+                      select="map:merge(check:findTenantChanges($checker), map{'duplicates':'combine'})"/>
+        <xsl:variable name="set" as="map(xs:string, xs:boolean)"
+            select="map:merge((for $r in $results($SET_IS_TENANT_ID) return map{$r : true()}),
+                               map{'duplicates' : 'use-any'})"/>
+        <xsl:variable name="move" as="map(xs:string, xs:string*)"
+                      select="map:remove($results,$SET_IS_TENANT_ID) => check:addSiblingMapRoles()"/>
+        <xsl:sequence select="map {
+                              $SET : $set,
+                              $MOVE : $move
+                              }"/>
+    </xsl:function>
+    <xsl:function name="check:findTenantChanges"
+                  as="map(xs:string, xs:string*)*">
+        <xsl:param name="checker" as="node()"/>
+        <xsl:apply-templates mode="findTenantChanges" select="$checker"/>
+    </xsl:function>
+
+    <xsl:template match="check:step[@name=$ROLES_HEADER and @type=$ROLES_TYPE and
+                         matches(@match,$tenantRoleRegex)]"
+                  mode="findTenantChanges">
+        <xsl:variable name="match" as="xs:string" select="check:roleFromMatch(@match)"/>
+        <xsl:variable name="param" as="xs:string">
+            <xsl:variable name="after" as="xs:string" select="substring-after($match,'{')"/>
+            <xsl:value-of select="substring($after,1,string-length($after)-1)"/>
+        </xsl:variable>
+
+        <xsl:try>
+            <xsl:variable name="fixParentParams" as="xs:string*"
+                          select="distinct-values(check:findParentTenantParams(., $param))"/>
+            <xsl:choose>
+                <!--
+                    There are no missing parent params to fix. This
+                    means that everything is in order, we are good,
+                    for now.
+                -->
+                <xsl:when test="empty($fixParentParams)" />
+                <!--
+                    We have parent params where isTenant isn't set to
+                    true, so we should denote that we need to modify
+                    these params.
+                -->
+                <xsl:otherwise>
+                    <xsl:map-entry key="$SET_IS_TENANT_ID" select="$fixParentParams"/>
+                </xsl:otherwise>
+            </xsl:choose>
+            <xsl:try>
+                <!--
+                    Because it is possible (and useful) to have multiple
+                    params of the same name, it could happen that there
+                    are additional params among our descendants, and if so
+                    this step needs to move.  Let's take a look to be safe.
+                -->
+                <xsl:map-entry key="xs:string(@id)" select="distinct-values(check:findChildTenantParams(.,$param))"/>
+                <xsl:catch _errors="{$MISSING_TENANT}">
+                    <!--
+                        Ignore : if we don't find anything here, this
+                        isn't an error because we found a parameter in
+                        our parent steps.
+                    -->
+                </xsl:catch>
+            </xsl:try>
+            <xsl:catch _errors="{$MISSING_TENANT}">
+                <!--
+                    We couldn't find the tenant among our parents. We
+                    can recover from this by looking at our
+                    decendents. If the tenant param is there we need
+                    to denote that this step must be moved.
+                -->
+                <xsl:try>
+                    <xsl:map-entry key="xs:string(@id)" select="distinct-values(check:findChildTenantParams(.,$param))"/>
+                    <xsl:catch _errors="{$MISSING_TENANT}">
+                        <!--
+                            Okay we still couldn't find it, this is truely
+                            an error. Log an error message and call it
+                            quits.
+                        -->
+                        <xsl:message terminate="yes" expand-text="yes">[ERROR] rax:roles match for role '{$match}', but no defined param named '{$param}' in this case.</xsl:message>
+                    </xsl:catch>
+                </xsl:try>
+            </xsl:catch>
+        </xsl:try>
+    </xsl:template>
+    <xsl:template match="text()" mode="findTenantChanges"/>
+
+    <!--
+        For the given $step, returns the ID if the step is a tenant
+        param of name $name. Or return the IDs of all children of
+        $step that are params $name of names.
+
+        If $step is of type ACCEPT, or there is a path to ACCEPT that
+        does not contain an approprite tenant param, then fail with a
+        $MISSING_TENANT error.
+    -->
+    <xsl:function name="check:findChildTenantParams" as="xs:string*">
+        <xsl:param name="step" as="node()"/>
+        <xsl:param name="name" as="xs:string"/>
+
+        <xsl:choose>
+            <xsl:when test="$step/@type='ACCEPT'">
+                <!--
+                    Made it to ACCEPT without a param name, this is an
+                    error!
+                -->
+                <xsl:sequence select="error($MISSING_TENANT)"/>
+            </xsl:when>
+            <xsl:when test="not($step/@next)">
+                <!--
+                    We are at a terminal step that is not accept (an
+                    error state).  Ignore this path, return nothing.
+                -->
+                <xsl:sequence select="()"/>
+            </xsl:when>
+            <xsl:when test="($step/@name=$name) and ($step/@type = $param-types)">
+                <!--
+                    Found the tenant so return the ID.
+                -->
+                <xsl:sequence select="xs:string($step/@id)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <!--
+                    Keep looking.
+                -->
+                <xsl:sequence select="for $s in check:stepsByIds($checker, check:next($step)) return check:findChildTenantParams($s, $name)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!--
+        For the given $step, returns the id of a parent step that
+        contains param of name $name, but has isTenant set to
+        false. It returns an empty sequence if isTenant is set to
+        true. It also fails with MISSING_TENANT error if the param is
+        not found at all.
+    -->
+    <xsl:function name="check:findParentTenantParams" as="xs:string*">
+        <xsl:param name="step" as="node()"/>
+        <xsl:param name="name" as="xs:string"/>
+
+        <xsl:choose>
+            <xsl:when test="$step/@type='START'">
+                <!--
+                    We walked back to start so, nope.
+                -->
+                <xsl:sequence select="error($MISSING_TENANT)"/>
+            </xsl:when>
+            <xsl:when test="($step/@name=$name) and ($step/@type = $param-types) and xs:boolean($step/@isTenant)">
+                <!--
+                    Found it and it requires no changes...so return nothing.
+                -->
+                <xsl:sequence select="()"/>
+            </xsl:when>
+            <xsl:when test="($step/@name=$name) and ($step/@type = $param-types) and not(xs:boolean($step/@isTenant))">
+                <!--
+                    Found it but isTenant is false, return the ID
+                -->
+                <xsl:sequence select="xs:string($step/@id)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <!--
+                    Keep looking.
+                -->
+                <xsl:variable name="parents" as="node()*" select="key('checker-by-ref',$step/@id, $checker)"/>
+                <xsl:sequence select="for $p in $parents return check:findParentTenantParams($p,$name)"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!--
+        Given a current $step, ruterns the ID the step if it is a
+        X-RELEVENAT-ROLE capture header. Continues to check to child
+        nodes until an X-RELEVENT-ROLE check is found.  If none is
+        found raisis an error $MISSING_REL_ROLE.
+    -->
+    <xsl:function name="check:findRelRole" as="xs:string?">
+        <xsl:param name="step" as="node()"/>
+        <xsl:param name="forRole" as="xs:string"/>
+        <xsl:choose>
+            <xsl:when test="$step/@type='ACCEPT'">
+                <!--
+                    Maide it to ACCEPT without setting an
+                    X-RELEVENT-ROLE, something is wrong here raise an
+                    error!
+                -->
+                <xsl:sequence
+                    select="error($MISSING_REL_ROLE, 'Missing Relevant Role Check for step ' || $forRole, $forRole)"/>
+            </xsl:when>
+            <xsl:when test="not($step/@next)">
+                <!--
+                    We are at a non-ACCEPT terminal step.
+                    Ignore this path.
+                -->
+                <xsl:sequence select="()"/>
+            </xsl:when>
+            <xsl:when test="($step/@type='CAPTURE_HEADER') and ($step/@name='X-RELEVANT-ROLES')">
+                <!--
+                    Found it, return the id
+                -->
+                <xsl:sequence select="xs:string($step/@id)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <!--
+                    Keep looking, return the first match.
+                -->
+                <xsl:sequence select="(for $s in check:stepsByIds($checker, check:next($step)) return check:findRelRole($s, $forRole))[1]"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+
+    <!--
+        Returns true if the checker contains at least one X-ROLE check
+        which references a tenant param.
+    -->
+    <xsl:function name="check:containsTenantRoleCheck"
+                  as="xs:boolean">
+        <xsl:sequence
+            select="exists($checker/check:checker/check:step[@name=$ROLES_HEADER
+                    and @type=$ROLES_TYPE and matches(@match,$tenantRoleRegex)][1])"/>
+    </xsl:function>
+</xsl:transform>

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/Config.scala
@@ -246,13 +246,48 @@ class Config extends LazyLogging {
   //
   //  1. The rax:anyMatch extension
   //  2. The rax:assert extension
-  //  3. Header Checks
+  //  3. The rax:isTenant extension
+  //  4. Header Checks
   //
   //  ...these features are required to implement rax:roles.
   //
   @BeanProperty
   @AffectsChecker
   var enableRaxRolesExtension : Boolean = false
+
+
+  //
+  //  Enable rax-is-tenant extension.
+  //
+  //  The extension is at the heart of multi-tenant role checks. When
+  //  enabled, a parameter with an attribute of rax:isTenant set to
+  //  true will be captured as a tenant that can be used for role
+  //  checks.
+  //
+  //  It is expected that the relationship between tenant and roles is
+  //  contained in a JSON object in a header named X-MAP-ROLES.  The
+  //  object contains a map between the tenant and the roles
+  //  associated with that tenant.
+  //
+  //  It is possible to enableRaxIsTenantExtension without enabling
+  //  the rax-roles extension.  In this case tenant roles may be
+  //  resolved, but no authorization checks are actually
+  //  performed. This may be useful in cases where authorization
+  //  checks are performed in a different filter.
+  //
+  //  When a tenant / role match is made against a particular
+  //  parameter an X-ROLE is created with the pattern role/{param},
+  //  where param is the name of the parameter that supplied the
+  //  tenant id and role the role associated with that parameter.
+  //
+  //  Currently only URI, Header, and Plain parameter types support
+  //  rax:isTenant. The capture header extension also supports an
+  //  isTenant attribute.
+  //
+  @BeanProperty
+  @AffectsChecker
+  var enableRaxIsTenantExtension : Boolean = false
+
 
   //
   //  Enable the rax-representation extension.

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/RequestAttributes.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/servlet/RequestAttributes.scala
@@ -29,4 +29,5 @@ object RequestAttributes {
   val CONTENT_ERROR_CODE = "com.rackspace.com.papi.components.checker.servlet.ContentErrorCode"
   val CONTENT_ERROR_PRIORITY = "com.rackspace.com.papi.components.checker.servlet.ContentErrorPriority"
   val REQUEST_XDM_VALUE = "com.rackspace.com.papi.components.checker.servlet.RequestAsXdmValue"
+  val MAP_ROLES = "com.rackspace.com.papi.components.checker.servlet.MapRoles"
 }

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/HeaderXSDAny.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/HeaderXSDAny.scala
@@ -22,20 +22,28 @@ import javax.xml.validation.Schema
 import com.rackspace.com.papi.components.checker.servlet._
 import com.rackspace.com.papi.components.checker.step.base.{ConnectedStep, Step, StepContext}
 import com.rackspace.com.papi.components.checker.util.HeaderUtil._
+
+import com.rackspace.com.papi.components.checker.util.TenantUtil._
+
 import org.xml.sax.SAXParseException
 
-import scala.collection.JavaConversions._
 
 class HeaderXSDAny(id : String, label : String, val name : String, val value : QName, schema : Schema,
                    val message : Option[String], val code : Option[Int], val captureHeader : Option[String],
-                   val priority : Long, next : Array[Step]) extends ConnectedStep(id, label, next) {
+                   val matchingRoles : Option[Set[String]], val isTenant : Boolean, val priority : Long,
+                   next : Array[Step]) extends ConnectedStep(id, label, next) {
 
   def this(id : String, label : String, name : String, value : QName, schema : Schema, priority : Long,
-           next : Array[Step]) = this(id, label, name, value, schema, None, None, None, priority, next)
+           next : Array[Step]) = this(id, label, name, value, schema, None, None, None, None, false, priority, next)
 
   def this(id : String, label : String, name : String, value : QName, schema : Schema, message : Option[String],
            code : Option[Int], priority : Long,
-           next : Array[Step]) = this(id, label, name, value, schema, message, code, None, priority, next)
+           next : Array[Step]) = this(id, label, name, value, schema, message, code, None, None, false, priority, next)
+
+  def this(id : String, label : String,  name : String,  ue : QName, schema : Schema,
+           message : Option[String],  code : Option[Int],  captureHeader : Option[String],
+           priority : Long, next : Array[Step]) = this(id, label, name, ue, schema, message, code,
+                                                       captureHeader, None, false, priority, next)
 
   override val mismatchMessage : String = {
     if (message.isEmpty) {
@@ -57,6 +65,7 @@ class HeaderXSDAny(id : String, label : String, val name : String, val value : Q
 
   override def checkStep(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, context : StepContext) : Option[StepContext] = {
     val headers : List[String] = getHeaders(context, req, name)
+    lazy val matchHeaders : List[String] = headers.filter(v => xsd.validate(v).isEmpty).toList
     var last_err : Option[SAXParseException] = None
 
     //
@@ -65,11 +74,15 @@ class HeaderXSDAny(id : String, label : String, val name : String, val value : Q
     //  otherwise set an error and None
     //
     if (headers.exists(v => { last_err = xsd.validate(v);  last_err match { case None => true ; case Some(_) => false } })) {
-      captureHeader match {
-        case None => Some(context)
-        case Some(h) => Some(context.copy (requestHeaders =
-          context.requestHeaders.addHeaders(h, headers.filter(v => xsd.validate(v).isEmpty).toList)))
+      val contextWithCaptureHeaders = captureHeader match {
+         case None => context
+         case Some(h) => context.copy(requestHeaders = context.requestHeaders.addHeaders(h, matchHeaders))
       }
+      val contextWithTenantRoles = isTenant match {
+        case false => contextWithCaptureHeaders
+        case true => addTenantRoles(contextWithCaptureHeaders, req, name, headers, matchingRoles)
+      }
+      Some(contextWithTenantRoles)
     } else {
      last_err match {
         case Some(_) => req.contentError(new Exception(mismatchMessage+value+" "+last_err.get.getMessage, last_err.get), mismatchCode, priority)

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/step/URI.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/step/URI.scala
@@ -20,28 +20,49 @@ import javax.servlet.FilterChain
 import com.rackspace.com.papi.components.checker.servlet._
 import com.rackspace.com.papi.components.checker.step.base.{ConnectedStep, Step, StepContext}
 
+import com.rackspace.com.papi.components.checker.util.TenantUtil._
+
 import scala.util.matching.Regex
 
-class URI(id : String, label : String, val uri : Regex, val captureHeader : Option[String], next : Array[Step]) extends ConnectedStep(id, label, next) {
+class URI(id : String, label : String, name : Option[String], val uri : Regex, val captureHeader : Option[String],
+          val isTenant : Boolean, next : Array[Step]) extends ConnectedStep(id, label, next) {
 
   def this (id : String, label : String, uri : Regex, next : Array[Step]) =
-    this(id, label, uri, None, next)
+    this(id, label, None, uri, None, false, next)
+
+  def this (id : String, label : String, uri : Regex, captureHeader : Option[String], next : Array[Step]) =
+    this(id, label, None, uri, captureHeader, false, next)
 
   override val mismatchMessage : String = uri.toString
 
   override def checkStep(req : CheckerServletRequest, resp : CheckerServletResponse, chain : FilterChain, context : StepContext) : Option[StepContext] = {
-    var ret : Option[StepContext] = None
     if (context.uriLevel < req.URISegment.length) {
       val v = req.URISegment(context.uriLevel)
       v match {
-        case uri() => captureHeader match {
-          case None => ret= Some(context.copy(uriLevel = context.uriLevel+1))
-          case Some(h) => ret = Some(context.copy(uriLevel = context.uriLevel+1,
-                                     requestHeaders = context.requestHeaders.addHeader(h, v)))
-        }
-        case _ => ret= None
+        case uri() =>
+          val contextWithCaptureHeaders = captureHeader match {
+            case None => context.copy(uriLevel = context.uriLevel+1)
+            case Some(h) => context.copy(uriLevel = context.uriLevel+1,
+              requestHeaders = context.requestHeaders.addHeader(h, v))
+          }
+          val contextWithTenantRoles = isTenant match {
+            case false => contextWithCaptureHeaders
+            case true =>
+              //
+              //  Note, if isTenant is true, then name will be set.  This is
+              //  enforced by validation of the checker format.
+              //
+              //  A valid machine should never have an empty name at this
+              //  point.
+              //
+              require(!name.isEmpty, "If isTenant is ture then a name should be specified.")
+              addTenantRoles(contextWithCaptureHeaders, req, name.get, v)
+          }
+          Some(contextWithTenantRoles)
+        case _ => None
       }
+    } else {
+      None
     }
-    ret
   }
 }

--- a/core/src/main/scala/com/rackspace/com/papi/components/checker/util/TenantUtil.scala
+++ b/core/src/main/scala/com/rackspace/com/papi/components/checker/util/TenantUtil.scala
@@ -1,0 +1,87 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.util
+
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.ROLES_HEADER
+import com.rackspace.com.papi.components.checker.step.base.StepContext
+
+import com.typesafe.scalalogging.slf4j.LazyLogging
+
+import scala.annotation.tailrec
+
+object TenantUtil extends LazyLogging {
+  /**
+   * Adds tenanted roles to the StepContext given the current checker
+   * request, the name of a tenant paramater, and the current value of
+   * the tenant parameter.
+   */
+  def addTenantRoles(context : StepContext, request : CheckerServletRequest,
+                     tenantName : String, tenantValue : String) : StepContext = try {
+    getPossibleRoles(context, request, tenantName, tenantValue)  match {
+      case Nil => context
+      case roles : List[String] => context.copy(requestHeaders = context.requestHeaders.addHeaders(ROLES_HEADER, roles))
+    }
+  } catch {
+    case e : Exception =>
+      logger.error(s"Strange error while computing tenant roles. Ignoring map roles!", e)
+      context
+  }
+
+  /**
+   * Adds tenanted roles to the StepContext given the current
+   * checker request, the name of a tenant parameter, and the current
+   * values of the tenant parameter.
+   *
+   * All values must be accepted for the given role for it to match.
+   */
+  def addTenantRoles(context : StepContext, request : CheckerServletRequest,
+                     tenantName : String, tenantValues : List[String],
+                     matchingRoles : Option[Set[String]]) : StepContext = try {
+    tenantValues match {
+      case Nil => context
+      case value :: Nil  => addTenantRoles(context, request, tenantName, value)
+      case firstValue :: otherValues => matchingRoles match {
+        case None => context
+        case Some(mroles) => reduceRoles(context, request, tenantName, firstValue :: otherValues, mroles, Nil) match {
+          case Nil => context
+          case roles : List[String] => context.copy(requestHeaders = context.requestHeaders.addHeaders(ROLES_HEADER, roles))
+        }
+      }
+    }
+  } catch {
+    case e : Exception =>
+      logger.error(s"Strange error while computing tenant roles. Ignoring map roles!", e)
+      context
+  }
+
+  @tailrec
+  private[this] def reduceRoles (context: StepContext, request : CheckerServletRequest,
+                                 tenantName : String, tenantValues : List[String],
+                                 matchingRoles : Set[String], retRoles : List[String]) : List[String] = tenantValues match {
+    case Nil => retRoles
+    case value :: nextTenantValues =>
+      getPossibleRoles(context, request, tenantName, value).filter(matchingRoles.contains(_)) match {
+        case Nil => Nil // We have a tenant value that doesn't match any roles, We can't let the request through!
+        case roles : List[String] => reduceRoles(context, request, tenantName, nextTenantValues, matchingRoles, roles ++ retRoles)
+      }
+  }
+
+
+  private[this] def getPossibleRoles(context : StepContext, request : CheckerServletRequest,
+                                     tenantName : String, tenantValue : String) : List[String] =
+    request.mappedRoles.getOrElse(tenantValue,Nil).map(_+"/{"+tenantName+"}")
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/BaseValidatorSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/BaseValidatorSuite.scala
@@ -15,8 +15,11 @@
  */
 package com.rackspace.com.papi.components.checker
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import java.io.{ByteArrayInputStream, File}
 import java.util.Enumeration
+import java.util.Base64
 import javax.servlet.FilterChain
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import javax.xml.parsers.DocumentBuilder
@@ -42,6 +45,10 @@ import scala.language.implicitConversions
 import scala.xml._
 
 class BaseValidatorSuite extends FunSuite {
+
+  val base64Encoder = Base64.getEncoder
+
+  def b64Encode (s : String) : String = base64Encoder.encodeToString(s.getBytes(UTF_8))
 
   //
   //  Common test vars

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRAXCaptureHeaderElementSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRAXCaptureHeaderElementSuite.scala
@@ -819,8 +819,8 @@ class ValidatorWADLRAXCaptureHeaderElementSuite extends BaseValidatorSuite {
         assert(csReq.getHeaders("X-HEADERS-START-WITH-A").toList == List("true"))
         assert(csReq.getHeaders("X-HEADERS-START-WITH-B").toList == List("true"))
         assert(csReq.getHeaders("ALL-X-AUTH-HEADERS").toList == List("foo!"))
-        assert(csReq.getHeaders("X-BODY-EMPTY").toList == List("false"))
-        assert(csReq.getHeaders("X-BODY-EMPTY2").toList == List("false"))
+        assert(csReq.getHeaders("X-BODY-EMPTY").toList == List("true"))
+        assert(csReq.getHeaders("X-BODY-EMPTY2").toList == List("true"))
         assert(csReq.getHeaders("X-FALSE").toList == List("false"))
       }))
 

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesCaptureHeaderTenantSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesCaptureHeaderTenantSuite.scala
@@ -1,0 +1,663 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.MAP_ROLES_HEADER
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.ROLES_HEADER
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml.XML
+
+@RunWith(classOf[JUnitRunner])
+class ValidatorWADLRaxRolesCaptureHeaderTenantSuite extends BaseValidatorSuite with VaryTestSuite {
+  //
+  // Configs
+  //
+  val raxRolesDisabled : CaseConfig = ("rax roles disabled", {
+    val c = TestConfig()
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = false
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = false
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesDisabledRemoveDups : CaseConfig = ("rax roles disabled, remove dups", {
+    val c = TestConfig()
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = false
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = true
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesEnabled : CaseConfig = ("rax roles enabled", {
+    val c = TestConfig()
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = false
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesEnabledRemoveDups : CaseConfig = ("rax roles enabled, remove dups", {
+    val c = TestConfig()
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = true
+    c.joinXPathChecks = false
+    c
+  })
+
+
+  val raxRolesEnabledIsTenantEnabled : CaseConfig = ("rax roles enabled, isTenant enabled", {
+    val c = TestConfig()
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = true
+    c.removeDups = false
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesEnabledIsTenantEnabledRemoveDups : CaseConfig = ("rax roles enabled, isTenant enabled, remove dups", {
+    val c = TestConfig()
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = true
+    c.removeDups = true
+    c.joinXPathChecks = false
+    c
+  })
+
+  //
+  //  TestWADLs
+  //
+  val captureHeaderTenant : TestWADL = ("CaptureHeader Tenant",
+    XML.loadString("""<application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{tenant}/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="tenant" style="template"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                </request>
+            </method>
+            <method name="GET" rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                </request>
+            </method>
+            <method name="DELETE"/>
+        </resource>
+        <rax:captureHeader name="X-TENANT"
+                           path="
+                                 (:
+                                   If there's a body and it's XML look in //@tenant
+                                   else look for a field named 'tenant' in JSON
+
+                                   And if there is no body split the URI by / and
+                                   look at fourth component.
+                                 :)
+                                 if (exists($body)) then
+                                    if ($body instance of node()) then tokenize(string($body//@tenant),' ') 
+                                                                  else $body('tenant')?*
+                                 else tokenize($req:uri,'/')[3]
+                                 "/>
+     </resources>
+   </application>"""))
+
+   val captureHeaderTenantExplicit : TestWADL = ("CaptureHeader Tenant (explicit isTenant)",
+     XML.loadString("""<application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{tenant}/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="tenant" style="template"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                </request>
+            </method>
+            <method name="GET" rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                </request>
+            </method>
+            <method name="DELETE"/>
+        </resource>
+       <rax:captureHeader name="X-TENANT"
+                          isTenant="true"
+                          path="
+                                 (:
+                                   If there's a body and it's XML look in //@tenant
+                                   else look for a field named 'tenant' in JSON
+
+                                   And if there is no body split the URI by / and
+                                   look at fourth component.
+                                 :)
+                                 if (exists($body)) then
+                                    if ($body instance of node()) then tokenize(string($body//@tenant),' ') 
+                                                                  else $body('tenant')?*
+                                 else tokenize($req:uri,'/')[3]
+                                 "/>
+     </resources>
+   </application>"""))
+
+   val captureHeaderTenantAtResource : TestWADL = ("CaptureHeader Tenant at resource",
+     XML.loadString("""<application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{tenant}/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="tenant" style="template"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                </request>
+            </method>
+            <method name="GET" rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                </request>
+            </method>
+             <method name="DELETE"/>
+             <rax:captureHeader name="X-TENANT"
+                   path="
+                            (:
+                              If there's a body and it's XML look in //@tenant
+                              else look for a field named 'tenant' in JSON
+
+                              And if there is no body split the URI by / and
+                              look at fourth component.
+                            :)
+                            if (exists($body)) then
+                               if ($body instance of node()) then tokenize(string($body//@tenant),' ') 
+                                                             else $body('tenant')?*
+                            else tokenize($req:uri,'/')[3]
+                         "/>
+
+        </resource>
+     </resources>
+   </application>"""))
+
+   val captureHeaderTenantAtResourceExplicit : TestWADL = ("CaptureHeader Tenant at resource (explicit isTenant)",
+     XML.loadString("""<application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{tenant}/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="tenant" style="template"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                </request>
+            </method>
+            <method name="GET" rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml"/>
+                    <representation mediaType="application/json"/>
+                </request>
+            </method>
+             <method name="DELETE"/>
+             <rax:captureHeader name="X-TENANT"
+                   isTenant="true"
+                   path="
+                            (:
+                              If there's a body and it's XML look in //@tenant
+                              else look for a field named 'tenant' in JSON
+
+                              And if there is no body split the URI by / and
+                              look at fourth component.
+                            :)
+                            if (exists($body)) then
+                               if ($body instance of node()) then tokenize(string($body//@tenant),' ') 
+                                                             else $body('tenant')?*
+                            else tokenize($req:uri,'/')[3]
+                         "/>
+
+        </resource>
+     </resources>
+   </application>"""))
+
+ val captureHeaderTenantAtMethod : TestWADL = ("CaptureHeader Tenant at method",
+   XML.loadString("""<application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{tenant}/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="tenant" style="template"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml">
+                     <rax:captureHeader name="X-TENANT" path="tokenize(string($body//@tenant),' ')"/>
+                    </representation>
+                    <representation mediaType="application/json">
+                     <rax:captureHeader name="X-TENANT" path="$body('tenant')?*"/>
+                    </representation>
+                </request>
+            </method>
+            <method name="GET" rax:roles="a:observer/{X-TENANT}">
+             <request>
+              <rax:captureHeader name="X-TENANT" path="tokenize($req:uri,'/')[3]"/>
+             </request>
+            </method>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml">
+                     <rax:captureHeader name="X-TENANT" path="tokenize(string($body//@tenant),' ')"/>
+                    </representation>
+                    <representation mediaType="application/json">
+                     <rax:captureHeader name="X-TENANT" path="$body('tenant')?*"/>
+                    </representation>
+                </request>
+            </method>
+            <method name="DELETE">
+              <request>
+               <rax:captureHeader name="X-TENANT" path="tokenize($req:uri,'/')[3]"/>
+              </request>
+            </method>
+        </resource>
+     </resources>
+   </application>"""))
+
+  val captureHeaderTenantAtMethodExplicit : TestWADL = ("CaptureHeader Tenant at method (isTenant explicit)",
+    XML.loadString("""<application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{tenant}/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="tenant" style="template"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml">
+                      <rax:captureHeader name="X-TENANT" path="tokenize(string($body//@tenant),' ')"
+                       isTenant="true"/>
+                    </representation>
+                    <representation mediaType="application/json">
+                      <rax:captureHeader name="X-TENANT" path="$body('tenant')?*"
+                       isTenant="true"/>
+                    </representation>
+                </request>
+            </method>
+            <method name="GET" rax:roles="a:observer/{X-TENANT}">
+             <request>
+              <rax:captureHeader name="X-TENANT" path="tokenize($req:uri,'/')[3]"
+               isTenant="true"/>
+             </request>
+            </method>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <representation mediaType="application/xml">
+                     <rax:captureHeader name="X-TENANT" path="tokenize(string($body//@tenant), ' ')"
+                       isTenant="true"/>
+                    </representation>
+                    <representation mediaType="application/json">
+                      <rax:captureHeader name="X-TENANT" path="$body('tenant')?*"
+                        isTenant="true"/>
+                    </representation>
+                </request>
+            </method>
+            <method name="DELETE">
+             <request>
+               <rax:captureHeader name="X-TENANT" path="tokenize($req:uri,'/')[3]"
+               isTenant="true"/>
+             </request>
+            </method>
+        </resource>
+     </resources>
+   </application>"""))
+
+  //
+  // Suites
+  //
+
+  //
+  // These are useful for the tests below
+  //
+  val nonContentMethods = List("GET", "DELETE")
+  val contentMethods = List("POST", "PUT")
+
+  //
+  // These should alaways fail regardless of configs, they're simple
+  // sanity tets on validation.
+  //
+
+  def sadSanity( desc: String, validator : Validator) : Unit = {
+    test(s"$desc : Should fail with a 405 on patch /v1/0/resource") {
+      assertResultFailed(validator.validate(request("PATCH","/v1/0/resource"), response, chain), 405)
+    }
+
+    test(s"$desc : Should fail with 404 on GET /v2/resoruce"){
+      assertResultFailed(validator.validate(request("GET","/v2/resource"), response, chain), 404)
+    }
+  }
+
+  //
+  // These should give positive results only when rax:roles is disabled.
+  //
+  def happyWhenRaxRolesIsDisabled(desc : String, validator : Validator) : Unit = {
+     val mapHeaderValue = b64Encode("""
+      {
+         "a" : ["a:admin","a:observer","bar"],
+         "b" : ["a:admin", "foo"],
+         "c" : ["a:reviewer", "bar", "biz", "a:creator"],
+         "d" : ["a:observer"]
+      }
+    """)
+
+    //
+    // No roles or bad roles set
+    //
+    nonContentMethods.foreach(m => {
+      test(s"$desc : should allow $m on /v1/0/resource") {
+        validator.validate(request(m,"/v1/0/resource"), response, chain)
+      }
+
+      test(s"$desc : should allow $m on /v1/0/resource (bad roles)") {
+        validator.validate(request(m,"/v1/0/resource", null, "", false,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+    })
+
+    contentMethods.foreach (m => {
+      test(s"$desc : should allow a $m with XML on /v1/777/resource") {
+        validator.validate(request(m,"/v1/777/resource", "application/xml", <xml tenant="foo"/>, true,
+          Map[String, List[String]]()), response, chain)
+      }
+
+      test(s"$desc : should allow a $m with XML on /v1/777/resource (bad roles)") {
+        validator.validate(request(m,"/v1/777/resource", "application/xml", <xml tenant="foo"/>, true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+
+      test(s"$desc : should succeed on $m with XML if the XML is bad on /v1/777/resource") {
+        validator.validate(request(m,"/v1/777/resource", "application/xml", <xml tenant3="foo"/>, true,
+          Map[String, List[String]]()), response, chain)
+      }
+
+      test(s"$desc : should allow a $m with JSON on /v1/777/resource") {
+        validator.validate(request(m,"/v1/777/resource", "application/json", """{ "tenant" : ["foo"] }""", true,
+          Map[String, List[String]]()), response, chain)
+      }
+
+      test(s"$desc : should allow a $m with JSON on /v1/777/resource (bad roles)") {
+        validator.validate(request(m,"/v1/777/resource", "application/json", """{ "tenant" : ["foo"] }""", true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+
+      test(s"$desc : should succeed a $m with JSON if the JSON is bad on /v1/777/resource") {
+        validator.validate(request(m,"/v1/777/resource", "application/json", """{ "tenant3" : ["foo"] }""", true,
+          Map[String, List[String]]()), response, chain)
+      }
+    })
+  }
+
+  //
+  // These tests should succeed in all cases when rax:roles is enabled
+  //
+  def happyWhenRaxRolesIsEnabled(desc : String, validator : Validator) : Unit = {
+    val mapHeaderValue = b64Encode("""
+      {
+         "1" : ["a:admin","foo","bar"],
+         "2" : ["a:creator", "foo", "a:observer"],
+         "3" : ["a:updater", "bar", "biz", "a:creator"],
+         "4" : ["a:observer"],
+         "5" : ["a:admin", "bar", "biz", "a:creator"]
+      }
+    """)
+
+    //
+    // Admins should be a able to perform all operations. According to
+    // the WADLs we get the tenent from the URI for GET and DELETE
+    // requests and from the tenant body for POST and PUT requests. So
+    // we match the appropriate parameter and deliberatly mismatch the
+    // other.
+    //
+    nonContentMethods.foreach (m => {
+      test(s"$desc : should allow $m on /v1/1/resource") {
+        validator.validate(request(m,"/v1/1/resource", null, "", false,
+          Map(
+            ROLES_HEADER->List("baz","biz","observer","notAnAdmin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+    })
+
+    contentMethods.foreach (m => {
+
+      //
+      //  The following match 1 : admin
+      //
+      test(s"$desc : should allow a $m with JSON on /v1/4/resource") {
+        validator.validate(request(m,"/v1/4/resource", "application/json", """{ "tenant" : ["1"] }""", true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+
+      test(s"$desc : should allow a $m with XML on /v1/4/resource") {
+        validator.validate(request(m,"/v1/4/resource", "application/xml", <xml tenant="1"/>, true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+
+      //
+      //  In the following multi-match check we match the 1 : admin
+      //  and 5 : admin
+      //
+      test(s"$desc : should allow a $m with JSON on /v1/4/resource (multi-match tenants)") {
+        validator.validate(request(m,"/v1/4/resource", "application/json", """{ "tenant" : ["5", "1"] }""", true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+
+      test(s"$desc : should allow a $m with XML on /v1/4/resource (multi-match tenants)") {
+        validator.validate(request(m,"/v1/4/resource", "application/xml", <xml tenant="5 1"/>, true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+
+      //
+      //  In the following multi-match check we match the 1 : admin
+      //  and 3 : creator or updater
+      //
+      test(s"$desc : should allow a $m with JSON on /v1/4/resource (multi-match tenants, mismatch)") {
+        validator.validate(request(m,"/v1/4/resource", "application/json", """{ "tenant" : ["3", "1"] }""", true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+
+      test(s"$desc : should allow a $m with XML on /v1/4/resource (multi-match tenants, mismatch)") {
+        validator.validate(request(m,"/v1/4/resource", "application/xml", <xml tenant="3 1"/>, true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+    })
+
+    //
+    // In nonContent methods, a mismatch in the URI should fail.
+    //
+    nonContentMethods.foreach (m => {
+      test(s"$desc : should fail $m on /v1/777/resource") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/777/resource", null, "", false,
+            Map(
+              ROLES_HEADER->List("baz","biz","observer","notAnAdmin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+    })
+
+    contentMethods.foreach (m => {
+      //
+      //  For content methods an admin match in the URI, but observer
+      //  match in the body should fail...
+      //
+      test(s"$desc : should fail a $m with JSON on /v1/1/resource if observer in body") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/1/resource", "application/json", """{ "tenant" : ["4"] }""", true,
+            Map(
+              ROLES_HEADER->List("baz","biz","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+
+      test(s"$desc : should fail a $m with XML on /v1/1/resource if observer in body") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/1/resource", "application/xml", <xml tenant="4"/>, true,
+            Map(
+              ROLES_HEADER->List("baz","biz","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+
+      //
+      //  ...This should fail even if the observer match is also
+      //  followed by a match which contains admin.
+      //  
+      //
+      test(s"$desc : should fail a $m with JSON on /v1/1/resource if observer, admin in body") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/1/resource", "application/json", """{ "tenant" : ["1", "4"] }""", true,
+            Map(
+              ROLES_HEADER->List("baz","biz","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+
+      test(s"$desc : should fail a $m with XML on /v1/1/resource if observer, admin in body") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/1/resource", "application/xml", <xml tenant="1 4"/>, true,
+            Map(
+              ROLES_HEADER->List("baz","biz","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+
+    })
+
+    //
+    //  Match observer in URI and body, all methods should fail except
+    //  for GET.
+    //
+    test(s"$desc : should allow GET on /v1/4/resource") {
+        validator.validate(request("GET","/v1/4/resource", null, "", false,
+          Map(
+            ROLES_HEADER->List("baz","biz","observer","notAnAdmin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+    }
+
+    test(s"$desc : should fail DELETE on /v1/4/resource") {
+      assertResultFailed(
+        validator.validate(request("DELETE","/v1/4/resource", null, "", false,
+          Map(
+            ROLES_HEADER->List("baz","biz","observer","notAnAdmin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain), 403)
+    }
+
+    contentMethods.foreach (m => {
+      test(s"$desc : should fail a $m with JSON on /v1/4/resource") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/4/resource", "application/json", """{ "tenant" : ["4"] }""", true,
+            Map(
+              ROLES_HEADER->List("baz","biz","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+
+      test(s"$desc : should fail a $m with XML on /v1/4/resource") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/4/resource", "application/xml", <xml tenant="4"/>, true,
+            Map(
+              ROLES_HEADER->List("baz","biz","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+    })
+
+  }
+
+  //
+  // Run testcases
+  //
+
+  val disabledCaptureHeaderTestCase : TestCase = (
+    List(captureHeaderTenant, captureHeaderTenantExplicit),    // WADLs
+    List(raxRolesDisabled, raxRolesDisabledRemoveDups),        // Configs
+    List(sadSanity, happyWhenRaxRolesIsDisabled)               // Suites
+  )
+  run(disabledCaptureHeaderTestCase)
+
+  val enabledCaptureHeaderTestCase : TestCase = (
+    List(captureHeaderTenant, captureHeaderTenantExplicit,
+      captureHeaderTenantAtResource,
+      captureHeaderTenantAtResourceExplicit,
+      captureHeaderTenantAtMethod,
+      captureHeaderTenantAtMethodExplicit),                    // WADLs
+    List(raxRolesEnabled, raxRolesEnabledRemoveDups,
+      raxRolesEnabledIsTenantEnabled,
+      raxRolesEnabledIsTenantEnabledRemoveDups),               // Configs
+    List(sadSanity, happyWhenRaxRolesIsEnabled)                // Suites
+  )
+  run(enabledCaptureHeaderTestCase)
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesHeaderMultiValueTenantSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesHeaderMultiValueTenantSuite.scala
@@ -1,0 +1,1138 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.MAP_ROLES_HEADER
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.ROLES_HEADER
+import com.rackspace.com.papi.components.checker.step.results.Result
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ValidatorWADLRaxRolesHeaderMultiValueTenantSuite extends ValidatorWADLRaxRolesHeaderTenantBase with VaryTestSuite {
+  //
+  // Test WADLs
+  //
+  val headerTenant : TestWADL = ("Header Multi Tenant (Header)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                   repeating="true"/>
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}"/>
+            <method name="DELETE"/>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+                <method name="GET"  rax:roles="#all"/>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}"/>
+                <method name="DELETE"/>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}"/>
+            </resource>
+        </resource>
+    </resources>
+      </application>)
+
+  val headerAllTenant : TestWADL = ("Header Multi Tenant (ALL)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                   repeating="true"/>
+            <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                   repeating="true"/>
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}"/>
+            <method name="DELETE"/>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+                <method name="GET"  rax:roles="#all"/>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}"/>
+                <method name="DELETE"/>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}"/>
+          </resource>
+        </resource>
+    </resources>
+      </application>)
+
+  val headerAnyTenant : TestWADL = ("Header Multi Tenant (ANY)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                   repeating="true" rax:anyMatch="true"/>
+            <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                   repeating="true" rax:anyMatch="true"/>
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}"/>
+            <method name="DELETE"/>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+                <method name="GET"  rax:roles="#all"/>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}"/>
+                <method name="DELETE"/>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}"/>
+            </resource>
+        </resource>
+    </resources>
+      </application>)
+
+   val headerTenantExplicit : TestWADL = ("Header Multi Tenant (Header, Explicit)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                   repeating="true" rax:isTenant="true"/>
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}"/>
+            <method name="DELETE"/>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+                <method name="GET"  rax:roles="#all"/>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}"/>
+                <method name="DELETE"/>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}"/>
+            </resource>
+        </resource>
+    </resources>
+      </application>)
+
+  val headerAllTenantExplicit : TestWADL = ("Header Multi Tenant (ALL, Explicit)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                   repeating="true" rax:isTenant="true"/>
+            <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                   repeating="true" rax:isTenant="true"/>
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}"/>
+            <method name="DELETE"/>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+                <method name="GET"  rax:roles="#all"/>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}"/>
+                <method name="DELETE"/>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}"/>
+            </resource>
+        </resource>
+    </resources>
+      </application>)
+
+  val headerAnyTenantExplicit : TestWADL = ("Header Multi Tenant (ANY, Explicit)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                   repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+            <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                   repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}"/>
+            <method name="DELETE"/>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+                <method name="GET"  rax:roles="#all"/>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}"/>
+                <method name="DELETE"/>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}"/>
+            </resource>
+        </resource>
+    </resources>
+      </application>)
+
+  val headerAtMethodTenant : TestWADL = ("Header Tenant in a method",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource" rax:roles="a:admin/{X-TENANT}">
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true"/>
+                </request>
+            </method>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true"/>
+                </request>
+            </method>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true"/>
+                </request>
+            </method>
+            <method name="DELETE">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true"/>
+                </request>
+            </method>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true"/>
+                    </request>
+                </method>
+                <method name="GET"  rax:roles="#all">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true"/>
+                    </request>
+                </method>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true"/>
+                    </request>
+                </method>
+                <method name="DELETE">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true"/>
+                    </request>
+                </method>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true"/>
+                    </request>
+                </method>
+            </resource>
+        </resource>
+      </resources>
+      </application>)
+
+  val headerAllAtMethodTenant : TestWADL = ("Header All Tenant in a method",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource" rax:roles="a:admin/{X-TENANT}">
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true"/>
+                </request>
+            </method>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true"/>
+
+                </request>
+            </method>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true"/>
+                </request>
+            </method>
+            <method name="DELETE">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true"/>
+                </request>
+            </method>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true"/>
+                    </request>
+                </method>
+                <method name="GET"  rax:roles="#all">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true"/>
+                    </request>
+                </method>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true"/>
+                    </request>
+                </method>
+                <method name="DELETE">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                              repeating="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true"/>
+                    </request>
+                  </method>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                              repeating="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true"/>
+                    </request>
+                </method>
+            </resource>
+        </resource>
+      </resources>
+                  </application>)
+
+  val headerAnyAtMethodTenant : TestWADL = ("Header Any Tenant in a method",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource" rax:roles="a:admin/{X-TENANT}">
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:anyMatch="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:anyMatch="true"/>
+                </request>
+            </method>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:anyMatch="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:anyMatch="true"/>
+
+                </request>
+            </method>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:anyMatch="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:anyMatch="true"/>
+                </request>
+            </method>
+            <method name="DELETE">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:anyMatch="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:anyMatch="true"/>
+                </request>
+            </method>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:anyMatch="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:anyMatch="true"/>
+                    </request>
+                </method>
+                <method name="GET"  rax:roles="#all">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:anyMatch="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:anyMatch="true"/>
+                    </request>
+                </method>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:anyMatch="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:anyMatch="true"/>
+                    </request>
+                </method>
+                <method name="DELETE">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                              repeating="true" rax:anyMatch="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:anyMatch="true"/>
+                  </request>
+                </method>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                              repeating="true" rax:anyMatch="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:anyMatch="true"/>
+                    </request>
+                </method>
+            </resource>
+        </resource>
+      </resources>
+      </application>)
+
+  val headerAtMethodTenantExplicit : TestWADL = ("Header Tenant in a method (Explicit)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource" rax:roles="a:admin/{X-TENANT}">
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:isTenant="true"/>
+                </request>
+            </method>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:isTenant="true"/>
+                </request>
+            </method>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:isTenant="true"/>
+                </request>
+            </method>
+            <method name="DELETE">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:isTenant="true"/>
+                </request>
+            </method>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="GET"  rax:roles="#all">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="DELETE">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+            </resource>
+        </resource>
+      </resources>
+      </application>)
+
+  val headerAllAtMethodTenantExplicit : TestWADL = ("Header All Tenant in a method (Explicit)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource" rax:roles="a:admin/{X-TENANT}">
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:isTenant="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:isTenant="true"/>
+                </request>
+            </method>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:isTenant="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:isTenant="true"/>
+
+                </request>
+            </method>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:isTenant="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:isTenant="true"/>
+                </request>
+            </method>
+            <method name="DELETE">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:isTenant="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:isTenant="true"/>
+                </request>
+            </method>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:isTenant="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="GET"  rax:roles="#all">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:isTenant="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:isTenant="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="DELETE">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                              repeating="true" rax:isTenant="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:isTenant="true"/>
+                    </request>
+                  </method>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                              repeating="true" rax:isTenant="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+            </resource>
+        </resource>
+      </resources>
+                  </application>)
+
+  val headerAnyAtMethodTenantExplicit : TestWADL = ("Header Any Tenant in a method (Explicit)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource" rax:roles="a:admin/{X-TENANT}">
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                </request>
+            </method>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+
+                </request>
+            </method>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                </request>
+            </method>
+            <method name="DELETE">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                           repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                </request>
+            </method>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="GET"  rax:roles="#all">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="DELETE">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                              repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                    </request>
+                  </method>
+                <method name="PATCH" rax:roles="role&#xA0;with&#xA0;spaces/{X-TENANT} a:patcher/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                              repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:boolean"
+                               repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                    </request>
+                </method>
+            </resource>
+        </resource>
+      </resources>
+      </application>)
+
+  //
+  // Suites
+  //
+
+
+  //
+  //  These should fail regardless of configs they are simple sanity
+  //  tests on the validator.
+  //
+
+  def sanity(desc : String, validator : Validator) : Unit = {
+    test(s"$desc : Should fail with a 405 on patch /v1/resource") {
+      assertResultFailed(validator.validate(request("PATCH","/v1/resource", null, "", false,
+        Map("X-TENANT"->List("1", "5"),
+            "X-OTHER"->List("other"))), response, chain), 405)
+    }
+
+    test(s"$desc : Should fail with 404 on GET /v2/resoruce"){
+      assertResultFailed(validator.validate(request("GET","/v2/resource", null, "", false,
+        Map("X-TENANT"->List("1", "5"),
+            "X-OTHER"->List("other"))), response, chain), 404)
+    }
+  }
+
+  def sanityHeader(desc : String, validator : Validator) : Unit = {
+    val mapHeaderValue = b64Encode("""
+      {
+         "1" : ["a:admin","foo","bar"]
+      }
+    """)
+
+    AllRequests.foreach (r => {
+      val method = r._1
+      val url = r._2
+
+      test(s"$desc : Should fail on $method $url when appropriate headers, but a boolean tenant"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("1", "false")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+          400, List("X-TENANT"))
+      }
+    })
+  }
+
+  def sanityAnyHeader(desc : String, validator : Validator) : Unit = {
+    val mapHeaderValue = b64Encode("""
+      {
+         "1" : ["a:admin","foo","bar"],
+         "false" : ["a:admin"],
+         "booga" : ["a:admin"],
+         "wooga" : ["a:admin"]
+      }
+    """)
+
+    AllRequests.foreach (r => {
+      val method = r._1
+      val url = r._2
+
+      test(s"$desc : Should fail on $method $url when appropriate headers, but booga, wooga as tenants"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("booga", "wooga")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+          400, List("X-TENANT"))
+      }
+
+      test(s"$desc : Should succeed on $method $url on AnyMatch tenant when appropriate headers are set (tenants 1, booga, wooga)"){
+        validateHeaderRequest(validator,r, Some(List("1", "booga", "wooga")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue)))
+      }
+
+      test(s"$desc : Should succeed on $method $url on AnyMatch tenant when appropriate headers are set (tenants false, booga, wooga)"){
+        validateHeaderRequest(validator,r, Some(List("false", "booga", "wooga")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue)))
+      }
+    })
+  }
+
+  def sanityAllHeader(desc : String, validator : Validator) : Unit = {
+    val mapHeaderValue = b64Encode("""
+      {
+         "1" : ["a:admin","foo","bar"],
+         "false" : ["a:admin"],
+         "booga" : ["a:admin"],
+         "wooga" : ["a:admin"]
+      }
+    """)
+
+    AllRequests.foreach (r => {
+      val method = r._1
+      val url = r._2
+
+      test(s"$desc : Should fail on $method $url on AllMatch when appropriate headers, but booga, wooga as tenants"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("booga", "wooga")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+          400, List("X-TENANT"))
+      }
+
+      test(s"$desc : Should fail on $method $url on AllMatch tenant when appropriate headers are set (tenants 1, booga, wooga)"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("1", "booga", "wooga")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+          400, List("X-TENANT"))
+      }
+
+      test(s"$desc : Should succed on $method $url on AllMatch tenant when appropriate headers are set (tenants false, 1)"){
+        validateHeaderRequest(validator,r, Some(List("false", "1")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue)))
+      }
+    })
+  }
+
+  def happyWhenRaxRolesIsEnabledMultiHeader(desc : String, validator : Validator) : Unit = {
+    val mapHeaderValue = b64Encode("""
+      {
+         "1" : ["a:admin","foo","bar"],
+         "2" : ["a:creator", "foo", "a:observer"],
+         "3" : ["a:updater", "bar", "biz", "a:creator"],
+         "4" : ["a:observer"],
+         "5" : ["a:admin", "bar", "biz", "a:creator"],
+         "6" : ["biz", "baz"],
+         "7" : ["role with spaces", "biz"],
+         "8" : ["a:patcher"]
+      }
+    """)
+
+    AllRequests.foreach (r => {
+      val method = r._1
+      val url = r._2
+
+      //
+      //  All requests should pass if headers are correctly set and
+      //  all tenants map to admin, they should all set a Releveant
+      //  role of a:admin. Except AnyRequest which passes all roles
+      //  through as relevant roles.
+      //
+      r match {
+        case r : Request if (AnyRequests.contains(r)) =>
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenants 1, 5 selected)"){
+            validateHeaderRequest(validator,r, Some(List("1", "5")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), Some(List("foo", "bar")))
+          }
+        case _ =>
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenants 1, 5 selected)"){
+            validateHeaderRequest(validator,r, Some(List("1", "5")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), Some(List("a:admin/{X-TENANT}")))
+          }
+      }
+
+      //
+      //  All requests should fail if there is a mismatch with the
+      //  tenant. Except AnyRequests which are open to the world.
+      //
+      r match {
+        case r : Request if (AnyRequests.contains(r)) =>
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenants 1, 5, 7 selected)"){
+            validateHeaderRequest(validator,r, Some(List("1", "5", "7")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), Some(List("foo", "bar")))
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenants 1, 5, 6 selected)"){
+            validateHeaderRequest(validator,r, Some(List("1", "5", "6")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), Some(List("foo", "bar")))
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (no role info)"){
+            validateHeaderRequest(validator,r, Some(List("5", "1")), Some(List("other")), None, None)
+          }
+
+        case _ =>
+          test(s"$desc : Should fail on $method $url when appropriate headers are set but there's no tenant access (tenant, 1, 5, 7 selected)"){
+            assertResultFailed(
+              validateHeaderRequest(validator,r, Some(List("1", "5", "7")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+              403)
+          }
+
+          test(s"$desc : Should fail on $method $url when appropriate headers are set but there's no tenant access (tenant, 1, 5, 6 selected)"){
+            assertResultFailed(
+              validateHeaderRequest(validator,r, Some(List("1", "5", "6")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+              403)
+          }
+
+          test(s"$desc : Should fail on $method $url when appropriate headers are set but there's no tenant access (no role info)"){
+            assertResultFailed(
+              validateHeaderRequest(validator,r, Some(List("5", "1")), Some(List("other")), None, None),
+              403)
+          }
+      }
+
+      //
+      //  Multi tenant match of observer should only succeed on
+      //  observer (and Any) match
+      //
+      r match {
+        case r : Request if (AnyRequests.contains(r) || ObserverRequests.contains(r)) =>
+          val rroles = {
+            if (AnyRequests.contains(r)) {
+              Some(List("foo","bar"))
+            } else {
+              Some(List("a:observer/{X-TENANT}"))
+            }
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 4 selected)"){
+            validateHeaderRequest(validator,r, Some(List("4")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), rroles)
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 4, 2 selected)"){
+            validateHeaderRequest(validator,r, Some(List("4", "2")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), rroles)
+          }
+
+        case _ =>
+          test(s"$desc : Should fail on $method $url when appropriate headers are set but it's an observer only tenant"){
+            assertResultFailed(
+              validateHeaderRequest(validator,r, Some(List("4")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+              403)
+          }
+
+          test(s"$desc : Should fail on $method $url when appropriate headers are set but it's an observer only tenant (tenant 4, 2 selected)"){
+            assertResultFailed(
+              validateHeaderRequest(validator,r, Some(List("4", "2")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+              403)
+          }
+      }
+
+      //
+      //  Multi tenant match of creator should succeed
+      //  creator, admin, and AnyMatch.
+      //
+      r match {
+        case r : Request if (AnyRequests.contains(r) || CreatorRequests.contains(r)) =>
+          val rroles = {
+            if (AnyRequests.contains(r)) {
+              Some(List("foo","bar"))
+            } else {
+              Some(List("a:creator/{X-TENANT}", "a:admin/{X-TENANT}"))
+            }
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 1, 2, 3 selected)"){
+            validateHeaderRequest(validator,r, Some(List("1","2","3")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), rroles)
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 5, 2 selected)"){
+            validateHeaderRequest(validator,r, Some(List("5", "2")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), rroles)
+          }
+        case _ => /* Ignore */
+      }
+
+      //
+      //  Multi tenant match of updater should succeed
+      //  updater, admin, and AnyMatch.
+      //
+      r match {
+        case r : Request if (AnyRequests.contains(r) || UpdaterRequests.contains(r)) =>
+          val rroles = {
+            if (AnyRequests.contains(r)) {
+              Some(List("foo","bar"))
+            } else {
+              Some(List("a:updater/{X-TENANT}", "a:admin/{X-TENANT}"))
+            }
+          }
+
+          val rroles2 = {
+            if (AnyRequests.contains(r)) {
+              Some(List("foo","bar"))
+            } else {
+              Some(List("a:admin/{X-TENANT}"))
+            }
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 1, 3 selected)"){
+            validateHeaderRequest(validator,r, Some(List("1","3")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), rroles)
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 5, 3 selected)"){
+            validateHeaderRequest(validator,r, Some(List("5", "3")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), rroles)
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 1, 5 selected)"){
+            validateHeaderRequest(validator,r, Some(List("1", "5")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), rroles2)
+          }
+        case _ => /* Ignore */
+      }
+
+      //
+      // Admin only requests should succeed only with Adimn tenants.
+      //
+      r match {
+        case r : Request if (AnyRequests.contains(r) || AdminOnlyRequests.contains(r)) =>
+          val rroles = {
+            if (AnyRequests.contains(r)) {
+              Some(List("foo","bar"))
+            } else {
+              Some(List("a:admin/{X-TENANT}"))
+            }
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (adimn only tenant 1 selected)"){
+            validateHeaderRequest(validator,r, Some(List("1")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), rroles)
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (admin only tenant 1, 5 selected)"){
+            validateHeaderRequest(validator,r, Some(List("1", "5")), Some(List("other")), Some(List("foo","bar")),
+              Some(List(mapHeaderValue)), rroles)
+          }
+
+        case _ => /* Ignore */
+      }
+
+
+    })
+
+    //
+    // On Creator only requests, tenants with non-creator role, should
+    // fail.
+    //
+    CreatorRequests.foreach (r => {
+      val method = r._1
+      val url = r._2
+
+      test(s"$desc : Should fail on $method $url when appropriate headers are set but a tenant contains observer only"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("4","2")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+          403)
+      }
+
+      test(s"$desc : Should fail on $method $url when appropriate headers are set but there is a tenant role mismatch"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("6","3")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+          403)
+      }
+    })
+
+    //
+    // On Updater only requests, tenants with non-updater role, should
+    // fail.
+    //
+    UpdaterRequests.foreach (r => {
+      val method = r._1
+      val url = r._2
+
+      test(s"$desc : Should fail on $method $url when appropriate headers are set but a tenant contains observer only (4, 3)"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("4","3")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+          403)
+      }
+
+      test(s"$desc : Should fail on $method $url when appropriate headers are set but there is a tenant role mismatch (2, 1)"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("2","1")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+          403)
+      }
+    })
+
+    //
+    // On AdminOnly only requests, tenants with non-admin role, should
+    // fail.
+    //
+    AdminOnlyRequests.foreach (r => {
+      val method = r._1
+      val url = r._2
+
+      test(s"$desc : Should fail on $method $url when appropriate headers are set but a tenant contains observer only (4, 1)"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("4","1")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+          403)
+      }
+
+      test(s"$desc : Should fail on $method $url when appropriate headers are set but there is a tenant role mismatch (5, 2)"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("5","2")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+          403)
+      }
+    })
+
+    //
+    //  Special case, roles with spaces
+    //
+    test(s"$desc : Should succeed on PATCH in /v1/resource/other if a role with a space is specified") {
+      validateHeaderRequest(validator,("PATCH", "/v1/resource/other"), Some(List("7")), Some(List("other")), Some(List("foo","bar")),
+        Some(List(mapHeaderValue)), Some(List("role with spaces/{X-TENANT}")))
+    }
+
+    test(s"$desc : Should succeed on PATCH in /v1/resource/other if a role with a:patcher is specified") {
+      validateHeaderRequest(validator,("PATCH", "/v1/resource/other"), Some(List("7", "8")), Some(List("other")), Some(List("foo","bar")),
+        Some(List(mapHeaderValue)), Some(List("role with spaces/{X-TENANT}","a:patcher/{X-TENANT}")))
+    }
+
+    test(s"$desc : Should fail on PATCH in /v1/resource/other if a tenant without an appropriate role is specified") {
+      assertResultFailed(
+        validateHeaderRequest(validator,("PATCH", "/v1/resource/other"), Some(List("7", "8", "4")), Some(List("other")), Some(List("foo","bar")),
+          Some(List(mapHeaderValue)), None), 403)
+    }
+
+  }
+
+  //
+  // Run testcases
+  //
+  val disabledHeaderTestCase : TestCase = (
+    List(headerTenant, headerAllTenant, headerAnyTenant),  // WADLs
+    List(raxRolesDisabled, raxRolesDisabledRemoveDups),    // Configs
+    List(sanity)                                           // Suites
+  )
+  run(disabledHeaderTestCase)
+
+  val enabledMultiHeaderSanityTestCase : TestCase = (
+    List(headerTenant, headerTenantExplicit,
+      headerAtMethodTenant,
+      headerAtMethodTenantExplicit),                      // WADLs
+    List(raxRolesEnabled, raxRolesEnabledRemoveDups,
+      raxRolesEnabledIsTenantEnabled,
+      raxRolesEnabledIsTenantEnabledRemoveDups),          // Configs
+    List(sanityHeader)                                    // Suites
+  )
+  run(enabledMultiHeaderSanityTestCase)
+
+  val enabledMultiHeaderAnyTestCase : TestCase = (
+    List(headerAnyTenant,
+      headerAnyTenantExplicit,
+      headerAnyAtMethodTenant,
+      headerAnyAtMethodTenantExplicit),                   // WADLs
+    List(raxRolesEnabled, raxRolesEnabledRemoveDups,
+      raxRolesEnabledIsTenantEnabled,
+      raxRolesEnabledIsTenantEnabledRemoveDups),          // Configs
+    List(sanityAnyHeader)                                 // Suites
+  )
+  run(enabledMultiHeaderAnyTestCase)
+
+  val enabledMultiHeaderAllTestCase : TestCase = (
+    List(headerAllTenant,
+      headerAllTenantExplicit,
+      headerAllAtMethodTenant,
+      headerAllAtMethodTenantExplicit),                   // WADLs
+    List(raxRolesEnabled, raxRolesEnabledRemoveDups,
+      raxRolesEnabledIsTenantEnabled,
+      raxRolesEnabledIsTenantEnabledRemoveDups),          // Configs
+    List(sanityAllHeader)                                 // Suites
+  )
+  run(enabledMultiHeaderAllTestCase)
+
+  val enabledMultiHeaderTestCase : TestCase = (
+    List(headerTenant, headerAllTenant, headerAnyTenant,
+      headerTenantExplicit,
+      headerAllTenantExplicit,
+      headerAnyTenantExplicit,
+      headerAtMethodTenant,
+      headerAllAtMethodTenant,
+      headerAnyAtMethodTenant,
+      headerAtMethodTenantExplicit,
+      headerAnyAtMethodTenantExplicit,
+      headerAllAtMethodTenantExplicit),                   // WADLs
+    List(raxRolesEnabled, raxRolesEnabledRemoveDups,
+      raxRolesEnabledIsTenantEnabled,
+      raxRolesEnabledIsTenantEnabledRemoveDups),          // Configs
+    List(sanity, happyWhenRaxRolesIsEnabledMultiHeader)   // Suites
+  )
+  run(enabledMultiHeaderTestCase)
+
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesHeaderTenantBase.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesHeaderTenantBase.scala
@@ -1,0 +1,155 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.com.papi.components.checker.RunAssertionsHandler.ASSERT_FUNCTION
+import com.rackspace.com.papi.components.checker.servlet.{CheckerServletRequest, CheckerServletResponse}
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.MAP_ROLES_HEADER
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.ROLES_HEADER
+import com.rackspace.com.papi.components.checker.step.results.Result
+
+import scala.collection.JavaConversions._
+
+class ValidatorWADLRaxRolesHeaderTenantBase extends BaseValidatorSuite {
+  //
+  //  Configs
+  //
+  val raxRolesDisabled = ("rax roles disabled", {
+    val c = TestConfig()
+    c.checkHeaders = true
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = false
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = false
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesDisabledRemoveDups = ("rax roles disabled, remove dups", {
+    val c = TestConfig()
+    c.checkHeaders = true
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = false
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = true
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesEnabled = ("rax roles enabled", {
+    val c = TestConfig()
+    c.checkHeaders = true
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = false
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesEnabledRemoveDups = ("rax roles enabled, remove dups", {
+    val c = TestConfig()
+    c.checkHeaders = true
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = true
+    c.joinXPathChecks = false
+    c
+  })
+
+
+  val raxRolesEnabledIsTenantEnabled = ("rax roles enabled, isTenant enabled", {
+    val c = TestConfig()
+    c.checkHeaders = true
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = true
+    c.removeDups = false
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesEnabledIsTenantEnabledRemoveDups = ("rax roles enabled, isTenant enabled, remove dups", {
+    val c = TestConfig()
+    c.checkHeaders = true
+    c.enableCaptureHeaderExtension = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = true
+    c.removeDups = true
+    c.joinXPathChecks = false
+    c
+  })
+
+
+  //
+  //  Tenant Header spicific types and func
+  //
+  type HeaderValue = List[String]
+  type Request = (String /* Method */, String /* URI */)
+  type RequestSet = Set[Request]
+
+  val AnyRequests : RequestSet = Set(
+    ("GET","/v1/resource/other")
+  )
+  val ObserverRequests : RequestSet = Set(
+    ("GET","/v1/resource")
+  )
+  val CreatorRequests : RequestSet = Set(
+    ("POST","/v1/resource"),
+    ("POST","/v1/resource/other")
+  )
+  val UpdaterRequests : RequestSet = Set(
+    ("PUT","/v1/resource"),
+    ("PUT","/v1/resource/other")
+  )
+  val AdminOnlyRequests : RequestSet = Set(
+    ("DELETE","/v1/resource"),
+    ("DELETE","/v1/resource/other")
+  )
+
+  val AllRequests : RequestSet =
+    AnyRequests ++ ObserverRequests ++
+  CreatorRequests ++ UpdaterRequests ++
+  AdminOnlyRequests
+
+  def validateHeaderRequest (validator : Validator, req : Request,
+    tenant : Option[HeaderValue],
+    other : Option[HeaderValue],
+    roles : Option[HeaderValue],
+    mapRoles : Option[HeaderValue],
+    expectedRevRoles : Option[HeaderValue]=None) : Result = {
+    val headerMap : Map[String, List[String]] = {
+      var hm = Map[String, List[String]]()
+      tenant.foreach (hm += "X-TENANT" -> _)
+      other.foreach (hm += "X-OTHER" -> _)
+      roles.foreach (hm += ROLES_HEADER -> _)
+      mapRoles.foreach (hm += MAP_ROLES_HEADER -> _)
+      hm
+    }
+
+    val chkReq = request(req._1, req._2, null, "", false, headerMap)
+
+    expectedRevRoles.foreach( rr => {
+      chkReq.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        val rrSet = Set[String]() ++ csReq.getHeaders("X-RELEVANT-ROLES").toList
+        rr.foreach(r => {assert(rrSet.contains(r))})
+      })
+    })
+
+    validator.validate(chkReq,response, chain)
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesHeaderTenantSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesHeaderTenantSuite.scala
@@ -1,0 +1,457 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.MAP_ROLES_HEADER
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.ROLES_HEADER
+import com.rackspace.com.papi.components.checker.step.results.Result
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ValidatorWADLRaxRolesHeaderTenantSuite extends ValidatorWADLRaxRolesHeaderTenantBase with VaryTestSuite {
+  //
+  // Test WADLs
+  //
+  val headerTenant : TestWADL = ("Header Single Tenant",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                   repeating="false"/>
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}"/>
+            <method name="DELETE"/>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+                <method name="GET"  rax:roles="#all"/>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}"/>
+                <method name="DELETE"/>
+            </resource>
+        </resource>
+    </resources>
+      </application>)
+
+  val headerTenantExplicit : TestWADL = ("Header Single Tenant Explicit",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource"
+                  rax:roles="a:admin/{X-TENANT}" rax:isTenant="true">
+            <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                   repeating="false"/>
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}"/>
+            <method name="DELETE"/>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}"/>
+                <method name="GET"  rax:roles="#all"/>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}"/>
+                <method name="DELETE"/>
+            </resource>
+        </resource>
+    </resources>
+      </application>)
+
+
+
+  val headerAtMethodTenant : TestWADL = ("Header Single Tenant in a method",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource" rax:roles="a:admin/{X-TENANT}">
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="false"/>
+                </request>
+            </method>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="false"/>
+                </request>
+            </method>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="false"/>
+                </request>
+            </method>
+            <method name="DELETE">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="false"/>
+                </request>
+            </method>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="false"/>
+                    </request>
+                </method>
+                <method name="GET"  rax:roles="#all">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="false"/>
+                    </request>
+                </method>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="false"/>
+                    </request>
+                </method>
+                <method name="DELETE">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="false"/>
+                    </request>
+                </method>
+            </resource>
+        </resource>
+      </resources>
+      </application>)
+
+  val headerAtMethodTenantExplicit : TestWADL = ("Header Single Tenant in a method explicit isTenant",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <resources base="https://test.api.openstack.com">
+        <resource path="/v1/resource" rax:roles="a:admin/{X-TENANT}">
+            <param name="X-OTHER" style="header" required="true" type="xsd:string"
+                   repeating="false"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="false" rax:isTenant="true"/>
+                </request>
+            </method>
+            <method name="GET"  rax:roles="a:observer/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="false" rax:isTenant="true"/>
+                </request>
+            </method>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="false" rax:isTenant="true"/>
+                </request>
+            </method>
+            <method name="DELETE">
+                <request>
+                    <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                           repeating="false" rax:isTenant="true"/>
+                </request>
+            </method>
+            <resource path="other">
+                <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="false" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="GET"  rax:roles="#all">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="false" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="PUT"  rax:roles="a:updater/{X-TENANT}">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="false" rax:isTenant="true"/>
+                    </request>
+                </method>
+                <method name="DELETE">
+                    <request>
+                        <param name="X-TENANT" style="header" required="true" type="xsd:int"
+                               repeating="false" rax:isTenant="true"/>
+                    </request>
+                </method>
+            </resource>
+        </resource>
+      </resources>
+    </application>)
+
+
+  //
+  // Suites
+  //
+
+
+  //
+  //  These should fail regardless of configs they are simple sanity
+  //  tests on the validator.
+  //
+
+  def sanity(desc : String, validator : Validator) : Unit = {
+    test(s"$desc : Should fail with a 405 on patch /v1/resource") {
+      assertResultFailed(validator.validate(request("PATCH","/v1/resource", null, "", false,
+        Map("X-TENANT"->List("5"),
+            "X-OTHER"->List("other"))), response, chain), 405)
+    }
+
+    test(s"$desc : Should fail with 404 on GET /v2/resoruce"){
+      assertResultFailed(validator.validate(request("GET","/v2/resource", null, "", false,
+        Map("X-TENANT"->List("5"),
+            "X-OTHER"->List("other"))), response, chain), 404)
+    }
+  }
+
+  def happyWhenRaxRolesIsDisabled (desc : String, validator : Validator) : Unit = {
+    val mapHeaderValue = b64Encode("""
+      {
+         "1" : ["a:admin","a:observer","bar"],
+         "2" : ["a:admin", "foo"],
+         "3" : ["a:reviewer", "bar", "biz", "a:creator"],
+         "4" : ["a:observer"],
+         "5" : ["none"]
+      }
+    """)
+
+    AllRequests.foreach (r => {
+      val method = r._1
+      val url = r._2
+
+      //
+      //  All requests sholud succeed if appropriate headers are set,
+      //  and fail if they are malformed or absent, if no roles are set.
+      //
+
+      test(s"$desc : Should succeed on $method $url when appropriate headers are set (no roles)"){
+        validateHeaderRequest(validator,r, Some(List("5")), Some(List("other")), None, None)
+      }
+
+      test(s"$desc : Should fail on $method $url when the X-TENANT header is malformed (no roles)") {
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("foo")), Some(List("other")), None, None),
+          400, List("X-TENANT"))
+      }
+
+      test(s"$desc : Should fail on $method $url when the X-OTHER header is missing (no roles)") {
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("10")), None, None, None),
+          400, List("X-OTHER"))
+      }
+
+      //
+      //  All requests sholud succeed if appropriate headers are set,
+      //  and fail if they are malformed or absent, if bad roles are set.
+      //
+      test(s"$desc : Should succeed on $method $url when appropriate headers are set (bad roles)"){
+        validateHeaderRequest(validator,r, Some(List("5")), Some(List("other")), Some(List("foo","bar")), None)
+      }
+
+      test(s"$desc : Should fail on $method $url when the X-TENANT header is malformed (bad roles)") {
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("foo")), Some(List("other")), Some(List("foo","bar")), None),
+          400, List("X-TENANT"))
+      }
+
+      test(s"$desc : Should fail on $method $url when the X-OTHER header is missing (bad roles)") {
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("10")), None, Some(List("foo","bar")), None),
+          400, List("X-OTHER"))
+      }
+
+      //
+      //  All requests sholud succeed if appropriate headers are set,
+      //  and fail if they are malformed or absent, if bad map-role is set
+      //
+      test(s"$desc : Should succeed on $method $url when appropriate headers are set (bad map role)"){
+        validateHeaderRequest(validator,r, Some(List("5")), Some(List("other")), None, Some(List(mapHeaderValue)))
+      }
+
+      test(s"$desc : Should fail on $method $url when the X-TENANT header is malformed (bad map role)") {
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("foo")), Some(List("other")), None, Some(List(mapHeaderValue))),
+          400, List("X-TENANT"))
+      }
+
+      test(s"$desc : Should fail on $method $url when the X-OTHER header is missing (bad map role)") {
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("10")), None, None, Some(List(mapHeaderValue))),
+          400, List("X-OTHER"))
+      }
+    })
+  }
+
+  def happyWhenRaxRolesIsEnabledSingleHeader(desc : String, validator : Validator) : Unit = {
+    val mapHeaderValue = b64Encode("""
+      {
+         "1" : ["a:admin","foo","bar"],
+         "2" : ["a:creator", "foo", "a:observer"],
+         "3" : ["a:updater", "bar", "biz", "a:creator"],
+         "4" : ["a:observer"],
+         "5" : ["a:admin", "bar", "biz", "a:creator"]
+      }
+    """)
+
+    AllRequests.foreach (r => {
+      val method = r._1
+      val url = r._2
+
+      //
+      //  All requests should pass if headers are correctly set and
+      //  there is an admin role assigned via tenant
+      //
+      test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 1 selected)"){
+        validateHeaderRequest(validator,r, Some(List("1")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue)))
+      }
+
+      test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 5 selected)"){
+        validateHeaderRequest(validator,r, Some(List("5")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue)))
+      }
+
+      //
+      //  All requests should fail if there is a mismatch of the
+      //  tenant with a 403, unless it is a GET on /v1/resource/other,
+      //  because that's open to the world.
+      //
+      //  Same basic behavior should occur if Roles or header maps are
+      //  missing.
+      //
+      r match {
+        case r : Request if (AnyRequests.contains(r)) =>
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 7 selected)"){
+            validateHeaderRequest(validator,r, Some(List("7")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue)))
+          }
+
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (no role info)"){
+            validateHeaderRequest(validator,r, Some(List("7")), Some(List("other")), None, None)
+          }
+
+        case _ =>
+          test(s"$desc : Should fail on $method $url when appropriate headers are set but there's no tenant access (tenant 7 selected)"){
+            assertResultFailed(
+              validateHeaderRequest(validator,r, Some(List("7")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+              403)
+          }
+
+          test(s"$desc : Should fail on $method $url when appropriate headers are set but there's no tenant access (no role info)"){
+            assertResultFailed(
+              validateHeaderRequest(validator,r, Some(List("7")), Some(List("other")), None, None),
+              403)
+          }
+      }
+
+      //
+      //  Single tenant match of observer should only succeed on
+      //  observer (and Any) match
+      //
+      r match {
+        case r : Request if (AnyRequests.contains(r) || ObserverRequests.contains(r)) =>
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 4 selected)"){
+            validateHeaderRequest(validator,r, Some(List("4")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue)))
+          }
+        case _ =>
+          test(s"$desc : Should fail on $method $url when appropriate headers are set but it's an observer only tenant"){
+            assertResultFailed(
+              validateHeaderRequest(validator,r, Some(List("4")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+              403)
+          }
+      }
+
+      //
+      //  Single tenant match of creator / observer should only
+      //  succeed on creator, observer, and anyMatch.
+      //
+      r match {
+        case r : Request if (AnyRequests.contains(r) || CreatorRequests.contains(r) || ObserverRequests.contains(r)) =>
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 2 selected)"){
+            validateHeaderRequest(validator,r, Some(List("2")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue)))
+          }
+        case _ =>
+          test(s"$desc : Should fail on $method $url when appropriate headers are set but there is no match for creator or observer"){
+            assertResultFailed(
+              validateHeaderRequest(validator,r, Some(List("2")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+              403)
+          }
+      }
+
+      //
+      //  Single tenant match of creator / updater should only succed
+      //  on creator, updater, and anyMatch.
+      //
+      r match {
+        case r : Request if (AnyRequests.contains(r) || CreatorRequests.contains(r) || UpdaterRequests.contains(r)) =>
+          test(s"$desc : Should succeed on $method $url when appropriate headers are set (tenant 3 selected)"){
+            validateHeaderRequest(validator,r, Some(List("3")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue)))
+          }
+        case _ =>
+          test(s"$desc : Should fail on $method $url when appropriate headers are set but there is no match for creator or updater"){
+            assertResultFailed(
+              validateHeaderRequest(validator,r, Some(List("3")), Some(List("other")), Some(List("foo","bar")), Some(List(mapHeaderValue))),
+              403)
+          }
+      }
+
+
+      //
+      // All requests sholud fail if the tenant value is in the wrong
+      // format, or we miss the required X-OTHER header
+      //
+      test(s"$desc : Should fail with a 400 on $method $url when appropriate headers are set but there's a malformed tenant (foo)"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("foo")), Some(List("other")), None, None),
+          400, List("X-TENANT"))
+      }
+
+      test(s"$desc : Should fail with a 400 on $method $url when appropriate headers the correct tenant, but we miss required X-OTHER header"){
+        assertResultFailed(
+          validateHeaderRequest(validator,r, Some(List("1")), None, None, None),
+          400, List("X-OTHER"))
+      }
+    })
+  }
+
+  //
+  // Run testcases
+  //
+  val disabledHeaderTestCase : TestCase = (
+    List(headerTenant, headerTenantExplicit),           // WADLs
+    List(raxRolesDisabled, raxRolesDisabledRemoveDups), // Configs
+    List(sanity, happyWhenRaxRolesIsDisabled)           // Suites
+  )
+  run(disabledHeaderTestCase)
+
+  val enabledHeaderSingleTestCase : TestCase = (
+    List(headerTenant, headerTenantExplicit,
+      headerAtMethodTenant,
+      headerAtMethodTenantExplicit),                      // WADLs
+    List(raxRolesEnabled, raxRolesEnabledRemoveDups,
+      raxRolesEnabledIsTenantEnabled,
+      raxRolesEnabledIsTenantEnabledRemoveDups),          // Configs
+    List(sanity, happyWhenRaxRolesIsEnabledSingleHeader)  // Suites
+  )
+  run(enabledHeaderSingleTestCase)
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesURLTenantSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesURLTenantSuite.scala
@@ -1,0 +1,290 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.com.papi.components.checker.RunAssertionsHandler._
+import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.MAP_ROLES_HEADER
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.ROLES_HEADER
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml._
+
+@RunWith(classOf[JUnitRunner])
+class ValidatorWADLRaxRolesURLTenantSuite extends BaseValidatorSuite with VaryTestSuite {
+  //
+  //  Configs
+  //
+  val raxRolesDisabled : CaseConfig = ("rax roles disabled", {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = false
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = false
+    c
+  })
+
+  val raxRolesDisabledRemoveDups : CaseConfig = ("rax roles disabled, remove dups", {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = false
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = true
+    c
+  })
+
+  val raxRolesEnabled : CaseConfig = ("rax roles enabled", {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = false
+    c
+  })
+
+  val raxRolesEnabledRemoveDups : CaseConfig = ("rax roles enabled, remove dups", {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = true
+    c
+  })
+
+  val raxRolesEnabledIsTenantEnabled : CaseConfig = ("rax roles enabled, isTenant enabled", {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = true
+    c.removeDups = false
+    c
+  })
+
+  val raxRolesEnabledIsTenantEnabledRemoveDups : CaseConfig = ("rax roles enabled, isTenant enabled, remove dups", {
+    val c = TestConfig()
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = true
+    c.removeDups = true
+    c
+  })
+
+  //
+  //  Test WADLs
+  //
+  val urlTenant : TestWADL = ("URL Tenant WADL",
+    <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{tenant}/resource"
+                  rax:roles="a:admin/{tenant}">
+            <param name="tenant" style="template"/>
+            <method name="POST" rax:roles="a:creator/{tenant}"/>
+            <method name="GET" rax:roles="a:observer/{tenant} observer"/>
+            <method name="PUT" rax:roles="a:creator/{tenant}"/>
+            <method name="DELETE" rax:roles="a:creator/{tenant}"/>
+        </resource>
+    </resources>
+      </application>)
+
+  val urlTenantExplicit : TestWADL = ("URL Tenant WADL (explicit isTenant)",
+    <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{tenant}/resource" rax:roles="a:admin/{tenant}">
+                 <param name="tenant" style="template" rax:isTenant="true"/>
+                 <method name="POST" rax:roles="a:creator/{tenant}"/>
+                 <method name="GET" rax:roles="a:observer/{tenant} observer"/>
+                 <method name="PUT" rax:roles="a:creator/{tenant}"/>
+                 <method name="DELETE" rax:roles="a:creator/{tenant}"/>
+        </resource>
+    </resources>
+      </application>)
+
+  val urlXSDTenant : TestWADL = ("URL XSD Tenant WADL",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+          xmlns:rax="http://docs.rackspace.com/api"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{tenant}/resource"
+                  rax:roles="a:admin/{tenant}">
+            <param name="tenant" style="template" type="xsd:int"/>
+            <method name="POST" rax:roles="a:creator/{tenant}"/>
+            <method name="GET" rax:roles="a:observer/{tenant} observer"/>
+            <method name="PUT" rax:roles="a:creator/{tenant}"/>
+            <method name="DELETE" rax:roles="a:creator/{tenant}"/>
+        </resource>
+    </resources>
+      </application>)
+
+  val urlXSDTenantExplicit : TestWADL = ("URL XSD Tenant WADL (explicit isTenant)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+      xmlns:rax="http://docs.rackspace.com/api"
+      xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{tenant}/resource" rax:roles="a:admin/{tenant}">
+                 <param name="tenant" style="template" type="xsd:int" rax:isTenant="true"/>
+                 <method name="POST" rax:roles="a:creator/{tenant}"/>
+                 <method name="GET" rax:roles="a:observer/{tenant} observer"/>
+                 <method name="PUT" rax:roles="a:creator/{tenant}"/>
+                 <method name="DELETE" rax:roles="a:creator/{tenant}"/>
+        </resource>
+    </resources>
+      </application>)
+
+
+  //
+  //  Suites
+  //
+
+  //
+  //  These should always fail, regardless of configs, they're a
+  //  simple sanity test on validation.
+  //
+  def sadSanity(desc : String, validator : Validator) : Unit = {
+    test(s"$desc : Should fail with a 405 on patch /v1/0/resource") {
+      assertResultFailed(validator.validate(request("PATCH","/v1/0/resource"), response, chain), 405)
+    }
+
+    test(s"$desc : Should fail with 404 on GET /v2/resoruce"){
+      assertResultFailed(validator.validate(request("GET","/v2/resource"), response, chain), 404)
+    }
+  }
+
+  //
+  //  Should give positive results only when rax-roles is disabled.
+  //
+  def happyWhenRAXRolesIsDisabled (desc : String, validator : Validator) : Unit = {
+    //
+    // No roles sent
+    //
+    test(s"$desc : should allow GET on /v1/0/resource"){
+      validator.validate(request("GET","/v1/0/resource"), response, chain)
+    }
+
+    test(s"$desc : should allow POST on /v1/0/resource"){
+      validator.validate(request("POST","/v1/0/resource"), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /v1/0/resource"){
+      validator.validate(request("PUT","/v1/0/resource"), response, chain)
+    }
+
+    test(s"$desc : should allow DELETE on /v1/0/resource"){
+      validator.validate(request("DELETE","/v1/0/resource"), response, chain)
+    }
+
+    //
+    // Bad roles sent
+    //
+    test(s"$desc : should allow GET on /v1/777/resource"){
+      validator.validate(request("GET","/v1/777/resource", null, "", false, Map(ROLES_HEADER->List("baz","biz","wooga"))), response, chain)
+    }
+
+    test(s"$desc : should allow POST on /v1/777/resource"){
+      validator.validate(request("POST","/v1/777/resource", null, "", false, Map(ROLES_HEADER->List("baz","biz","wooga"))), response, chain)
+    }
+
+    test(s"$desc : should allow PUT on /v1/777/resource"){
+      validator.validate(request("PUT","/v1/777/resource", null, "", false, Map(ROLES_HEADER->List("baz","biz","wooga"))), response, chain)
+    }
+
+    test(s"$desc : should allow DELETE on /v1/777/resource"){
+      validator.validate(request("DELETE","/v1/777/resource", null, "", false, Map(ROLES_HEADER->List("baz","biz","wooga"))), response, chain)
+    }
+  }
+
+  def happyWhenRAXRolesIsEnabled (desc : String, validator : Validator) : Unit = {
+      val mapHeaderValue = b64Encode("""
+      {
+         "1" : ["a:admin","a:observer","bar"],
+         "2" : ["a:admin", "foo"],
+         "3" : ["a:reviewer", "bar", "biz", "a:creator"],
+         "4" : ["a:observer"]
+      }
+    """)
+
+    val observerTenants = List("1","2","4")
+
+    observerTenants.foreach( t => {
+      test(s"$desc : Should allow GET on /v1/$t/resource") {
+        validator.validate(request("GET",s"/v1/$t/resource", null, "", false,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+    })
+
+
+    test(s"$desc : Should allow GET on /v1/3/resource with observer") {
+      validator.validate(request("GET","/v1/3/resource", null, "", false,
+        Map(
+          ROLES_HEADER->List("baz","observer","b:admin","admin"),
+          MAP_ROLES_HEADER->List(mapHeaderValue)
+        )), response, chain)
+    }
+
+    test(s"$desc : Should reject GET on /v1/3/resource") {
+      assertResultFailed(
+        validator.validate(request("GET","/v1/3/resource", null, "", false,
+          Map(
+            ROLES_HEADER->List("baz","a:observer","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain), 403)
+    }
+
+    val creatorMethods = List("POST","PUT","DELETE")
+    val creatorTenants = List("1","2","3")
+
+    creatorMethods.foreach (m => {
+      creatorTenants.foreach (t => {
+        test(s"$desc : Should allow $m on /v1/$t/resource") {
+          validator.validate(request(m,s"/v1/$t/resource", null, "", false,
+            Map(
+              ROLES_HEADER->List("baz","biz","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain)
+        }
+      })
+
+      test(s"$desc : Should reject $m on /v1/4/resource") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/4/resource", null, "", false,
+            Map(
+              ROLES_HEADER->List("baz","a:observer","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+
+    })
+  }
+
+  //
+  //  Run testcases
+  //
+  val disabledURLTestCase : TestCase = (
+    List(urlTenant, urlTenantExplicit,
+         urlXSDTenant, urlXSDTenantExplicit),           // WADLs
+    List(raxRolesDisabled, raxRolesDisabledRemoveDups), // Configs
+    List(sadSanity, happyWhenRAXRolesIsDisabled)        // Suites
+  )
+  run(disabledURLTestCase)
+
+  val enabledURLTestCase : TestCase = (
+    List(urlTenant, urlTenantExplicit,
+         urlXSDTenant, urlXSDTenantExplicit),           // WADLs
+    List(raxRolesEnabled, raxRolesEnabledRemoveDups,
+         raxRolesEnabledIsTenantEnabled,
+         raxRolesEnabledIsTenantEnabledRemoveDups),     // Configs
+    List(sadSanity, happyWhenRAXRolesIsEnabled)         // Suites
+  )
+  run(enabledURLTestCase)
+
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesXPathTenantSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRaxRolesXPathTenantSuite.scala
@@ -1,0 +1,604 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.com.papi.components.checker.RunAssertionsHandler._
+import com.rackspace.com.papi.components.checker.servlet._
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.MAP_ROLES_HEADER
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.ROLES_HEADER
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml._
+
+@RunWith(classOf[JUnitRunner])
+class ValidatorWADLRaxRolesXPathTenantSuite extends BaseValidatorSuite with VaryTestSuite {
+  //
+  //  Configs
+  //
+  val raxRolesDisabled : CaseConfig = ("rax roles disabled", {
+    val c = TestConfig()
+    c.checkPlainParams = true
+    c.enableRaxRolesExtension = false
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = false
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesDisabledRemoveDupsJoinXPath : CaseConfig = ("rax roles disabled, remove dups, joinXPath", {
+    val c = TestConfig()
+    c.checkPlainParams = true
+    c.enableRaxRolesExtension = false
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c
+  })
+
+  val raxRolesEnabled : CaseConfig = ("rax roles enabled", {
+    val c = TestConfig()
+    c.checkPlainParams = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = false
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesEnabledRemoveDups : CaseConfig = ("rax roles enabled, remove dups", {
+    val c = TestConfig()
+    c.checkPlainParams = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = true
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesEnabledRemoveDupsJoinXPath : CaseConfig = ("rax roles enabled, remove dups, joinXPath", {
+    val c = TestConfig()
+    c.checkPlainParams = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = false
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c
+  })
+
+  val raxRolesEnabledIsTenantEnabled : CaseConfig = ("rax roles enabled, isTenant enabled", {
+    val c = TestConfig()
+    c.checkPlainParams = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = true
+    c.removeDups = false
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesEnabledIsTenantEnabledRemoveDups : CaseConfig = ("rax roles enabled, isTenant enabled, remove dups", {
+    val c = TestConfig()
+    c.checkPlainParams = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = true
+    c.removeDups = true
+    c.joinXPathChecks = false
+    c
+  })
+
+  val raxRolesEnabledIsTenantEnabledRemoveDupsJoinXPath : CaseConfig = ("rax roles enabled, isTenant enabled, remove dups, joinXPath", {
+    val c = TestConfig()
+    c.checkPlainParams = true
+    c.enableRaxRolesExtension = true
+    c.enableRaxIsTenantExtension = true
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c
+  })
+
+
+  //
+  //  Test WADLs
+  //
+  val xpathTenant : TestWADL = ("XPath and URL Tenant",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{X-TENANT}/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="X-TENANT" style="template"/>
+            <method name="POST" rax:roles="a:admin/{X-TENANT2} a:creator/{X-TENANT2}">
+                <request>
+                    <representation href="#xmlRep"/>
+                    <representation href="#jsonRep"/>
+                </request>
+            </method>
+            <method name="GET" rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:admin/{X-TENANT2} a:updater/{X-TENANT2}">
+                <request>
+                    <representation href="#xmlRep"/>
+                    <representation href="#jsonRep"/>
+                </request>
+            </method>
+            <method name="DELETE"/>
+        </resource>
+    </resources>
+    <representation id="xmlRep" mediaType="application/xml">
+        <param name="X-TENANT2" style="plain"
+               path="//@tenant2" required="true"/>
+    </representation>
+    <representation id="jsonRep" mediaType="application/json">
+        <param name="X-TENANT2" style="plain"
+               path="$body?tenant2" required="true"/>
+    </representation>
+  </application>)
+
+  val xpathTenantExplicit : TestWADL = ("XPath and URL Tenant (explicit isTenant)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{X-TENANT}/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="X-TENANT" style="template" rax:isTenant="true"/>
+            <method name="POST" rax:roles="a:admin/{X-TENANT2} a:creator/{X-TENANT2}">
+                <request>
+                    <representation href="#xmlRep"/>
+                    <representation href="#jsonRep"/>
+                </request>
+            </method>
+            <method name="GET" rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:admin/{X-TENANT2} a:updater/{X-TENANT2}">
+                <request>
+                    <representation href="#xmlRep"/>
+                    <representation href="#jsonRep"/>
+                </request>
+            </method>
+            <method name="DELETE"/>
+        </resource>
+    </resources>
+    <representation id="xmlRep" mediaType="application/xml">
+        <param name="X-TENANT2" style="plain"
+               path="//@tenant2" required="true"
+               rax:isTenant="true"/>
+    </representation>
+    <representation id="jsonRep" mediaType="application/json">
+        <param name="X-TENANT2" style="plain"
+               path="$body?tenant2" required="true"
+               rax:isTenant="true"/>
+    </representation>
+  </application>)
+
+  val xpathSameNameTenant : TestWADL = ("XPath and URL Tenant (with the same name)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{X-TENANT}/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="X-TENANT" style="template"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <representation href="#xmlRep"/>
+                    <representation href="#jsonRep"/>
+                </request>
+            </method>
+            <method name="GET" rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <representation href="#xmlRep"/>
+                    <representation href="#jsonRep"/>
+                </request>
+            </method>
+            <method name="DELETE"/>
+        </resource>
+    </resources>
+    <representation id="xmlRep" mediaType="application/xml">
+        <param name="X-TENANT" style="plain"
+               path="//@tenant2" required="true"/>
+    </representation>
+    <representation id="jsonRep" mediaType="application/json">
+        <param name="X-TENANT" style="plain"
+               path="$body?tenant2" required="true"/>
+    </representation>
+  </application>)
+
+  val xpathSameNameTenantExplicit : TestWADL = ("XPath and URL Tenant (with the same name, explicit isTenant)",
+    <application xmlns="http://wadl.dev.java.net/2009/02"
+             xmlns:rax="http://docs.rackspace.com/api"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <resources base="https://test.api.openstack.com">
+        <resource path="/v1/{X-TENANT}/resource"
+                  rax:roles="a:admin/{X-TENANT}">
+            <param name="X-TENANT" style="template" rax:isTenant="true"/>
+            <method name="POST" rax:roles="a:creator/{X-TENANT}">
+                <request>
+                    <representation href="#xmlRep"/>
+                    <representation href="#jsonRep"/>
+                </request>
+            </method>
+            <method name="GET" rax:roles="a:observer/{X-TENANT}"/>
+            <method name="PUT" rax:roles="a:updater/{X-TENANT}">
+                <request>
+                    <representation href="#xmlRep"/>
+                    <representation href="#jsonRep"/>
+                </request>
+            </method>
+            <method name="DELETE"/>
+        </resource>
+    </resources>
+    <representation id="xmlRep" mediaType="application/xml">
+        <param name="X-TENANT" style="plain"
+               path="//@tenant2" required="true"
+               rax:isTenant="true"/>
+    </representation>
+    <representation id="jsonRep" mediaType="application/json">
+        <param name="X-TENANT" style="plain"
+               path="$body?tenant2" required="true"
+               rax:isTenant="true"/>
+    </representation>
+  </application>)
+
+
+  //
+  // Suites
+  //
+
+
+  //
+  // These are useful for the tests below
+  //
+  val nonContentMethods = List("GET", "DELETE")
+  val contentMethods = List("POST", "PUT")
+
+
+  //
+  //  These sholud always fail regardless of configs, they're a simple
+  //  sanity test on validation.
+  //
+  def sadSanity(desc : String, validator : Validator) : Unit = {
+    test(s"$desc : Should fail with a 405 on patch /v1/0/resource") {
+      assertResultFailed(validator.validate(request("PATCH","/v1/0/resource"), response, chain), 405)
+    }
+
+    test(s"$desc : Should fail with 404 on GET /v2/resoruce"){
+      assertResultFailed(validator.validate(request("GET","/v2/resource"), response, chain), 404)
+    }
+  }
+
+  //
+  // These should give positive results only when rax:roles is disabled.
+  //
+  def happyWhenRaxRolesIsDisabled(desc : String, validator : Validator) : Unit = {
+    val mapHeaderValue = b64Encode("""
+      {
+         "a" : ["a:admin","a:observer","bar"],
+         "b" : ["a:admin", "foo"],
+         "c" : ["a:reviewer", "bar", "biz", "a:creator"],
+         "d" : ["a:observer"]
+      }
+    """)
+
+    //
+    // No roles or bad roles set
+    //
+    nonContentMethods.foreach(m => {
+      test(s"$desc : should allow $m on /v1/0/resource") {
+        validator.validate(request(m,"/v1/0/resource"), response, chain)
+      }
+
+      test(s"$desc : should allow $m on /v1/0/resource (bad roles)") {
+        validator.validate(request(m,"/v1/0/resource", null, "", false,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+    })
+
+    contentMethods.foreach (m => {
+      test(s"$desc : should allow a $m with XML on /v1/777/resource") {
+        validator.validate(request(m,"/v1/777/resource", "application/xml", <xml tenant2="foo"/>, true,
+          Map[String, List[String]]()), response, chain)
+      }
+
+      test(s"$desc : should allow a $m with XML on /v1/777/resource (bad roles)") {
+        validator.validate(request(m,"/v1/777/resource", "application/xml", <xml tenant2="foo"/>, true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+
+      test(s"$desc : should fail a $m with XML if the XML is bad on /v1/777/resource") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/777/resource", "application/xml", <xml tenant3="foo"/>, true,
+            Map[String, List[String]]()), response, chain), 400)
+      }
+
+      test(s"$desc : should allow a $m with JSON on /v1/777/resource") {
+        validator.validate(request(m,"/v1/777/resource", "application/json", """{ "tenant2" : "foo" }""", true,
+          Map[String, List[String]]()), response, chain)
+      }
+
+      test(s"$desc : should allow a $m with JSON on /v1/777/resource (bad roles)") {
+        validator.validate(request(m,"/v1/777/resource", "application/json", """{ "tenant2" : "foo" }""", true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+
+      test(s"$desc : should fail a $m with JSON if the JSON is bad on /v1/777/resource") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/777/resource", "application/json", """{ "tenant3" : "foo" }""", true,
+            Map[String, List[String]]()), response, chain), 400)
+      }
+    })
+  }
+
+  def happyWhenRAXRolesIsEnabled (desc : String, validator : Validator) : Unit = {
+      val mapHeaderValue = b64Encode("""
+      {
+         "1" : ["a:admin","foo","bar"],
+         "2" : ["a:creator", "foo", "a:observer"],
+         "3" : ["a:updater", "bar", "biz", "a:creator"],
+         "4" : ["a:observer"]
+      }
+    """)
+
+    //
+    // Admin tenants should be able to perform all operations. Here we
+    // get a:admin because we are accessing tenant 1 on the URI.
+    //
+    // We are deliberately not matching anything on tenant2 to test
+    // that case.
+    //
+    nonContentMethods.foreach (m => {
+      test(s"$desc : should allow $m on /v1/1/resource") {
+        validator.validate(request(m,"/v1/1/resource", null, "", false,
+          Map(
+            ROLES_HEADER->List("baz","biz","observer","notAnAdmin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+    })
+
+    contentMethods.foreach (m => {
+      test(s"$desc : should allow a $m with JSON on /v1/1/resource") {
+        validator.validate(request(m,"/v1/1/resource", "application/json", """{ "tenant2" : "foo" }""", true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+
+      test(s"$desc : should allow a $m with XML on /v1/1/resource") {
+        validator.validate(request(m,"/v1/1/resource", "application/xml", <xml tenant2="foo"/>, true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+    })
+
+    //
+    //  Check admin tenants here, this time we don't match the first
+    //  tenant, but we do match on the 2nd tenant.  In this case
+    //  nonContentMethods fail, but content methods pass.
+    //
+    nonContentMethods.foreach (m => {
+      test(s"$desc : should fail $m on /v1/777/resource (no role match!)") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/777/resource", null, "", false,
+            Map(
+              ROLES_HEADER->List("baz","biz","observer","notAnAdmin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+    })
+
+    contentMethods.foreach (m => {
+
+      test(s"$desc : should allow a $m with XML on /v1/777/resource") {
+        validator.validate(request(m,"/v1/777/resource", "application/xml", <xml tenant2="1"/>, true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+      }
+
+    })
+
+    //
+    //  In this case we match a:observer on the URL template. All
+    //  methods should fail except for GET.
+    //
+
+    test(s"$desc : should allow GET on /v1/4/resource") {
+        validator.validate(request("GET","/v1/4/resource", null, "", false,
+          Map(
+            ROLES_HEADER->List("baz","biz","observer","notAnAdmin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain)
+    }
+
+    test(s"$desc : should fail DELETE on /v1/4/resource") {
+      assertResultFailed(
+        validator.validate(request("DELETE","/v1/4/resource", null, "", false,
+          Map(
+            ROLES_HEADER->List("baz","biz","observer","notAnAdmin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain), 403)
+    }
+
+    contentMethods.foreach (m => {
+      test(s"$desc : should fail a $m with JSON on /v1/4/resource") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/4/resource", "application/json", """{ "tenant2" : "foo" }""", true,
+            Map(
+              ROLES_HEADER->List("baz","biz","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+
+      test(s"$desc : should fail a $m with XML on /v1/4/resource") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/4/resource", "application/xml", <xml tenant2="foo"/>, true,
+            Map(
+              ROLES_HEADER->List("baz","biz","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+    })
+
+    //
+    // Here we show content methods failing on observer when there's
+    // no match in the URL param.
+    //
+    //
+
+    contentMethods.foreach (m => {
+      test(s"$desc : should fail a $m with JSON on /v1/777/resource with 4 on tenant 2") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/777/resource", "application/json", """{ "tenant2" : "4" }""", true,
+            Map(
+              ROLES_HEADER->List("baz","biz","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+
+      test(s"$desc : should fail a $m with XML on /v1/777/resource with 4 on tenant 2") {
+        assertResultFailed(
+          validator.validate(request(m,"/v1/777/resource", "application/xml", <xml tenant2="4"/>, true,
+            Map(
+              ROLES_HEADER->List("baz","biz","b:admin","admin"),
+              MAP_ROLES_HEADER->List(mapHeaderValue)
+            )), response, chain), 403)
+      }
+    })
+
+
+    //
+    //  In this case we match the a:creator method in the plain
+    //  parameter, and no match in the URI parameter.  We can perform
+    //  a POST, but all other operations will fail.
+    //
+    //  (Note that failing on 777 match for nonContent methods already
+    //  checked above.)
+    //
+    //
+    test(s"$desc : should allow a POST with JSON on /v1/777/resource, when we match 2 on tenant 2") {
+      validator.validate(request("POST","/v1/777/resource", "application/json", """{ "tenant2" : "2" }""", true,
+        Map(
+          ROLES_HEADER->List("baz","biz","b:admin","admin"),
+          MAP_ROLES_HEADER->List(mapHeaderValue)
+        )), response, chain)
+    }
+
+    test(s"$desc : should allow a POST with XML on /v1/777/resource, when we match 2 on tenant 2") {
+      validator.validate(request("POST","/v1/777/resource", "application/xml", <xml tenant2="2"/>, true,
+        Map(
+          ROLES_HEADER->List("baz","biz","b:admin","admin"),
+          MAP_ROLES_HEADER->List(mapHeaderValue)
+        )), response, chain)
+    }
+
+    test(s"$desc : should fail a PUT with JSON on /v1/777/resource, when we match 2 on tenant 2") {
+      assertResultFailed(
+        validator.validate(request("PUT","/v1/777/resource", "application/json", """{ "tenant2" : "2" }""", true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain), 403)
+    }
+
+    test(s"$desc : should fail a PUT with XML on /v1/777/resource, when we match 2 on tenant 2") {
+      assertResultFailed(
+        validator.validate(request("PUT","/v1/777/resource", "application/xml", <xml tenant2="2"/>, true,
+          Map(
+            ROLES_HEADER->List("baz","biz","b:admin","admin"),
+            MAP_ROLES_HEADER->List(mapHeaderValue)
+          )), response, chain), 403)
+    }
+
+
+    //
+    // Same as above, but this case we check creator and updater
+    // simultaniously.
+    //
+    // (Note that failing on 777 match for nonContent methods already
+    //  checked above)
+    //
+    //
+    test(s"$desc : should allow a POST with JSON on /v1/777/resource, when we match 3 on tenant 2") {
+      validator.validate(request("POST","/v1/777/resource", "application/json", """{ "tenant2" : "3" }""", true,
+        Map(
+          ROLES_HEADER->List("baz","biz","b:admin","admin"),
+          MAP_ROLES_HEADER->List(mapHeaderValue)
+        )), response, chain)
+    }
+
+    test(s"$desc : should allow a POST with XML on /v1/777/resource, when we match 3 on tenant 2") {
+      validator.validate(request("POST","/v1/777/resource", "application/xml", <xml tenant2="3"/>, true,
+        Map(
+          ROLES_HEADER->List("baz","biz","b:admin","admin"),
+          MAP_ROLES_HEADER->List(mapHeaderValue)
+        )), response, chain)
+    }
+
+    test(s"$desc : should allow a PUT with JSON on /v1/777/resource, when we match 3 on tenant 2") {
+      validator.validate(request("PUT","/v1/777/resource", "application/json", """{ "tenant2" : "3" }""", true,
+        Map(
+          ROLES_HEADER->List("baz","biz","b:admin","admin"),
+          MAP_ROLES_HEADER->List(mapHeaderValue)
+        )), response, chain)
+    }
+
+    test(s"$desc : should fail a PUT with XML on /v1/777/resource, when we match 3 on tenant 2") {
+      validator.validate(request("PUT","/v1/777/resource", "application/xml", <xml tenant2="3"/>, true,
+        Map(
+          ROLES_HEADER->List("baz","biz","b:admin","admin"),
+          MAP_ROLES_HEADER->List(mapHeaderValue)
+        )), response, chain)
+    }
+
+  }
+
+  //
+  //  Run testcases
+  //
+  val disabledXPathTestCase : TestCase = (
+    List(xpathTenant, xpathTenantExplicit),                      // WADLs
+    List(raxRolesDisabled, raxRolesDisabledRemoveDupsJoinXPath), //Configs
+    List(sadSanity, happyWhenRaxRolesIsDisabled)                 // Suites
+  )
+  run (disabledXPathTestCase)
+
+  val enabledXPathTestCase : TestCase = (
+    List(xpathTenant, xpathTenantExplicit,
+         xpathSameNameTenant, xpathSameNameTenantExplicit),     // WADLs
+    List(raxRolesEnabled, raxRolesEnabledRemoveDups,
+         raxRolesEnabledRemoveDupsJoinXPath,
+         raxRolesEnabledIsTenantEnabled,
+         raxRolesEnabledIsTenantEnabledRemoveDups,
+         raxRolesEnabledIsTenantEnabledRemoveDupsJoinXPath),    //Configs
+    List(sadSanity, happyWhenRAXRolesIsEnabled)                 // Suites
+  )
+  run (enabledXPathTestCase)
+
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/VaryTestSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/VaryTestSuite.scala
@@ -1,0 +1,49 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker
+
+import com.rackspace.cloud.api.wadl.Converters._
+
+import java.io.File
+import scala.xml._
+
+trait VaryTestSuite {
+  type TestWADL     = (String, NodeSeq) /* Descrption, WADL */
+  type TestWADLList = List[TestWADL]    /* A list of test wadls */
+  type CaseConfig   = (String, Config)  /* Description, TestConfig */
+  type ConfigList   = List[CaseConfig]  /* A list of test configs */
+  type Suite        = (String, Validator) => Unit  /* A Function that runs tests, given a validator and a description */
+  type SuiteList    = List[Suite]        /* A list of tests */
+
+  type TestCase = (TestWADLList, ConfigList, SuiteList)
+
+  val localVaryWADLURI = (new File(System.getProperty("user.dir"),"myvarywadl.wadl")).toURI.toString
+
+  def run(t : TestCase) : Unit = {
+    val testWADLList   : TestWADLList = t._1
+    val configList : ConfigList = t._2
+    val suiteList : SuiteList = t._3
+
+    testWADLList.foreach (w => {
+      configList.foreach ( c => {
+        val validator = Validator((localVaryWADLURI, w._2), c._2)
+        suiteList.foreach (t => {
+          t(w._1+" : "+c._1, validator)
+        })
+      })
+    })
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/step/BaseStepSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/step/BaseStepSuite.scala
@@ -75,6 +75,7 @@ class BaseStepSuite extends BaseValidatorSuite {
   //  Test schema
   //
   val testSchema = schemaFactory.newSchema(new StreamSource(getClass.getResourceAsStream("/xsd/test-urlxsd.xsd")))
+  val xsdSchema  = schemaFactory.newSchema(new StreamSource(getClass.getResourceAsStream("/xsd/blank.xsd")))
 
   //
   // Test json schema

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/step/TenantRoleStepSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/step/TenantRoleStepSuite.scala
@@ -1,0 +1,552 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.step
+
+import javax.xml.namespace.QName
+
+import javax.servlet.FilterChain
+
+import com.rackspace.com.papi.components.checker.step.base.Step
+import com.rackspace.com.papi.components.checker.step.base.StepContext
+
+import com.rackspace.com.papi.components.checker.step.results.Result
+
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletResponse
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.MAP_ROLES_HEADER
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.ROLES_HEADER
+
+import com.rackspace.com.papi.components.checker.util.ImmutableNamespaceContext
+import com.rackspace.com.papi.components.checker.util.HeaderMap
+
+import com.rackspace.com.papi.components.checker.LogAssertions
+
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.databind.ObjectMapper
+
+import org.junit.runner.RunWith
+
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TenantRoleStepSuite extends BaseStepSuite with LogAssertions {
+
+  val mapHeaderValue = b64Encode("""
+      {
+         "tenant1" : ["admin","foo","bar"],
+         "tenant2" : ["admin", "foo"],
+         "tenant3" : ["foo", "bar", "biz", "booz"],
+         "tenant4" : ["booga"]
+      }
+    """)
+  val CAPTURE_HEADER = "X-TENANT-HEADER"
+  val XSD_STRING = new QName("http://www.w3.org/2001/XMLSchema", "string", "xsd")
+  val initContext = new StepContext(0, (new HeaderMap).addHeaders(ROLES_HEADER, List("foo")))
+
+  val privateMapper = {
+    val om = new ObjectMapper
+
+    om.registerModule(DefaultScalaModule)
+    om
+  }
+
+  type ProcessStepType = (String /* Tenant Param Name */,
+                          Boolean /* enable tenant */,
+                          Option[List[String]] /* matchTenants */,
+                          Option[Set[String]]  /* matchRoles */,
+                          Option[String] /* Capture Header */,
+                          StepContext /* existing context */) => StepContext
+
+  type TenantRoleSteps = Map[String /*step name*/, ProcessStepType]
+
+
+  //
+  //  These are functions of type ProcessStep that create a step and
+  //  do a check based on parameters.
+  //
+  def xpathProcessStep(tenantName : String, enableTenant : Boolean,
+                       matchTenants : Option[List[String]], matchRoles : Option[Set[String]],
+                       captureHeader : Option[String],
+                       context : StepContext) : StepContext = {
+    val nsContext = ImmutableNamespaceContext(Map("tst"->"http://test.org/test"))
+    val xpath = new XPath("XPath", "XPath", Some(tenantName), "/tst:tenants/tst:tenant[1]", None, None, nsContext, 20, captureHeader, enableTenant, 10, Array[Step]())
+    val xml = <tenants xmlns="http://test.org/test">
+    {
+      matchTenants match {
+        case Some(matches) => matches.map { t => <tenant>{t}</tenant> }
+        case None => <tenant/>
+      }
+    }
+    </tenants>
+    val req = request("PUT", "/a/b", "application/xml", xml, true, Map(MAP_ROLES_HEADER->List(mapHeaderValue)))
+
+    xpath.checkStep (req, response, chain, context).get
+  }
+
+  def jsonXPathProcessStep(tenantName : String, enableTenant : Boolean,
+                           matchTenants : Option[List[String]], matchRoles : Option[Set[String]],
+                           captureHeader : Option[String],
+                           context : StepContext) : StepContext = {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val xpath = new JSONXPath("JSONXPath", "JSONXPath", Some(tenantName), "$_?tenants(1)", None, None, nsContext, 31, captureHeader, enableTenant, 10, Array[Step]())
+    val json : Map[String, List[String]] = Map[String, List[String]]( "tenants" -> { matchTenants match {
+      case Some(mts : List[String]) => mts
+      case None => List[String]("")
+    }})
+    val req = request("PUT", "/a/b", "application/json",privateMapper.writeValueAsString(json), true, Map(MAP_ROLES_HEADER->List(mapHeaderValue)))
+
+    xpath.checkStep (req, response, chain, context).get
+  }
+
+  def uriProcessStep(tenantName : String, enableTenant : Boolean,
+                     matchTenants : Option[List[String]], matchRoles : Option[Set[String]],
+                     captureHeader : Option[String],
+                     context : StepContext) : StepContext = {
+
+    val uri = new URI("URI", "URI", Some(tenantName), ".*".r, captureHeader, enableTenant, Array[Step]())
+    //
+    //  This step requires a single match tenant, No match and
+    //  multi-match don't make sense in a URI param.
+    //
+    //  So if you're here 'cus of a None.get or NoSuchElementException,
+    //  you're using this function in the wrong test!
+    //
+    val uriMatch = matchTenants.get.head
+
+    uri.checkStep (request("GET", s"/$uriMatch/b","","", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue))), response, chain, context).get
+  }
+
+
+  def uriXSDProcessStep(tenantName : String, enableTenant : Boolean,
+                        matchTenants : Option[List[String]],
+                        matchRoles : Option[Set[String]], captureHeader : Option[String],
+                        context : StepContext) : StepContext = {
+    //
+    //  Because of the way error-messaging works with URIXSD, we can't
+    //  just call checkStep directly. We must call check and intercept
+    //  the context from there. Kinda nasty, this got somewhat fixed
+    //  with content error types, but not in URLXSD.
+    //
+    var retContext : Option[StepContext] = None
+    val capture = new Step("capture", "CaptureContext") {
+      override def check(req : CheckerServletRequest,
+                         resp : CheckerServletResponse,
+                         chain : FilterChain,
+                         captureContext : StepContext) : Option[Result] = {
+        retContext = Some(captureContext)
+        None
+      }
+    }
+    val urixsd = new URIXSD("URIXSD", "URIXSD", Some(tenantName), XSD_STRING, xsdSchema, captureHeader, enableTenant, Array[Step](capture))
+
+    //
+    //  This step requires a single match tenant, No match and
+    //  multi-match don't make sense in a URI param.
+    //
+    //  So if you're here 'cus of a None.get or NoSuchElementException,
+    //  you're using this function in the wrong test!
+    //
+    val uriMatch = matchTenants.get.head
+
+    urixsd.check (request("GET", s"/$uriMatch/b","","", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue))), response, chain, context)
+    retContext.get
+  }
+
+  def headerSingleProcessStep(tenantName : String, enableTenant : Boolean,
+                              matchTenants : Option[List[String]],
+                              matchRoles : Option[Set[String]], captureHeader : Option[String],
+                              context : StepContext) : StepContext = {
+    val header = new HeaderSingle("HEADER_SINGLE", "Header Single", tenantName, ".*".r, None, None, captureHeader, enableTenant, 12345, Array[Step]())
+
+    //
+    //  This step requires a single match tenant, multi-match does not
+    //  make sense in a HeaderSingle step.
+    //
+    //
+    val headerMatch = matchTenants.get.head
+
+    header.checkStep (request("GET", s"/a/b","","", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue), tenantName->List(headerMatch))),
+                      response, chain, context).get
+  }
+
+
+  def headerXSDSingleProcessStep(tenantName : String, enableTenant : Boolean,
+                                 matchTenants : Option[List[String]], matchRoles : Option[Set[String]],
+                                 captureHeader : Option[String],
+                                 context : StepContext) : StepContext = {
+    val header = new HeaderXSDSingle("HEADER_SINGLE", "Header Single", tenantName, XSD_STRING, xsdSchema, None, None, captureHeader, enableTenant, 12345, Array[Step]())
+
+    //
+    //  This step requires a single match tenant, multi-match does not
+    //  make sense in a HeaderSingle step.
+    //
+    //
+    val headerMatch = matchTenants.get.head
+
+    header.checkStep (request("GET", s"/a/b","","", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue), tenantName->List(headerMatch))),
+                      response, chain, context).get
+  }
+
+  def headerProcessStep(tenantName : String, enableTenant : Boolean,
+                        matchTenants : Option[List[String]], matchRoles : Option[Set[String]],
+                        captureHeader : Option[String],
+                        context : StepContext) : StepContext = {
+    val header = new Header("HEADER", "Header", tenantName, ".*".r, None, None, captureHeader, matchRoles, enableTenant, 12345, Array[Step]())
+
+    header.checkStep (request("GET", s"/a/b","","", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue), tenantName->matchTenants.get)),
+                      response, chain, context).get
+  }
+
+
+  def headerXSDProcessStep(tenantName : String, enableTenant : Boolean,
+                           matchTenants : Option[List[String]], matchRoles : Option[Set[String]],
+                           captureHeader : Option[String],
+                           context : StepContext) : StepContext = {
+    val header = new HeaderXSD("HEADERXSD", "Header XSD", tenantName, XSD_STRING, xsdSchema, None, None, captureHeader, matchRoles, enableTenant, 12345, Array[Step]())
+
+    header.checkStep (request("GET", s"/a/b","","", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue), tenantName->matchTenants.get)),
+                      response, chain, context).get
+  }
+
+
+  def headerAnyProcessStep(tenantName : String, enableTenant : Boolean,
+                           matchTenants : Option[List[String]], matchRoles : Option[Set[String]],
+                           captureHeader : Option[String],
+                           context : StepContext) : StepContext = {
+
+    val header = new HeaderAny("HEADER_ANY", "Header Any", tenantName, ".*".r, None, None, captureHeader, matchRoles, enableTenant, 12345, Array[Step]())
+
+    header.checkStep (request("GET", s"/a/b","","", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue), tenantName->matchTenants.get)),
+                      response, chain, context).get
+  }
+
+
+  def headerXSDAnyProcessStep(tenantName : String, enableTenant : Boolean,
+                              matchTenants : Option[List[String]],
+                              matchRoles : Option[Set[String]], captureHeader : Option[String],
+                              context : StepContext) : StepContext = {
+
+    val testHeader = "X-TEST-HEADER"
+    val header = new HeaderXSDAny("HEADERXSD_Any", "HeaderXSD Any", tenantName, XSD_STRING, xsdSchema, None, None, captureHeader, matchRoles, enableTenant, 12345, Array[Step]())
+
+    header.checkStep (request("GET", s"/a/b","","", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue), tenantName->matchTenants.get)),
+                      response, chain, context).get
+  }
+
+
+  def headerAllProcessStep(tenantName : String, enableTenant : Boolean,
+                           matchTenants : Option[List[String]], matchRoles : Option[Set[String]],
+                           captureHeader : Option[String],
+                           context : StepContext) : StepContext = {
+
+    val header = new HeaderAll("HEADER_ALL", "Header All", tenantName, None, None, Some(".*".r), None, None, captureHeader, matchRoles, enableTenant, 12345, Array[Step]())
+
+    header.checkStep (request("GET", s"/a/b","","", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue), tenantName->matchTenants.get)),
+                      response, chain, context).get
+  }
+
+
+  def captureHeaderProcessStep(tenantName : String, enableTenant : Boolean,
+                               matchTenants : Option[List[String]], matchRoles : Option[Set[String]],
+                               captureHeader : Option[String],
+                               context : StepContext) : StepContext = {
+    val nsContext = ImmutableNamespaceContext(Map[String,String]())
+    val captureHeaderStep = new CaptureHeader("CaptureHeader", "Capture Header", tenantName,  "$_?tenants?*", nsContext, 31, matchRoles, enableTenant, Array[Step]())
+    val json : Map[String, List[String]] = Map[String, List[String]]( "tenants" -> { matchTenants match {
+      case Some(mts : List[String]) => mts
+      case None => List[String]("")
+    }})
+    val req = request("PUT", "/a/b", "application/json",privateMapper.writeValueAsString(json), true, Map(MAP_ROLES_HEADER->List(mapHeaderValue)))
+
+    //
+    //  Capture header is a weird case because the parameter name and
+    //  the capture header name are always the same. We split these up
+    //  to play nice with the test faramework.
+    //
+    val contextWithRoles = captureHeaderStep.checkStep (req, response, chain, context).get
+    captureHeader match {
+      case Some(header) =>
+        contextWithRoles.copy(requestHeaders = contextWithRoles.requestHeaders.addHeaders(header, contextWithRoles.requestHeaders(tenantName)))
+      case None => contextWithRoles
+    }
+  }
+
+  //
+  //  Steps that can processes only a single tenant value.
+  //
+  val tenantRoleStepsSingle : TenantRoleSteps = Map(
+    "XPATH" -> xpathProcessStep,
+    "JSON_XPATH" -> jsonXPathProcessStep,
+    "URI" -> uriProcessStep,
+    "URIXSD" -> uriXSDProcessStep,
+    "HEADER_SINGLE" -> headerSingleProcessStep,
+    "HEADERXSD_SINGLE" -> headerXSDSingleProcessStep
+  )
+
+  //
+  //  Steps that can process multiple tenant values
+  //
+  val tenantRoleStepsMulti : TenantRoleSteps = Map(
+    "HEADER" -> headerProcessStep,
+    "HEADERXSD" -> headerXSDProcessStep,
+    "HEADER_ANY" -> headerAnyProcessStep,
+    "HEADERXSD_ANY" -> headerXSDAnyProcessStep,
+    "HEADER_ALL" -> headerAllProcessStep,
+    "CAPTURE_HEADER" -> captureHeaderProcessStep
+  )
+
+  //
+  // These tests cover single tenant value, note that we also run
+  // these tests on steps that support multiple tenant values as well.
+  //
+  for ((stepName, processStep) <- tenantRoleStepsSingle ++ tenantRoleStepsMulti) {
+    test(s"If isTenant is enabled in a(n) $stepName step should set correct roles on a match") {
+      val tstContext  = processStep("happyTenant",true, Some(List("tenant1")), None, None, initContext)
+      val tstContext2 = processStep("happyTenant",true, Some(List("tenant2")), None, None, initContext)
+      val tstContext3 = processStep("happyTenant",true, Some(List("tenant4")), None, None, initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo","admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}"))
+      assert (!tstContext.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo","admin/{happyTenant}", "foo/{happyTenant}"))
+      assert (!tstContext2.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo","booga/{happyTenant}"))
+      assert (!tstContext3.requestHeaders.contains(CAPTURE_HEADER))
+    }
+
+    test(s"If isTenant is enabled in a(n) $stepName step should set correct roles on a match (capture header)") {
+      val tstContext  = processStep("happyTenant",true, Some(List("tenant1")), None, Some(CAPTURE_HEADER), initContext)
+      val tstContext2 = processStep("happyTenant",true, Some(List("tenant2")), None, Some(CAPTURE_HEADER), initContext)
+      val tstContext3 = processStep("happyTenant",true, Some(List("tenant4")), None, Some(CAPTURE_HEADER), initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo","admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}"))
+      assert (tstContext.requestHeaders(CAPTURE_HEADER) == List("tenant1"))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo","admin/{happyTenant}", "foo/{happyTenant}"))
+      assert (tstContext2.requestHeaders(CAPTURE_HEADER) == List("tenant2"))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo","booga/{happyTenant}"))
+      assert (tstContext3.requestHeaders(CAPTURE_HEADER) == List("tenant4"))
+    }
+
+
+    test(s"If isTenant is enabled in a(n) $stepName, but there is no tenant match there should be no change in the content") {
+      val tstContext  = processStep("happyTenant", true, Some(List("t1")), None, None, initContext)
+      val tstContext2 = processStep("happyTenant", true, Some(List("t2")), None, None, initContext)
+      val tstContext3 = processStep("happyTenant", true, Some(List("t4")), None, None, initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext2.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext3.requestHeaders.contains(CAPTURE_HEADER))
+    }
+
+    test(s"If isTenant is enabled in a(n) $stepName, but there is no tenant match there should be no change in the content (capture header)") {
+      val tstContext  = processStep("happyTenant", true, Some(List("t1")), None, Some(CAPTURE_HEADER), initContext)
+      val tstContext2 = processStep("happyTenant", true, Some(List("t2")), None, Some(CAPTURE_HEADER), initContext)
+      val tstContext3 = processStep("happyTenant", true, Some(List("t4")), None, Some(CAPTURE_HEADER), initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext.requestHeaders(CAPTURE_HEADER) == List("t1"))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext2.requestHeaders(CAPTURE_HEADER) == List("t2"))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext3.requestHeaders(CAPTURE_HEADER) == List("t4"))
+    }
+
+    test(s"If isTenant is disabled in a(n) $stepName there should be no change in the content") {
+      val tstContext  = processStep("happyTenant",false, Some(List("tenant1")), None, None, initContext)
+      val tstContext2 = processStep("happyTenant",false, Some(List("tenant2")), None, None, initContext)
+      val tstContext3 = processStep("happyTenant",false, Some(List("tenant4")), None, None, initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext2.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext3.requestHeaders.contains(CAPTURE_HEADER))
+    }
+
+    test(s"If isTenant is disabled in a(n) $stepName there should be no change in the content (capture header)") {
+      val tstContext  = processStep("happyTenant",false, Some(List("tenant1")), None, Some(CAPTURE_HEADER), initContext)
+      val tstContext2 = processStep("happyTenant",false, Some(List("tenant2")), None, Some(CAPTURE_HEADER), initContext)
+      val tstContext3 = processStep("happyTenant",false, Some(List("tenant4")), None, Some(CAPTURE_HEADER), initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext.requestHeaders(CAPTURE_HEADER) == List("tenant1"))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext2.requestHeaders(CAPTURE_HEADER) == List("tenant2"))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext3.requestHeaders(CAPTURE_HEADER) == List("tenant4"))
+    }
+  }
+
+  //
+  // These tests cover multi tenant value checks
+  //
+  for ((stepName, processStep) <- tenantRoleStepsMulti) {
+
+    test(s"If isTenant is enabled in a(n) $stepName step should set correct roles on a match (multi-tenant)") {
+      val tstContext  = processStep("happyTenant",true, Some(List("tenant1", "tenant2", "tenant3")), Some(Set("foo/{happyTenant}")), None, initContext)
+      val tstContext2 = processStep("happyTenant",true, Some(List("tenant1", "tenant3")), Some(Set("bar/{happyTenant}","foo/{happyTenant}")), None, initContext)
+      val tstContext3 = processStep("happyTenant",true, Some(List("tenant1", "tenant2")), Some(Set("admin/{happyTenant}")), None, initContext)
+
+      assert ((Set[String]() ++ tstContext.requestHeaders(ROLES_HEADER)) == Set("foo", "foo/{happyTenant}"))
+      assert (!tstContext.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert ((Set[String]() ++ tstContext2.requestHeaders(ROLES_HEADER)) == Set("foo","bar/{happyTenant}", "foo/{happyTenant}"))
+      assert (!tstContext2.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert ((Set[String]() ++ tstContext3.requestHeaders(ROLES_HEADER)) == Set("foo","admin/{happyTenant}"))
+      assert (!tstContext3.requestHeaders.contains(CAPTURE_HEADER))
+    }
+
+    test(s"If isTenant is enabled in a(n) $stepName step should set correct roles on a match (multi-tenant, capture header)") {
+      val tstContext  = processStep("happyTenant",true, Some(List("tenant1", "tenant2", "tenant3")), Some(Set("foo/{happyTenant}")), Some(CAPTURE_HEADER), initContext)
+      val tstContext2 = processStep("happyTenant",true, Some(List("tenant1", "tenant3")), Some(Set("bar/{happyTenant}","foo/{happyTenant}")), Some(CAPTURE_HEADER), initContext)
+      val tstContext3 = processStep("happyTenant",true, Some(List("tenant1", "tenant2")), Some(Set("admin/{happyTenant}")), Some(CAPTURE_HEADER), initContext)
+
+      assert ((Set[String]() ++ tstContext.requestHeaders(ROLES_HEADER)) == Set("foo", "foo/{happyTenant}"))
+      assert (tstContext.requestHeaders(CAPTURE_HEADER) == List("tenant1", "tenant2", "tenant3"))
+
+      assert ((Set[String]() ++ tstContext2.requestHeaders(ROLES_HEADER)) == Set("foo","bar/{happyTenant}", "foo/{happyTenant}"))
+      assert (tstContext2.requestHeaders(CAPTURE_HEADER) == List("tenant1", "tenant3"))
+
+      assert ((Set[String]() ++ tstContext3.requestHeaders(ROLES_HEADER)) == Set("foo","admin/{happyTenant}"))
+      assert (tstContext3.requestHeaders(CAPTURE_HEADER) == List("tenant1", "tenant2"))
+    }
+
+    test(s"If isTenant is enabled in a(n) $stepName, but there is no tenant match there should be no change in the content (multi-tenant)") {
+      val tstContext  = processStep("happyTenant", true, Some(List("t1", "tenant1")), Some(Set("foo/{happyTenant}")), None, initContext)
+      val tstContext2 = processStep("happyTenant", true, Some(List("tenant1", "t2")), Some(Set("foo/{happyTenant}")), None, initContext)
+      val tstContext3 = processStep("happyTenant", true, Some(List("tenant3", "tenant1", "tenant4")), Some(Set("foo/{happyTenant}")), None, initContext)
+      val tstContext4 = processStep("happyTenant", true, Some(List("tenant4", "tenant2")), Some(Set("foo/{happyTenant}")), None, initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext2.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext3.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext4.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext4.requestHeaders.contains(CAPTURE_HEADER))
+    }
+
+    test(s"If isTenant is enabled in a(n) $stepName, but there is no tenant match there should be no change in the content (multi-tenant, capture header)") {
+      val tstContext  = processStep("happyTenant", true, Some(List("t1", "tenant1")), Some(Set("foo/{happyTenant}")), Some(CAPTURE_HEADER), initContext)
+      val tstContext2 = processStep("happyTenant", true, Some(List("tenant1", "t2")), Some(Set("foo/{happyTenant}")), Some(CAPTURE_HEADER), initContext)
+      val tstContext3 = processStep("happyTenant", true, Some(List("tenant3", "tenant1", "tenant4")), Some(Set("foo/{happyTenant}")), Some(CAPTURE_HEADER), initContext)
+      val tstContext4 = processStep("happyTenant", true, Some(List("tenant4", "tenant2")), Some(Set("foo/{happyTenant}")), Some(CAPTURE_HEADER), initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext.requestHeaders(CAPTURE_HEADER) == List("t1", "tenant1"))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext2.requestHeaders(CAPTURE_HEADER) == List("tenant1", "t2"))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext3.requestHeaders(CAPTURE_HEADER) == List("tenant3", "tenant1", "tenant4"))
+
+      assert (tstContext4.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext4.requestHeaders(CAPTURE_HEADER) == List("tenant4", "tenant2"))
+    }
+
+    test(s"If isTenant is disabled in a(n) $stepName there should be no change in the content (multi-tenant)") {
+      val tstContext  = processStep("happyTenant",false, Some(List("tenant1", "tenant2", "tenant3")), Some(Set("foo/{happyTenant}")), None, initContext)
+      val tstContext2 = processStep("happyTenant",false, Some(List("tenant1", "tenant3")), Some(Set("foo/{happyTenant}")), None, initContext)
+      val tstContext3 = processStep("happyTenant",false, Some(List("tenant1", "tenant2")), Some(Set("foo/{happyTenant}")), None, initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext2.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext3.requestHeaders.contains(CAPTURE_HEADER))
+    }
+
+    test(s"If isTenant is disabled in a(n) $stepName there should be no change in the content (multi-tenant, capture header)") {
+      val tstContext  = processStep("happyTenant",false, Some(List("tenant1", "tenant2", "tenant3")), Some(Set("foo/{happyTenant}")), Some(CAPTURE_HEADER), initContext)
+      val tstContext2 = processStep("happyTenant",false, Some(List("tenant1", "tenant3")), Some(Set("foo/{happyTenant}")), Some(CAPTURE_HEADER), initContext)
+      val tstContext3 = processStep("happyTenant",false, Some(List("tenant1", "tenant2")), Some(Set("foo/{happyTenant}")), Some(CAPTURE_HEADER), initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext.requestHeaders(CAPTURE_HEADER) == List("tenant1", "tenant2", "tenant3"))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext2.requestHeaders(CAPTURE_HEADER) == List("tenant1", "tenant3"))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext3.requestHeaders(CAPTURE_HEADER) == List("tenant1", "tenant2"))
+    }
+  }
+
+  //
+  //  XPath on XML has a weird properity where you can select a node
+  //  that won't actually resolve to a string.  This is specific to
+  //  XML nodes, and doesn't affect JSON. We test the weird case here.
+  //
+  val tenantRoleXPathStep : TenantRoleSteps = Map(
+    "XPATH" -> xpathProcessStep
+  )
+
+  for ((stepName, processStep) <- tenantRoleXPathStep) {
+    test(s"If isTenant is enabled in a(n) $stepName, but no tenant is selected there should be no change in the content") {
+      val tstContext  = processStep("happyTenant", true, None, None, None, initContext)
+      val tstContext2 = processStep("happyTenant", true, None, None, None, initContext)
+      val tstContext3 = processStep("happyTenant", true, None, None, None, initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext2.requestHeaders.contains(CAPTURE_HEADER))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (!tstContext3.requestHeaders.contains(CAPTURE_HEADER))
+    }
+
+    test(s"If isTenant is enabled in a(n) $stepName, but no tenant is selected there should be no change in the content (capture header)") {
+      val tstContext  = processStep("happyTenant", true, None, None, Some(CAPTURE_HEADER), initContext)
+      val tstContext2 = processStep("happyTenant", true, None, None, Some(CAPTURE_HEADER), initContext)
+      val tstContext3 = processStep("happyTenant", true, None, None, Some(CAPTURE_HEADER), initContext)
+
+      assert (tstContext.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext.requestHeaders(CAPTURE_HEADER) == List(""))
+
+      assert (tstContext2.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext2.requestHeaders(CAPTURE_HEADER) == List(""))
+
+      assert (tstContext3.requestHeaders(ROLES_HEADER) == List("foo"))
+      assert (tstContext3.requestHeaders(CAPTURE_HEADER) == List(""))
+    }
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/util/TenantUtilSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/util/TenantUtilSuite.scala
@@ -1,0 +1,248 @@
+/***
+ *   Copyright 2017 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.util
+
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.ROLES_HEADER
+import com.rackspace.com.papi.components.checker.servlet.CheckerServletRequest.MAP_ROLES_HEADER
+import com.rackspace.com.papi.components.checker.step.base.StepContext
+
+import com.rackspace.com.papi.components.checker.BaseValidatorSuite
+
+import org.junit.runner.RunWith
+import org.mockito.Mockito.when
+import org.scalatest.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class TenantUtilSuite extends BaseValidatorSuite {
+
+  type HappyPathAssertType = Map[(String /* Tenant Name */, String /*Tenant Value*/), List[String] /*Expected Roles*/]
+  type SadPathAssertType = Map[String /*  Desc*/, (String /* Tenant Name */, String /* Tenant Value */, Option[String] /* Map Header Value */)]
+
+
+  type HappyPathListAssertType = Map[(String /* Tenant Name */, List[String] /*Tenant Values*/), List[String] /*Expected Roles*/]
+  type SadPathListAssertType = Map[String /*  Desc*/, (String /* Tenant Name */, List[String] /* Tenant Values */, Option[String] /* Map Header Value */)]
+
+  val mapHeaderValue = b64Encode("""
+      {
+         "tenant1" : ["admin","foo","bar"],
+         "tenant2" : ["admin", "foo"],
+         "tenant3" : ["foo", "bar", "biz", "booz"],
+         "tenant4" : ["booga"]
+      }
+    """)
+
+  //
+  //  Happy asserts with no preexisting headers
+  //
+
+  val happyAsserts : HappyPathAssertType = Map(
+    ("happyTenant", "tenant1") -> List("admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}"),
+    ("happyTenant", "tenant2") -> List("admin/{happyTenant}", "foo/{happyTenant}"),
+    ("happyTenant", "tenant3") -> List("foo/{happyTenant}", "bar/{happyTenant}", "biz/{happyTenant}", "booz/{happyTenant}"),
+    ("fooTenant", "tenant1") -> List("admin/{fooTenant}", "foo/{fooTenant}", "bar/{fooTenant}")
+  )
+
+  val emptyContext = StepContext()
+
+  for ((tenantInfo, expectedRoles) <- happyAsserts) {
+    val tenantName  = tenantInfo._1
+    val tenantValue = tenantInfo._2
+
+    test(s"Assert correct headers given $tenantName and $tenantValue and an empty context") {
+      val req = new CheckerServletRequest(request("GET","/foo", "application/XML", "", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue))))
+      val newContext = TenantUtil.addTenantRoles(emptyContext, req, tenantName, tenantValue)
+      assert (newContext.requestHeaders(ROLES_HEADER) == expectedRoles)
+    }
+
+    test(s"Assert correct headers given $tenantName and $tenantValue and an empty context (list call)") {
+      val req = new CheckerServletRequest(request("GET","/foo", "application/XML", "", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue))))
+      val newContext = TenantUtil.addTenantRoles(emptyContext, req, tenantName, List(tenantValue), None)
+      assert (newContext.requestHeaders(ROLES_HEADER) == expectedRoles)
+    }
+
+  }
+
+  //
+  //  Happy asserts with existing request headers.
+  //
+
+  val happyNonEmptyAsserts : HappyPathAssertType = Map(
+    ("happyTenant", "tenant1") -> List("foo", "admin/{happyTenant}", "admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}"),
+    ("happyTenant", "tenant2") -> List("foo", "admin/{happyTenant}", "admin/{happyTenant}", "foo/{happyTenant}"),
+    ("happyTenant", "tenant3") -> List("foo", "admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}", "biz/{happyTenant}", "booz/{happyTenant}"),
+    ("fooTenant", "tenant1") -> List("foo", "admin/{happyTenant}", "admin/{fooTenant}", "foo/{fooTenant}", "bar/{fooTenant}")
+  )
+
+  val notEmptyContext = new StepContext(0, (new HeaderMap).addHeaders(ROLES_HEADER, List("foo","admin/{happyTenant}")))
+
+  for ((tenantInfo, expectedRoles) <- happyNonEmptyAsserts) {
+    val tenantName  = tenantInfo._1
+    val tenantValue = tenantInfo._2
+
+    test(s"Assert correct headers given $tenantName and $tenantValue and an non-empty context") {
+      val req = new CheckerServletRequest(request("GET","/foo", "application/XML", "", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue))))
+      val newContext = TenantUtil.addTenantRoles(notEmptyContext, req, tenantName, tenantValue)
+      assert (newContext.requestHeaders(ROLES_HEADER) == expectedRoles)
+    }
+
+    test(s"Assert correct headers given $tenantName and $tenantValue and an non-empty context (list call)") {
+      val req = new CheckerServletRequest(request("GET","/foo", "application/XML", "", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue))))
+      val newContext = TenantUtil.addTenantRoles(notEmptyContext, req, tenantName, List(tenantValue), None)
+      assert (newContext.requestHeaders(ROLES_HEADER) == expectedRoles)
+    }
+  }
+
+  //
+  //  Sad asserts, missed tenants.
+  //
+
+  val sadAsserts : SadPathAssertType = Map(
+    "If tenant does not match"->("happyTenant", "tenant5", Some(mapHeaderValue)),
+    "If the map header is null"->("happyTenant", "tenant1", Some(b64Encode("null"))),
+    "If the map header is valid json, with wrong format (boolean) "->("happyTenant", "tenant1", Some(b64Encode("false"))),
+    "If the map header is valid json, with wrong format (no list)"->("happyTenant", "tenant1", Some(b64Encode("""{ "tenant1" : "foo" }"""))),
+    "If the map header contains unparsadble json"->("happyTenant", "tenant1", Some(b64Encode("{ booga ]"))),
+    "If there is no map header"->("happyTenant", "tenant1", None),
+    "If we have bad base64 data"->("happyTenant", "tenant1", Some("""{ "tenant1" : ["foo"]} """))
+  )
+
+  for ((desc, assertInf) <- sadAsserts) {
+    val tenantName  = assertInf._1
+    val tenantValue = assertInf._2
+    val mapHeader   = assertInf._3
+
+    test(s"$desc do not modify the context") {
+      val req = new CheckerServletRequest(request("GET","/foo", "application/XML", "", false, mapHeader match {
+        case Some(s : String) => Map(MAP_ROLES_HEADER->List(s))
+        case None => Map[String, List[String]]()
+      }))
+
+      val newEmptyContext = TenantUtil.addTenantRoles(emptyContext, req, tenantName, tenantValue)
+      assert (newEmptyContext == emptyContext)
+
+      val newNotEmptyContext = TenantUtil.addTenantRoles(notEmptyContext, req, tenantName, tenantValue)
+      assert (newNotEmptyContext == notEmptyContext)
+    }
+
+    test(s"$desc do not modify the context (list call)") {
+      val req = new CheckerServletRequest(request("GET","/foo", "application/XML", "", false, mapHeader match {
+        case Some(s : String) => Map(MAP_ROLES_HEADER->List(s))
+        case None => Map[String, List[String]]()
+      }))
+
+      val newEmptyContext = TenantUtil.addTenantRoles(emptyContext, req, tenantName, List(tenantValue), None)
+      assert (newEmptyContext == emptyContext)
+
+      val newNotEmptyContext = TenantUtil.addTenantRoles(notEmptyContext, req, tenantName, List(tenantValue), None)
+      assert (newNotEmptyContext == notEmptyContext)
+    }
+
+  }
+
+  //
+  //  Happy asserts on a list with multiple tenant values.
+  //
+  val happyListAsserts : HappyPathListAssertType = Map(
+    ("happyTenant", List("tenant1", "tenant2")) -> List("foo/{happyTenant}", "admin/{happyTenant}", "bar/{happyTenant}"),
+    ("happyTenant", List("tenant2", "tenant1")) -> List("foo/{happyTenant}", "admin/{happyTenant}", "bar/{happyTenant}"),
+    ("happyTenant", List("tenant1", "tenant3")) -> List("bar/{happyTenant}", "foo/{happyTenant}", "admin/{happyTenant}"),
+    ("happyTenant", List("tenant3", "tenant1")) -> List("bar/{happyTenant}", "foo/{happyTenant}", "admin/{happyTenant}"),
+    ("happyTenant", List("tenant2", "tenant3")) -> List("foo/{happyTenant}", "bar/{happyTenant}", "admin/{happyTenant}"),
+    ("happyTenant", List("tenant1", "tenant2", "tenant3")) -> List("foo/{happyTenant}", "bar/{happyTenant}", "admin/{happyTenant}"),
+    ("happyTenant", List("tenant3", "tenant2", "tenant1")) -> List("foo/{happyTenant}", "bar/{happyTenant}", "admin/{happyTenant}"),
+    ("happyTenant", List("tenant2", "tenant3", "tenant1")) -> List("foo/{happyTenant}", "bar/{happyTenant}", "admin/{happyTenant}"),
+    ("fooTenant", List("tenant2", "tenant3", "tenant1")) -> List("foo/{fooTenant}", "bar/{fooTenant}", "admin/{fooTenant}")
+  )
+
+  for ((tenantInfo, expectedRoles) <- happyListAsserts) {
+    val tenantName = tenantInfo._1
+    val tenantValues = tenantInfo._2
+
+    test(s"Correctly Handle multiple roles with tenant name $tenantName on values : $tenantValues") {
+      val req = new CheckerServletRequest(request("GET","/foo", "application/XML", "", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue))))
+      val newContext = TenantUtil.addTenantRoles(emptyContext, req, tenantName, tenantValues, Some(Set("admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}",
+                                                                                                       "admin/{fooTenant}", "foo/{fooTenant}", "bar/{fooTenant}")))
+      assert ((Set[String]() ++ newContext.requestHeaders(ROLES_HEADER)) == (Set[String]() ++ expectedRoles))
+    }
+  }
+
+  //
+  //  Happy asserts with existing request headers
+  //
+  val happyNonEmptyListAsserts : HappyPathListAssertType = Map(
+    ("happyTenant", List("tenant1", "tenant2")) -> List("foo", "admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}"),
+    ("happyTenant", List("tenant2", "tenant1")) -> List("foo", "admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}"),
+    ("happyTenant", List("tenant1", "tenant3")) -> List("foo", "admin/{happyTenant}", "bar/{happyTenant}", "foo/{happyTenant}"),
+    ("happyTenant", List("tenant3", "tenant1")) -> List("foo", "admin/{happyTenant}", "bar/{happyTenant}", "foo/{happyTenant}"),
+    ("happyTenant", List("tenant2", "tenant3")) -> List("foo", "admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}"),
+    ("happyTenant", List("tenant1", "tenant2", "tenant3")) -> List("foo", "admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}"),
+    ("happyTenant", List("tenant3", "tenant2", "tenant1")) -> List("foo", "admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}"),
+    ("happyTenant", List("tenant2", "tenant3", "tenant1")) -> List("foo", "admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}"),
+    ("fooTenant", List("tenant2", "tenant3", "tenant1")) -> List("foo", "admin/{happyTenant}", "foo/{fooTenant}", "bar/{fooTenant}", "admin/{fooTenant}")
+  )
+
+  for ((tenantInfo, expectedRoles) <- happyNonEmptyListAsserts) {
+    val tenantName = tenantInfo._1
+    val tenantValues = tenantInfo._2
+
+    test(s"Correctly Handle multiple roles with tenant name $tenantName on values : $tenantValues on a non-empty context") {
+      val req = new CheckerServletRequest(request("GET","/foo", "application/XML", "", false, Map(MAP_ROLES_HEADER->List(mapHeaderValue))))
+      val newContext = TenantUtil.addTenantRoles(notEmptyContext, req, tenantName, tenantValues, Some(Set("admin/{happyTenant}", "foo/{happyTenant}", "bar/{happyTenant}",
+                                                                                                          "admin/{fooTenant}", "foo/{fooTenant}", "bar/{fooTenant}")))
+      assert ((Set[String]() ++ newContext.requestHeaders(ROLES_HEADER)) == (Set[String]() ++ expectedRoles))
+    }
+  }
+
+
+  //
+  //  Sad asserts, missed tenants with multiple tenant values.
+  //
+
+  val sadListAsserts : SadPathListAssertType = Map(
+    "If tenant does not match (does not exist)"->("happyTenant", List("tenant1","tenant5"), Some(mapHeaderValue)),
+    "If tenant does not match (no roles match)"->("happyTenant", List("tenant1","tenant2","tenant4"), Some(mapHeaderValue)),
+    "If tenant does not match (no roles match 2)"->("happyTenant", List("tenant4","tenant1","tenant3"), Some(mapHeaderValue)),
+    "If tenant does not match (no roles match 3)"->("happyTenant", List("tenant4","tenant2"), Some(mapHeaderValue)),
+    "If the map header is null"->("happyTenant", List("tenant1","tenant2"), Some(b64Encode("null"))),
+    "If the map header is valid json, with wrong format (boolean) "->("happyTenant", List("tenant1", "tenant2"), Some(b64Encode("false"))),
+    "If the map header is valid json, with wrong format (no list)"->("happyTenant", List("tenant1","tenant2"), Some(b64Encode("""{ "tenant1" : "foo" }"""))),
+    "If the map header contains unparsadble json"->("happyTenant", List("tenant1","tenant2"), Some(b64Encode("{ booga ]"))),
+    "If there is no map header"->("happyTenant", List("tenant1","tenant2"), None),
+    "If the map header has invalid base64 encoding"->("happyTenant", List("tenant1","tenant2"), Some("""{ "tenant1" : "foo" }"""))
+  )
+
+  for ((desc, assertInf) <- sadListAsserts) {
+    val tenantName  = assertInf._1
+    val tenantValues = assertInf._2
+    val mapHeader   = assertInf._3
+
+    test(s"$desc do not modify the context (multi-value)") {
+      val req = new CheckerServletRequest(request("GET","/foo", "application/XML", "", false, mapHeader match {
+        case Some(s : String) => Map(MAP_ROLES_HEADER->List(s))
+        case None => Map[String, List[String]]()
+      }))
+
+      val newEmptyContext = TenantUtil.addTenantRoles(emptyContext, req, tenantName, tenantValues, Some(Set("admin/{happyTenant}", "booga/{fooTenant}")))
+      assert (newEmptyContext == emptyContext)
+
+      val newNotEmptyContext = TenantUtil.addTenantRoles(notEmptyContext, req, tenantName, tenantValues, Some(Set("admin/{happyTenant}", "booga/{fooTenant}")))
+      assert (newNotEmptyContext == notEmptyContext)
+    }
+  }
+
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerTenantFailSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerTenantFailSpec.scala
@@ -1,0 +1,220 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import com.rackspace.com.papi.components.checker.{LogAssertions, Config}
+import org.apache.logging.log4j.Level
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerTenantFailSpec extends BaseCheckerSpec with LogAssertions {
+  //
+  // Namespaces
+  //
+  register ("xsd", "http://www.w3.org/2001/XMLSchema")
+  register ("wadl","http://wadl.dev.java.net/2009/02")
+  register ("chk","http://www.rackspace.com/repose/wadl/checker")
+
+  //
+  //  Custom Configs
+  //
+  val maskConfig = {
+    val c = new Config()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = true
+    c
+  }
+
+  val raxRolesConfig = {
+    val c = new Config()
+    c.enableRaxRolesExtension = true
+    c.maskRaxRoles403 = false
+    c
+  }
+
+  feature("The WADLCheckerBuilder identitifes errors related to tenanted roles and fails") {
+    info("As a delveloper")
+    info("I want to catch errors with tenanted roles early in the loading of a WADL")
+    info("so that I can more easly debug a WADL, and anomolies to appear in production")
+
+    //
+    //  The two scenarios below are a stop gap, while we implement
+    //  support for mask rax:roles.
+    //
+    scenario ("Given a transform with Mask Rax-Roles enabled") {
+      Given("a WADL which leverages rax:roles")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}" rax:roles="admin/{id}">
+                   <param name="id" style="template" type="xsd:string"/>
+                   <param name="stepType" style="template" type="xsd:string"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The WADL is translated")
+      val checkerLog = log(Level.ERROR) {
+        intercept[WADLException] {
+          val checker = builder.build(inWADL, maskConfig)
+          println (checker) // Should never print!
+        }
+      }
+      Then ("There should be an error detailing that rax:roles mask is currently not supported")
+      assert(checkerLog,"not implemented")
+    }
+
+    scenario ("Given a transform with Mask Rax-Roles enabled (no tenant match)") {
+      Given("a WADL which leverages rax:roles mask when there is no tenant match")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}" rax:roles="admin/{foo}">
+                   <param name="id" style="template" type="xsd:string"/>
+                   <param name="stepType" style="template" type="xsd:string"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The WADL is translated")
+      val checkerLog = log(Level.ERROR) {
+        intercept[WADLException] {
+          val checker = builder.build(inWADL, maskConfig)
+          println (checker) // Should never print!
+        }
+      }
+      Then ("There should be an error detailing that rax:roles mask is currently not supported")
+      assert(checkerLog,"not implemented")
+    }
+
+    scenario ("Given a transform with Rax-Roles on a teant but missing the tenant parameter") {
+      Given("a WADL which leverages rax:roles when there is no tenant match")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}" rax:roles="admin/{foo}">
+                   <param name="id" style="template" type="xsd:string"/>
+                   <param name="stepType" style="template" type="xsd:string"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The WADL is translated")
+      val checkerLog = log(Level.ERROR) {
+        intercept[WADLException] {
+          val checker = builder.build(inWADL, raxRolesConfig)
+          println (checker) // Should never print!
+        }
+      }
+      Then ("There should be an error detailing that rax:roles mask is currently not supported")
+      assert(checkerLog, "no defined param named 'foo'")
+    }
+
+    scenario ("Given a transform with Rax-Roles on a teant with a role name that contains a \\") {
+      Given("a WADL which leverages rax:roles tenanted with a role name that contains a \\")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}" rax:roles="ad\m\in/{header}">
+                   <param name="id" style="template" type="xsd:string"/>
+                   <param name="stepType" style="template" type="xsd:string"/>
+                   <method href="#getMethod" />
+              </resource>
+              <rax:captureHeader path="55" name="header"/>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The WADL is translated")
+      val checker = builder.build(inWADL, raxRolesConfig)
+      Then ("The backslash should be properly encoded")
+      assert(checker,"exists(/chk:checker/chk:step[@type='CAPTURE_HEADER' and @matchingRoles='ad\\m\\in/{header}'])")
+      assert(checker,"exists(/chk:checker/chk:step[@type='CAPTURE_HEADER' and @name='X-RELEVANT-ROLES' and contains(@path, 'ad\\m\\in/{header}')])")
+    }
+
+    scenario ("Given a transform with Rax-Roles on a teant with a role name that contains a \\\\") {
+      Given("a WADL which leverages rax:roles tenanted with a role name that contains a \\\\")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}" rax:roles="ad\\m\\in/{header}">
+                   <param name="id" style="template" type="xsd:string"/>
+                   <param name="stepType" style="template" type="xsd:string"/>
+                   <method href="#getMethod" />
+              </resource>
+              <rax:captureHeader path="55" name="header"/>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The WADL is translated")
+      val checker = builder.build(inWADL, raxRolesConfig)
+      Then ("The backslash should be properly encoded")
+      assert(checker,"exists(/chk:checker/chk:step[@type='CAPTURE_HEADER' and @matchingRoles='ad\\\\m\\\\in/{header}'])")
+      assert(checker,"exists(/chk:checker/chk:step[@type='CAPTURE_HEADER' and @name='X-RELEVANT-ROLES' and contains(@path, 'ad\\\\m\\\\in/{header}')])")
+    }
+
+
+    scenario ("Given a transform with Rax-Roles on a teant with a role name that contains a space") {
+      Given("a WADL which leverages rax:roles tenanted with a role name that contains a space")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}" rax:roles="ad&#xA0;m&#xA0;in/{header}">
+                   <param name="id" style="template" type="xsd:string"/>
+                   <param name="stepType" style="template" type="xsd:string"/>
+                   <method href="#getMethod" />
+              </resource>
+              <rax:captureHeader path="55" name="header"/>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The WADL is translated")
+      val checker = builder.build(inWADL, raxRolesConfig)
+      Then ("The backslash should be properly encoded")
+      assert(checker,"exists(/chk:checker/chk:step[@type='CAPTURE_HEADER' and @matchingRoles='ad m in/{header}'])")
+      assert(checker,"exists(/chk:checker/chk:step[@type='CAPTURE_HEADER' and @name='X-RELEVANT-ROLES' and contains(@path, 'ad m in/{header}')])")
+    }
+
+  }
+
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerTenantNoNameSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerTenantNoNameSpec.scala
@@ -1,0 +1,339 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import com.rackspace.com.papi.components.checker.{LogAssertions, Config}
+import org.apache.logging.log4j.Level
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml._
+
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerTenantNoNameSpec extends BaseCheckerSpec with LogAssertions {
+
+  case class TenantNoNameTest (desc : String, conf : Config, wadl : NodeSeq, messages : List[String])
+
+  //
+  // Custom configs
+  //
+  val plainConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = true
+    c.checkPlainParams = true
+    c.removeDups = false
+    c
+  }
+
+  val headerConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = true
+    c.checkHeaders = true
+    c.removeDups = false
+    c
+  }
+
+  val headerNoDupsConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = true
+    c.checkHeaders = true
+    c.removeDups = true
+    c
+  }
+
+  val noNameTestCases : Array[TenantNoNameTest] =  Array(
+    new TenantNoNameTest("Template pramater of type string missing name and isTenant=true",
+      stdConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}">
+                   <param style="template" type="xsd:string" rax:isTenant="true"/>
+                   <param name="stepType" style="template" type="xsd:string"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+        </application>, List("param of name 'id' is not found")),
+    new TenantNoNameTest("Template pramater of type int missing name and isTenant=true",
+      stdConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}">
+                   <param style="template" type="xsd:int" rax:isTenant="true"/>
+                   <param name="stepType" style="template" type="xsd:int"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+      </application>, List("param of name 'id' is not found")),
+    new TenantNoNameTest("XPath with missing name and isTenant=true",
+      plainConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/xml">
+                      <param style="plain" path="/tst:a/@id" required="true" rax:isTenant="true"/>
+                      <param name="stepType" style="plain" path="/tst:a/@stepType" required="true" />
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, List("The element requires a name", "/tst:a/@id")),
+    new TenantNoNameTest("JSON XPath with missing name and isTenant=true",
+      plainConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/json">
+                      <param style="plain" path="$_?tst?id" required="true" rax:isTenant="true"/>
+                      <param name="stepType" style="plain" path="$_?tst?stepType" required="true" />
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, List("The element requires a name", "$_?tst?id")),
+    new TenantNoNameTest("Header with missing name and isTenant=true",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param style="header" required="true" repeating="true" rax:isTenant="true"/>
+                  <param name="stepType" style="header" required="true" repeating="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, List("Headers always require a name", "header")),
+    new TenantNoNameTest("Header of type xsd:int with missing name and isTenant=true",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param style="header" required="true" repeating="true" type="xsd:int" rax:isTenant="true"/>
+                  <param name="stepType" style="header" required="true" type="xsd:int" repeating="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, List("Headers always require a name", "header")),
+    new TenantNoNameTest("Header (single) with missing name and isTenant=true",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param style="header" required="true"  rax:isTenant="true"/>
+                  <param name="stepType" style="header" required="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, List("Headers always require a name", "header")),
+    new TenantNoNameTest("Header (single) of type xsd:int with missing name and isTenant=true",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param style="header" required="true" type="xsd:int" rax:isTenant="true"/>
+                  <param name="stepType" style="header" required="true" type="xsd:int"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, List("Headers always require a name", "header")),
+    new TenantNoNameTest("Header (any) with missing name and isTenant=true",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="2388"/>
+                 <param style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, List("Headers always require a name", "header")),
+    new TenantNoNameTest("Header (xsd:int, any) with missing name and isTenant=true",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="2388"/>
+                 <param style="header" type="xsd:int" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true" rax:anyMatch="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true" rax:anyMatch="true" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, List("Headers always require a name", "header")),
+    new TenantNoNameTest("Header (all) with missing name and isTenant=true",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param style="header" type="xsd:int" required="true" repeating="true" rax:isTenant="true"/>
+                 <param style="header" type="xsd:string" required="true" repeating="true" fixed="foo" rax:isTenant="true"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" fixed="foo"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, List("Headers always require a name", "header")),
+    new TenantNoNameTest("Capture Header with missing name and isTenant=true",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <rax:captureHeader path="$req:uri" isTenant="true"/>
+                 <rax:captureHeader name="stepType" path="'CAPTURE_HEADER'" />
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, List("The element requires a name", "$req:uri"))
+  )
+
+  //
+  //  Register some common prefixes, you'll need the for XPath
+  //  assertions.
+  //
+  register ("xsd", "http://www.w3.org/2001/XMLSchema")
+  register ("wadl","http://wadl.dev.java.net/2009/02")
+  register ("chk","http://www.rackspace.com/repose/wadl/checker")
+  register ("tst", "http://www.rackspace.com/repose/wadl/checker/step/test")
+
+  feature ("The WADLCheckerBuilder can correctly identifies a WADL where a parameter name is misseng") {
+    info ("As a developer")
+    info ("I want to be able to catch errors with rax:isTenants when a param name is missing ")
+    info ("so that I can more easily debug a WADL")
+
+
+    //
+    //  In these cases we should make sure that the name is correctly
+    //  set or an error is generated.
+    //
+    for (nnt <- noNameTestCases) {
+      val desc = nnt.desc
+      scenario(desc) {
+        Given(s"a WADL where $desc")
+        val inWADL = nnt.wadl
+        When("the wadl is translated")
+        val checkerLog = log (Level.ERROR) {
+          intercept[WADLException] {
+            val checker = builder.build(inWADL, nnt.conf)
+            println(checker) // Should never print!
+          }
+        }
+        Then ("There should be an error detailing that the checker requires a name")
+        nnt.messages.foreach (assert(checkerLog, _))
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerTenantSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerTenantSpec.scala
@@ -1,0 +1,1365 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import com.rackspace.com.papi.components.checker.Config
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml._
+
+object WADLCheckerTenantSpec {
+  //
+  //  We create test cases for testing tenants for each step type.
+  //
+  case class TenantTest (desc : String, conf : Config, wadl : NodeSeq, stepType : String, isTenant : Boolean, stepCount : Int = 1)
+
+  val stdConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = true
+    c
+  }
+
+  val stdNTEConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = false
+    c
+  }
+
+
+  //
+  // Custom configs
+  //
+  val plainConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = true
+    c.checkPlainParams = true
+    c.removeDups = false
+    c
+  }
+
+  val plainNTEConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = false
+    c.checkPlainParams = true
+    c.removeDups = false
+    c
+  }
+
+  val headerConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = true
+    c.checkHeaders = true
+    c.removeDups = false
+    c
+  }
+
+  val headerNTEConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = false
+    c.checkHeaders = true
+    c.removeDups = false
+    c
+  }
+
+
+  val headerNoDupsConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = true
+    c.checkHeaders = true
+    c.removeDups = true
+    c
+  }
+
+  val headerNTENoDupsConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = false
+    c.checkHeaders = true
+    c.removeDups = true
+    c
+  }
+
+  def disabledTestCases : List[TenantTest] = List(
+    new TenantTest("The WADL contains a template parameter of type string with rax:isTenant (rax:isTenant extn disabled)",
+      stdNTEConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}">
+                   <param name="id" style="template" type="xsd:string" rax:isTenant="true"/>
+                   <param name="stepType" style="template" type="xsd:string"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+        </application>, "URL", false),
+    new TenantTest("The WADL contains a template parameter of type int with rax:isTenant (rax:isTenant extn disabled)",
+      stdNTEConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}">
+                   <param name="id" style="template" type="xsd:int" rax:isTenant="true"/>
+                   <param name="stepType" style="template" type="xsd:int"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+        </application>, "URLXSD", false),
+    new TenantTest("The WADL contains an XPath plain parameter of type string with rax:isTenant (rax:isTenant extn disabled)",
+      plainNTEConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/xml">
+                      <param name="id" style="plain" path="/tst:a/@id" required="true" rax:isTenant="true"/>
+                      <param name="stepType" style="plain" path="/tst:a/@stepType" required="true"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "XPATH", false),
+    new TenantTest("The WADL contains a JSON XPath plain parameter of type string with rax:isTenant (rax:isTenant extn disabled)",
+      plainNTEConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/json">
+                      <param name="id" style="plain" path="$_?tst?id" required="true" rax:isTenant="true"/>
+                      <param name="stepType" style="plain" path="$_?tst?stepType" required="true"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "JSON_XPATH", false),
+    new TenantTest("The WADL contains a Header parameter of type string with rax:isTenant (rax:isTenant extn disabled)",
+      headerNTEConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" required="true" repeating="true" rax:isTenant="true"/>
+                  <param name="stepType" style="header" required="true" repeating="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER", false),
+    new TenantTest("The WADL contains a Header parameter of type int with rax:isTenant (rax:isTenant extn disabled)",
+      headerNTEConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:isTenant="true"/>
+                  <param name="stepType" style="header" type="xsd:int" required="true" repeating="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD", false),
+    new TenantTest("The WADL contains a Header (single) parameter of type string with rax:isTenant (rax:isTenant extn disabled)",
+      headerNTEConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" required="true" rax:isTenant="true" />
+                  <param name="stepType" style="header" required="true" />
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_SINGLE", false),
+    new TenantTest("The WADL contains a Header (single) parameter of type int with rax:isTenant (rax:isTenant extn disabled)",
+      headerNTEConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" type="xsd:int" required="true" rax:isTenant="true" />
+                  <param name="stepType" style="header" type="xsd:int" required="true" />
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD_SINGLE", false),
+    new TenantTest("The WADL contains a Header (any) parameter of type string with rax:isTenant (remove dups) (rax:isTenant extn disabled)",
+      headerNTENoDupsConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+           <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="2388"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ANY", false),
+    new TenantTest("The WADL contains a Header (any) parameter of type int with rax:isTenant (mixed, 2) (rax:isTenant extn disabled)",
+      headerNTEConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false"/>
+                 <param name="id" style="header" type="xsd:float" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true" rax:anyMatch="true"/>
+                 <param name="stepType" style="header" type="xsd:float" required="true"  repeating="true" rax:anyMatch="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD_ANY", false, 2),
+    new TenantTest("The WADL contains a Header (all) parameter of types string, int with rax:isTenant (rax:isTenant extn disabled)",
+      headerNTEConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:isTenant="true"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" fixed="foo" rax:isTenant="true"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" fixed="foo"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ALL", false),
+    new TenantTest("The WADL contains a Capture header  with rax:isTenant (rax:isTenant extn disabled)",
+      headerNTEConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <rax:captureHeader name="id"       path="$req:uri" isTenant="true"/>
+                 <rax:captureHeader name="stepType" path="'CAPTURE_HEADER'" />
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "CAPTURE_HEADER", false)
+  )
+
+  def testCases : List[TenantTest] = List(
+    new TenantTest("The WADL contains a template parameter of type string without rax:isTenant",
+      stdConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}">
+                   <param name="id" style="template" type="xsd:string"/>
+                   <param name="stepType" style="template" type="xsd:string"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+        </application>, "URL", false),
+    new TenantTest("The WADL contains a template parameter of type string without rax:isTenant (explicit false)",
+      stdConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}">
+                   <param name="id" style="template" type="xsd:string" rax:isTenant="false"/>
+                   <param name="stepType" style="template" type="xsd:string" rax:isTenant="false"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+        </application>, "URL", false),
+    new TenantTest("The WADL contains a template parameter of type string with rax:isTenant",
+      stdConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}">
+                   <param name="id" style="template" type="xsd:string" rax:isTenant="true"/>
+                   <param name="stepType" style="template" type="xsd:string"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+        </application>, "URL", true),
+    new TenantTest("The WADL contains a template parameter of type int without rax:isTenant",
+      stdConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}">
+                   <param name="id" style="template" type="xsd:int"/>
+                   <param name="stepType" style="template" type="xsd:int"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+        </application>, "URLXSD", false),
+    new TenantTest("The WADL contains a template parameter of type int without rax:isTenant (explicit false)",
+      stdConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}">
+                   <param name="id" style="template" type="xsd:int" rax:isTenant="false"/>
+                   <param name="stepType" style="template" type="xsd:int" rax:isTenant="false"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+        </application>, "URLXSD", false),
+    new TenantTest("The WADL contains a template parameter of type int with rax:isTenant",
+      stdConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/{id}/resource/{stepType}">
+                   <param name="id" style="template" type="xsd:int" rax:isTenant="true"/>
+                   <param name="stepType" style="template" type="xsd:int"/>
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <response status="200 203"/>
+           </method>
+        </application>, "URLXSD", true),
+    new TenantTest("The WADL contains an XPath plain parameter of type string without rax:isTenant",
+      plainConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/xml">
+                      <param name="id" style="plain" path="/tst:a/@id" required="true"/>
+                      <param name="stepType" style="plain" path="/tst:a/@stepType" required="true"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "XPATH", false),
+    new TenantTest("The WADL contains an XPath plain parameter of type string without rax:isTenant (explicit false)",
+      plainConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/xml">
+                      <param name="id" style="plain" path="/tst:a/@id" required="true" rax:isTenant="false"/>
+                      <param name="stepType" style="plain" path="/tst:a/@stepType" required="true" rax:isTenant="false"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "XPATH", false),
+    new TenantTest("The WADL contains an XPath plain parameter of type string with rax:isTenant",
+      plainConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/xml">
+                      <param name="id" style="plain" path="/tst:a/@id" required="true" rax:isTenant="true"/>
+                      <param name="stepType" style="plain" path="/tst:a/@stepType" required="true"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "XPATH", true),
+    new TenantTest("The WADL contains a JSON XPath plain parameter of type string without rax:isTenant",
+      plainConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/json">
+                      <param name="id" style="plain" path="$_?tst?id" required="true"/>
+                      <param name="stepType" style="plain" path="$_?tst?stepType" required="true"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "JSON_XPATH", false),
+    new TenantTest("The WADL contains a JSON XPath plain parameter of type string without rax:isTenant (explicit false)",
+      plainConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/json">
+                      <param name="id" style="plain" path="$_?tst?id" required="true" rax:isTenant="false"/>
+                      <param name="stepType" style="plain" path="$_?tst?stepType" required="true" rax:isTenant="false"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "JSON_XPATH", false),
+    new TenantTest("The WADL contains a JSON XPath plain parameter of type string with rax:isTenant",
+      plainConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/json">
+                      <param name="id" style="plain" path="$_?tst?id" required="true" rax:isTenant="true"/>
+                      <param name="stepType" style="plain" path="$_?tst?stepType" required="true"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "JSON_XPATH", true),
+    new TenantTest("The WADL contains a Header parameter of type string without rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" required="true" repeating="true"/>
+                  <param name="stepType" style="header" required="true" repeating="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER", false),
+    new TenantTest("The WADL contains a Header parameter of type string without rax:isTenant (explicit false)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" required="true" repeating="true" rax:isTenant="false"/>
+                  <param name="stepType" style="header" required="true" repeating="true" rax:isTenant="false"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER", false),
+    new TenantTest("The WADL contains a Header parameter of type string with rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" required="true" repeating="true" rax:isTenant="true"/>
+                  <param name="stepType" style="header" required="true" repeating="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER", true),
+    new TenantTest("The WADL contains a Header parameter of type int without rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" type="xsd:int" required="true" repeating="true"/>
+                  <param name="stepType" style="header" type="xsd:int" required="true" repeating="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD", false),
+    new TenantTest("The WADL contains a Header parameter of type int without rax:isTenant (explicit false)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:isTenant="false"/>
+                  <param name="stepType" style="header" type="xsd:int" required="true" repeating="true" rax:isTenant="false"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD", false),
+    new TenantTest("The WADL contains a Header parameter of type int with rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:isTenant="true"/>
+                  <param name="stepType" style="header" type="xsd:int" required="true" repeating="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD", true),
+    new TenantTest("The WADL contains a Header (single) parameter of type string without rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" required="true" />
+                  <param name="stepType" style="header" required="true" />
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_SINGLE", false),
+    new TenantTest("The WADL contains a Header (single) parameter of type string without rax:isTenant (explicit false)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" required="true" rax:isTenant="false"/>
+                  <param name="stepType" style="header" required="true" rax:isTenant="false"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_SINGLE", false),
+    new TenantTest("The WADL contains a Header (single) parameter of type string with rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" required="true" rax:isTenant="true" />
+                  <param name="stepType" style="header" required="true" />
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_SINGLE", true),
+    new TenantTest("The WADL contains a Header (single) parameter of type int without rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" type="xsd:int" required="true" />
+                  <param name="stepType" style="header" type="xsd:int" required="true" />
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD_SINGLE", false),
+    new TenantTest("The WADL contains a Header (single) parameter of type int without rax:isTenant (explicit false)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" type="xsd:int" required="true" rax:isTenant="false"/>
+                  <param name="stepType" style="header" type="xsd:int" required="true" rax:isTenant="false"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD_SINGLE", false),
+    new TenantTest("The WADL contains a Header (single) parameter of type int with rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                  <param name="id" style="header" type="xsd:int" required="true" rax:isTenant="true" />
+                  <param name="stepType" style="header" type="xsd:int" required="true" />
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD_SINGLE", true),
+    new TenantTest("The WADL contains a Header (any) parameter of type string without rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" fixed="2388"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ANY", false, 2),
+    new TenantTest("The WADL contains a Header (any) parameter of type string without rax:isTenant (remove dups)",
+      headerNoDupsConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" fixed="2388"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ANY", false),
+    new TenantTest("The WADL contains a Header (any) parameter of type string without rax:isTenant (explicit false)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="2388"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ANY", false, 2),
+    new TenantTest("The WADL contains a Header (any) parameter of type string without rax:isTenant (remove dups, explicit false)",
+      headerNoDupsConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="2388"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ANY", false),
+    new TenantTest("The WADL contains a Header (any) parameter of type string with rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="2388"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ANY", true, 2),
+    new TenantTest("The WADL contains a Header (any) parameter of type string with rax:isTenant (mixed)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="2388"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ANY", true, 2),
+    new TenantTest("The WADL contains a Header (any) parameter of type string with rax:isTenant (mixed 2)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="2388"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ANY", true, 2),
+    new TenantTest("The WADL contains a Header (any) parameter of type string with rax:isTenant (remove dups)",
+      headerNoDupsConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+           <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="2388"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ANY", true),
+    new TenantTest("The WADL contains a Header (any) parameter of type string with rax:isTenant (remove dups, mixed)",
+      headerNoDupsConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+           <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="2388"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ANY", true),
+    new TenantTest("The WADL contains a Header (any) parameter of type string with rax:isTenant (remove dups, mixed 2)",
+      headerNoDupsConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+           <request>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false" fixed="2388"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true" fixed="4666"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" rax:anyMatch="true" fixed="bar"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ANY", true),
+    new TenantTest("The WADL contains a Header (any) parameter of type int without rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:anyMatch="true"/>
+                 <param name="id" style="header" type="xsd:float" required="true" repeating="true" rax:anyMatch="true"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true" rax:anyMatch="true"/>
+                 <param name="stepType" style="header" type="xsd:float" required="true"  repeating="true" rax:anyMatch="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD_ANY", false, 2),
+    new TenantTest("The WADL contains a Header (any) parameter of type int without rax:isTenant (explicit false)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false"/>
+                 <param name="id" style="header" type="xsd:float" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true" rax:anyMatch="true" rax:isTenant="false"/>
+                 <param name="stepType" style="header" type="xsd:float" required="true"  repeating="true" rax:anyMatch="true" rax:isTenant="false"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD_ANY", false, 2),
+    new TenantTest("The WADL contains a Header (any) parameter of type int with rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                 <param name="id" style="header" type="xsd:float" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true" rax:anyMatch="true"/>
+                 <param name="stepType" style="header" type="xsd:float" required="true"  repeating="true" rax:anyMatch="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD_ANY", true, 2),
+    new TenantTest("The WADL contains a Header (any) parameter of type int with rax:isTenant (mixed)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                 <param name="id" style="header" type="xsd:float" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true" rax:anyMatch="true"/>
+                 <param name="stepType" style="header" type="xsd:float" required="true"  repeating="true" rax:anyMatch="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD_ANY", true, 2),
+    new TenantTest("The WADL contains a Header (any) parameter of type int with rax:isTenant (mixed, 2)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="false"/>
+                 <param name="id" style="header" type="xsd:float" required="true" repeating="true" rax:anyMatch="true" rax:isTenant="true"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true" rax:anyMatch="true"/>
+                 <param name="stepType" style="header" type="xsd:float" required="true"  repeating="true" rax:anyMatch="true"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADERXSD_ANY", true, 2),
+    new TenantTest("The WADL contains a Header (all) parameter of types string, int without rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" fixed="foo"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true" />
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" fixed="foo"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ALL", false),
+    new TenantTest("The WADL contains a Header (all) parameter of types string, int without rax:isTenant (explicit false)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:isTenant="false"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" fixed="foo" rax:isTenant="false"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true" rax:isTenant="false"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" fixed="foo" rax:isTenant="false"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ALL", false),
+    new TenantTest("The WADL contains a Header (all) parameter of types string, int with rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:isTenant="true"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" fixed="foo" rax:isTenant="true"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" fixed="foo"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ALL", true),
+    new TenantTest("The WADL contains a Header (all) parameter of types string, int with rax:isTenant (mixed)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:isTenant="true"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" fixed="foo" rax:isTenant="false"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" fixed="foo"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ALL", true),
+    new TenantTest("The WADL contains a Header (all) parameter of types string, int with rax:isTenant (mixed, 2)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <param name="id" style="header" type="xsd:int" required="true" repeating="true" rax:isTenant="false"/>
+                 <param name="id" style="header" type="xsd:string" required="true" repeating="true" fixed="foo" rax:isTenant="true"/>
+                 <param name="stepType" style="header" type="xsd:int" required="true"  repeating="true"/>
+                 <param name="stepType" style="header" type="xsd:string" required="true"  repeating="true" fixed="foo"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "HEADER_ALL", true),
+    new TenantTest("The WADL contains a Capture header  without rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <rax:captureHeader name="id"       path="$req:uri"/>
+                 <rax:captureHeader name="stepType" path="'CAPTURE_HEADER'"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "CAPTURE_HEADER", false),
+    new TenantTest("The WADL contains a Capture header  without rax:isTenant (explicit false)",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <rax:captureHeader name="id"       path="$req:uri" isTenant="false"/>
+                 <rax:captureHeader name="stepType" path="'CAPTURE_HEADER'" isTenant="false"/>
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "CAPTURE_HEADER", false),
+    new TenantTest("The WADL contains a Capture header  with rax:isTenant",
+      headerConfig, <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+               <request>
+                 <rax:captureHeader name="id"       path="$req:uri" isTenant="true"/>
+                 <rax:captureHeader name="stepType" path="'CAPTURE_HEADER'" />
+               </request>
+               <response status="200 203"/>
+           </method>
+        </application>, "CAPTURE_HEADER", true)
+  )
+}
+
+import WADLCheckerTenantSpec._
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerTenantSpec extends BaseCheckerSpec {
+  //
+  //  Register some common prefixes, you'll need the for XPath
+  //  assertions.
+  //
+  register ("xsd", "http://www.w3.org/2001/XMLSchema")
+  register ("wadl","http://wadl.dev.java.net/2009/02")
+  register ("chk","http://www.rackspace.com/repose/wadl/checker")
+  register ("tst", "http://www.rackspace.com/repose/wadl/checker/step/test")
+
+  feature ("The WADLCheckerBuilder can correctly transforma a WADL into checker format") {
+    info ("As a developer")
+    info ("I want to be able to transform a WADL which references rax:isTenants to a ")
+    info ("a description of a machine that can validate the API in checker format")
+    info ("so that an API validator can process the checker format to validate the API")
+    info ("and correctly set tenant roles")
+
+    //
+    //  Happy path tests, we are simply making sure that for each step
+    //  type we correctly set (or not set) the isTenant attribute on
+    //  the step.
+    //
+    //  The scenarios are described in the testCases list above, but
+    //  the assertions are fairly static in these cases.
+    //
+
+    for (tt <- testCases ++ disabledTestCases) {
+      val desc = tt.desc
+      scenario(desc) {
+        val stepType = tt.stepType
+        val stepCount = tt.stepCount
+        Given(s"a WADL where $desc")
+        val inWADL = tt.wadl
+        When ("the wadl is translated")
+        val checker = builder.build (inWADL, tt.conf)
+        Then (s"There should be steps of $stepType")
+        assert(checker, s"count(/chk:checker/chk:step[@type='$stepType' and lower-case(@name)='id']) = $stepCount")
+        assert(checker, s"count(/chk:checker/chk:step[@type='$stepType' and lower-case(@name)='steptype']) = $stepCount")
+        And (s"The $stepType 'stepType' step should have isTenant set to false (or not set)")
+        assert(checker, s"every $$s in /chk:checker/chk:step[@type='$stepType' and lower-case(@name)='steptype'] satisfies not(xsd:boolean($$s/@isTenant))")
+        if (!tt.isTenant) {
+          And (s"The $stepType 'id' step should have isTenant set to false (or not set)")
+          assert(checker, s"every $$s in /chk:checker/chk:step[@type='$stepType' and lower-case(@name)='id'] satisfies not(xsd:boolean($$s/@isTenant))")
+        } else {
+          And (s"The $stepType 'id' step should have isTenant set to true")
+          assert(checker, s"every $$s in /chk:checker/chk:step[@type='$stepType' and lower-case(@name)='id'] satisfies xsd:boolean($$s/@isTenant)")
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerTenantXPathOptSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerTenantXPathOptSpec.scala
@@ -1,0 +1,258 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import com.rackspace.com.papi.components.checker.Config
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.xml._
+
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerTenantXPathOptSpec extends BaseCheckerSpec {
+
+  //
+  // Custom configs
+  //
+  val plainConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = true
+    c.checkPlainParams = true
+    c.removeDups = false
+    c.joinXPathChecks = false
+    c
+  }
+
+  val plainDupsConfig = {
+    val c = new Config
+    c.enableRaxIsTenantExtension = true
+    c.checkPlainParams = true
+    c.removeDups = true
+    c.joinXPathChecks = true
+    c
+  }
+
+  //
+  //  Register some common prefixes, you'll need the for XPath
+  //  assertions.
+  //
+  register ("xsd", "http://www.w3.org/2001/XMLSchema")
+  register ("wadl","http://wadl.dev.java.net/2009/02")
+  register ("chk","http://www.rackspace.com/repose/wadl/checker")
+  register ("xsl", "http://www.w3.org/1999/XSL/Transform")
+
+  feature ("The WADLCheckerBuilder can correctly handle rax:isTenant extension with XPath join optimization") {
+    info ("As a developer")
+    info ("When translating a WADL to checker format with rax:isTenant, I wast XPath join optimization to work correctly")
+    info ("so that I can take advantage of the optimization when it's appropriate.")
+
+
+    scenario ("A WADL with two XPaths no rax:isTenant set to false and joinXPathChecks disabled") {
+      Given("A WADL with two XPath, no rax:isTenant")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/xml">
+                      <param name="id" style="plain" path="/tst:a/@id" required="true"/>
+                      <param name="stepType" style="plain" path="/tst:a/@stepType" required="true"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The wadl is translated")
+      val checker = builder.build (inWADL, plainConfig)
+      Then("There should be the right number of XPath steps")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @name='id']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @name='stepType']) = 1")
+    }
+
+    scenario ("A WADL with two XPaths no rax:isTenant set to false and joinXPathChecks enabled") {
+      Given("A WADL with two XPath, no rax:isTenant")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/xml">
+                      <param name="id" style="plain" path="/tst:a/@id" required="true"/>
+                      <param name="stepType" style="plain" path="/tst:a/@stepType" required="true"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The wadl is translated")
+      val checker = builder.build (inWADL, plainDupsConfig)
+      Then("There should be no XPath steps and an XSL should be in its place")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 0")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']) = 1")
+      assert (checker, "count(//xsl:when[@test='/tst:a/@id']) = 1")
+      assert (checker, "count(//xsl:when[@test='/tst:a/@stepType']) = 1")
+    }
+
+    scenario ("A WADL with two XPaths no rax:isTenant set to false and joinXPathChecks enabled (explicit false)") {
+      Given("A WADL with two XPath, no rax:isTenant")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/xml">
+                      <param name="id" style="plain" path="/tst:a/@id" required="true" rax:isTenant="false"/>
+                      <param name="stepType" style="plain" path="/tst:a/@stepType" required="true" rax:isTenant="false"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The wadl is translated")
+      val checker = builder.build (inWADL, plainDupsConfig)
+      Then("There should be no XPath steps and an XSL should be in its place")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 0")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']) = 1")
+      assert (checker, "count(//xsl:when[@test='/tst:a/@id']) = 1")
+      assert (checker, "count(//xsl:when[@test='/tst:a/@stepType']) = 1")
+    }
+
+    scenario ("A WADL with two XPaths  rax:isTenant set to true to both of them and joinXPathChecks enabled") {
+      Given("A WADL with two XPath, no rax:isTenant")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/xml">
+                      <param name="id" style="plain" path="/tst:a/@id" required="true" rax:isTenant="true"/>
+                      <param name="stepType" style="plain" path="/tst:a/@stepType" required="true" rax:isTenant="true"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The wadl is translated")
+      val checker = builder.build (inWADL, plainDupsConfig)
+      Then("There should be no XSL steps and an XPATH steps should be in its place")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']) = 0")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @name='id']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @name='stepType']) = 1")
+    }
+
+    scenario ("A WADL with two XPaths rax:isTenant set to true on the first one and joinXPathChecks enabled") {
+      Given("A WADL with two XPath, no rax:isTenant")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/xml">
+                      <param name="id" style="plain" path="/tst:a/@id" required="true" rax:isTenant="true"/>
+                      <param name="stepType" style="plain" path="/tst:a/@stepType" required="true" rax:isTenant="false"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The wadl is translated")
+      val checker = builder.build (inWADL, plainDupsConfig)
+      Then("There should be no XSL steps and an XPATH steps should be in its place")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 2")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']) = 0")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @name='id']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @name='stepType']) = 1")
+    }
+
+    scenario ("A WADL with two XPaths rax:isTenant set to true on the second one and joinXPathChecks enabled") {
+      Given("A WADL with two XPath, no rax:isTenant")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02"
+                     xmlns:rax="http://docs.rackspace.com/api"
+                     xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                     xmlns:tst="http://www.rackspace.com/repose/wadl/checker/step/test"
+           >
+           <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="path/to/my/resource">
+                   <method href="#getMethod" />
+              </resource>
+           </resources>
+           <method id="getMethod" name="GET">
+                <request>
+                    <representation mediaType="application/xml">
+                      <param name="id" style="plain" path="/tst:a/@id" required="true" rax:isTenant="false"/>
+                      <param name="stepType" style="plain" path="/tst:a/@stepType" required="true" rax:isTenant="true"/>
+                   </representation>
+               </request>
+               <response status="200 203"/>
+           </method>
+      </application>
+      When("The wadl is translated")
+      val checker = builder.build (inWADL, plainDupsConfig)
+      Then("There should be no XSL steps and an XPATH steps should be in its place")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XSL']) = 1")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @name='id']) = 0")
+      assert (checker, "count(/chk:checker/chk:step[@type='XPATH' and @name='stepType']) = 1")
+      assert (checker, "count(//xsl:when[@test='/tst:a/@id']) = 1")
+      assert (checker, "count(//xsl:when[@test='/tst:a/@stepType']) = 0")
+    }
+
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,11 @@
             <version>${jackson-databind.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-scala_${scala.major}.${scala.minor}</artifactId>
+            <version>${jackson-databind.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.fge</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>${json-schema-validator.version}</version>


### PR DESCRIPTION
The general pattern is followed:

```xml
    <application xmlns="http://wadl.dev.java.net/2009/02" xmlns:rax="http://docs.rackspace.com/api">
     <resources base="https://test.api.openstack.com">
        <resource path="/v1/{tenant}/resource"
                  rax:roles="a:admin/{tenant}">
            <param name="tenant" style="template"/>
            <method name="POST" rax:roles="a:creator/{tenant}"/>
            <method name="GET" rax:roles="a:observer/{tenant} observer"/>
            <method name="PUT" rax:roles="a:creator/{tenant}"/>
            <method name="DELETE" rax:roles="a:creator/{tenant}"/>
        </resource>
     </resources>
    </application>
```

Note that roles such as `a:creator/{tenant}`. The tenant can be
specified from a parameter of types: template, plain, header or it can
be specified via a the Capture Header extension.

It is still possible to specify a non-tenant role such as `a:creator`,
this signifies (as before) that the role is contained by *any* tenant.

Relevant roles are reported either in the tenanted (`a:creator/{tenant}`) or the
non-tenated (`a:creator`) form to denote whether a tenant check was
performed or not.

If the parameter resolves to more than one tenant value, then
appropriate roles must assigned to *all* the tenants specified or else
the request is rejected.

The feature requires the header `X-MAP-ROLES` to be specified.  The
format is a base64 encoded object of the form:

```javascript
      {
         "1" : ["a:admin","foo","bar"],
         "2" : ["a:creator", "foo", "a:observer"],
         "3" : ["a:updater", "bar", "biz", "a:creator"],
         "4" : ["a:observer"],
         "5" : ["a:admin", "bar", "biz", "a:creator"]
      }
```

..which contains a mapping from tenants to appropriate roles.

The following limitations exists:

1. Tenant role checks are currently not supported when roles are
   masked with 404 or 405 responses. If the mask feature is enabled,
   and multi-tenant roles are specified, the validator will throw an
   error while loading the WADL.

2. Plain parameters can only capture single values in XML and JSON. It
   is, however, possible to specify an XPath into the body with the
   CaptureHeader extension to capture multiple tenants in the XML/JSON
   body.