### PR TITLE
Fixed a bug where adding extra whitspace in rax:roles cause errors.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,7 @@
 # Releases #
+## In Progress Work ##
+1. Fixed a bug where adding extra whitespace in the ```rax:roles``` attribute caused errors.
+
 ## Release 2.6.0 (2018-02-12) ##
 1. Added support for ```rax:representation```, this works like ```wadl:representation``` in that it can make assertions about XML, JSON representations. With ```rax:representation```, the representation may be embedded in another representation (JSON in XML), or in a header.
 1. Added support for multi-tenant role checks to rax:roles. These checks follow the pattern ```rolename/{tenantId}``` in ```rax:roles``` where ```rolename``` is the name of the role and ```tenantId``` is the name of a Header, Plain (Body), Template (URL), or CaptureHeader WADL parameter that captures the tenant.

--- a/core/src/main/resources/xsl/raxRoles.xsl
+++ b/core/src/main/resources/xsl/raxRoles.xsl
@@ -23,7 +23,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:wadl="http://wadl.dev.java.net/2009/02"
                 xmlns:xsd="http://www.w3.org/2001/XMLSchema"
                 xmlns:rax="http://docs.rackspace.com/api">
@@ -48,7 +48,7 @@
         <xsl:variable name="allRoles" as="xsd:string*">
             <xsl:sequence select="$roles"/>
             <xsl:if test="@rax:roles">
-                <xsl:sequence select="tokenize(@rax:roles,' ')"/>
+                <xsl:sequence select="tokenize(normalize-space(@rax:roles),' ')"/>
             </xsl:if>
         </xsl:variable>
 
@@ -65,7 +65,7 @@
         <xsl:variable name="allRoles" as="xsd:string*">
           <xsl:sequence select="$roles"/>
           <xsl:if test="@rax:roles">
-              <xsl:sequence select="tokenize(@rax:roles,' ')"/>
+              <xsl:sequence select="tokenize(normalize-space(@rax:roles),' ')"/>
           </xsl:if>
         </xsl:variable>
         <xsl:copy>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRelevantRolesSuite.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/ValidatorWADLRelevantRolesSuite.scala
@@ -92,7 +92,12 @@ class ValidatorWADLRelevantRolesSuite extends BaseValidatorSuite {
           <resource path="/encoded" rax:roles="f&#160;oo bar">
             <method name="GET"/>
           </resource>
-        </resource>
+       </resource>
+       <resource path="/multi-line">
+           <method name="GET" rax:roles="foo
+                                         bar
+               "/>
+       </resource>
       </resources>
     </application>
   }
@@ -199,5 +204,42 @@ class ValidatorWADLRelevantRolesSuite extends BaseValidatorSuite {
 
       validator.validate(req, response, chain)
     }
+
+    test(s"X-RELEVANT-ROLES header should contain a matching role with multiline modes using $configDesc") {
+      val validator = Validator(WADL_withRaxRoles, config)
+      val req = request("GET", "/multi-line", "application/xml", goodXML, parseContent = false,
+        Map("X-Roles" -> List("buz", "foo")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-RELEVANT-ROLES").toList == List("foo"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"X-RELEVANT-ROLES header should contain a matching role (bar) with multiline modes using $configDesc") {
+      val validator = Validator(WADL_withRaxRoles, config)
+      val req = request("GET", "/multi-line", "application/xml", goodXML, parseContent = false,
+        Map("X-Roles" -> List("bar","biz")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-RELEVANT-ROLES").toList == List("bar"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
+    test(s"X-RELEVANT-ROLES header should contain a matching role (foo, bar) with multiline modes using $configDesc") {
+      val validator = Validator(WADL_withRaxRoles, config)
+      val req = request("GET", "/multi-line", "application/xml", goodXML, parseContent = false,
+        Map("X-Roles" -> List("foo","bar")))
+
+      req.setAttribute(ASSERT_FUNCTION, (csReq: CheckerServletRequest, csResp: CheckerServletResponse, res: Result) => {
+        assert(csReq.getHeaders("X-RELEVANT-ROLES").toList == List("foo","bar"))
+      })
+
+      validator.validate(req, response, chain)
+    }
+
   }
 }


### PR DESCRIPTION
In some cases, (mask403s) the WADL will fail to load, in others it
setup condinitions that could never pass -- (expecting X-ROLES to be
present but empty). It also caused problems with Relevant Roles.

Added test cases to Releveant Roles, since this captures all the
scenarios.