### PR TITLE
We are not handling missing Method name correctly

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,7 @@
 # Releases #
 ## In Progress Work ##
 1. Fixed a bug where adding extra whitespace in the ```rax:roles``` attribute caused errors.
+1. Fixed a bug where we were not reporting a proper error if a method name was missing.
 
 ## Release 2.6.0 (2018-02-12) ##
 1. Added support for ```rax:representation```, this works like ```wadl:representation``` in that it can make assertions about XML, JSON representations. With ```rax:representation```, the representation may be embedded in another representation (JSON in XML), or in a header.

--- a/core/src/main/resources/xsl/wadl-asserts.xsl
+++ b/core/src/main/resources/xsl/wadl-asserts.xsl
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   wadl-asserts.xsl
+
+   This stylesheet simply copies over a normalized wadl and displays
+   an error if assertions fail. It is always run - even when
+   validation is disabled because stages later in the pipeline expect
+   a valid WADL.
+
+   Technically the assertions checks here may be better placed in the
+   wadl-tools project, but they are here because:
+
+   1. It is convenient.
+   2. It is a good placeholder for api-checker specific checks in the
+   future.
+
+   Copyright 2018 Rackspace US, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+               xmlns:wadl="http://wadl.dev.java.net/2009/02"
+               version="3.0">
+
+    <xsl:mode on-no-match="shallow-copy"/>
+
+    <xsl:template match="wadl:method[not(@href) and not(@name)]">
+        <xsl:message terminate="yes">[ERROR] The method <xsl:copy-of select="."/> requires a name.</xsl:message>
+    </xsl:template>
+</xsl:transform>

--- a/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerWADLAssertSpec.scala
+++ b/core/src/test/scala/com/rackspace/com/papi/components/checker/wadl/WADLCheckerWADLAssertSpec.scala
@@ -1,0 +1,56 @@
+/***
+ *   Copyright 2018 Rackspace US, Inc.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.rackspace.com.papi.components.checker.wadl
+
+import com.rackspace.com.papi.components.checker.{LogAssertions, Config}
+import org.apache.logging.log4j.Level
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class WADLCheckerWADLAssertSpec extends BaseCheckerSpec with LogAssertions {
+  feature ("The WADLCheckerBuilder can correctly identify WADLs that violate checker WADL assertions") {
+    info ("As a developer")
+    info ("I would like to catch errors not normally caught by WADL tools in WADL that are specific to the")
+    info ("api-checker, so that I can more easily debug a WADL")
+
+    scenario("A WADL with a no-name method"){
+      Given("a WADL with a no-name method")
+      val inWADL = <application xmlns="http://wadl.dev.java.net/2009/02">
+         <grammars/>
+           <resources base="https://test.api.openstack.com">
+              <resource path="/a/b">
+                   <method id="nameless">
+                      <response status="200 203"/>
+                   </method>
+              </resource>
+           </resources>
+      </application>
+      When ("The WADL is translated")
+      val checkerLog = log (Level.ERROR) {
+        intercept[WADLException] {
+          val checker = builder.build(inWADL, new Config())
+          println(checker) // Should never print!
+        }
+      }
+      Then ("There should be an error detailing that the method requires a name")
+      List("method","nameless","requires a name").foreach(m => {
+        assert(checkerLog, m)
+      })
+    }
+  }
+}


### PR DESCRIPTION
If the method name is left out, we get very cryptic error, instead we should assume the method is a GET.  Note that the WADL spec does not define what the method name should be, we are just assuming it's GET, which seams like a reasonable guess. 

Current Error:

````
An empty sequence is not allowed as the first argument of check:toRegExEscaped()
Exception in thread "main" com.rackspace.com.papi.components.checker.wadl.WADLException: WADL Processing Error: An empty sequence is not allowed as the first argument of check:toRegExEscaped()
	at com.rackspace.com.papi.components.checker.wadl.WADLCheckerBuilder.buildFromWADL(WADLCheckerBuilder.scala:695)
	at com.rackspace.com.papi.components.checker.wadl.WADLCheckerBuilder.build(WADLCheckerBuilder.scala:754)
	at com.rackspace.com.papi.components.checker.wadl.WADLDotBuilder.build(WADLDotBuilder.scala:98)
	at com.rackspace.com.papi.components.checker.cli.Wadl2Dot$.main(Wadl2Dot.scala:220)
	at com.rackspace.com.papi.components.checker.cli.Wadl2Dot.main(Wadl2Dot.scala)
Caused by: net.sf.saxon.s9api.SaxonApiException: An empty sequence is not allowed as the first argument of check:toRegExEscaped()
	at net.sf.saxon.s9api.XsltTransformer.close(XsltTransformer.java:691)
	at net.sf.saxon.s9api.XsltTransformer.transform(XsltTransformer.java:590)
	at com.rackspace.com.papi.components.checker.wadl.WADLCheckerBuilder.com$rackspace$com$papi$components$checker$wadl$WADLCheckerBuilder$$buildChecker(WADLCheckerBuilder.scala:443)
	at com.rackspace.com.papi.components.checker.wadl.WADLCheckerBuilder$$anonfun$buildFromWADL$1$$anonfun$5.apply(WADLCheckerBuilder.scala:682)
	at com.rackspace.com.papi.components.checker.wadl.WADLCheckerBuilder$$anonfun$buildFromWADL$1$$anonfun$5.apply(WADLCheckerBuilder.scala:682)
	at com.rackspace.com.papi.components.checker.wadl.BuilderHelper$.applyBuildSteps(BuilderHelper.scala:129)
	at com.rackspace.com.papi.components.checker.wadl.WADLCheckerBuilder$$anonfun$buildFromWADL$1.apply$mcV$sp(WADLCheckerBuilder.scala:690)
	at com.rackspace.com.papi.components.checker.wadl.WADLCheckerBuilder$$anonfun$buildFromWADL$1.apply(WADLCheckerBuilder.scala:649)
	at com.rackspace.com.papi.components.checker.wadl.WADLCheckerBuilder$$anonfun$buildFromWADL$1.apply(WADLCheckerBuilder.scala:649)
	at com.rackspace.cloud.api.wadl.util.XSLErrorDispatcher$class.handleXSLException(xsl-error-dispatcher.scala:15)
	at com.rackspace.com.papi.components.checker.wadl.WADLCheckerBuilder.handleXSLException(WADLCheckerBuilder.scala:218)
	at com.rackspace.com.papi.components.checker.wadl.WADLCheckerBuilder.buildFromWADL(WADLCheckerBuilder.scala:649)
	... 4 more
Caused by: net.sf.saxon.trans.XPathException: An empty sequence is not allowed as the first argument of check:toRegExEscaped()
	at net.sf.saxon.expr.Expression.typeError(Expression.java:1428)
	at net.sf.saxon.expr.CardinalityChecker.evaluateItem(CardinalityChecker.java:284)
	at net.sf.saxon.expr.parser.ExpressionTool.evaluate(ExpressionTool.java:326)
	at net.sf.saxon.expr.UserFunctionCall.evaluateArguments(UserFunctionCall.java:643)
	at net.sf.saxon.expr.UserFunctionCall.evaluateArguments(UserFunctionCall.java:623)
	at net.sf.saxon.expr.UserFunctionCall.callFunction(UserFunctionCall.java:529)
	at net.sf.saxon.expr.UserFunctionCall.evaluateItem(UserFunctionCall.java:479)
	at net.sf.saxon.expr.Expression.evaluateAsString(Expression.java:886)
	at net.sf.saxon.expr.instruct.SimpleNodeConstructor.processLeavingTail(SimpleNodeConstructor.java:218)
	at net.sf.saxon.expr.instruct.Block.processLeavingTail(Block.java:687)
	at net.sf.saxon.expr.instruct.Instruction.process(Instruction.java:151)
	at net.sf.saxon.expr.instruct.ElementCreator.processLeavingTail(ElementCreator.java:337)
	at net.sf.saxon.expr.instruct.ElementCreator.processLeavingTail(ElementCreator.java:284)
	at net.sf.saxon.expr.instruct.Block.processLeavingTail(Block.java:687)
	at net.sf.saxon.expr.instruct.Choose.processLeavingTail(Choose.java:880)
	at net.sf.saxon.expr.instruct.Block.processLeavingTail(Block.java:687)
	at net.sf.saxon.expr.LetExpression.processLeavingTail(LetExpression.java:699)
	at net.sf.saxon.expr.instruct.TemplateRule.applyLeavingTail(TemplateRule.java:347)
	at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:502)
	at net.sf.saxon.expr.instruct.ApplyTemplates.apply(ApplyTemplates.java:295)
	at net.sf.saxon.expr.instruct.ApplyTemplates.processLeavingTail(ApplyTemplates.java:252)
	at net.sf.saxon.expr.instruct.Block.processLeavingTail(Block.java:687)
	at net.sf.saxon.expr.LetExpression.processLeavingTail(LetExpression.java:699)
	at net.sf.saxon.expr.instruct.TemplateRule.applyLeavingTail(TemplateRule.java:347)
	at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:502)
	at net.sf.saxon.expr.instruct.ApplyTemplates.apply(ApplyTemplates.java:295)
	at net.sf.saxon.expr.instruct.ApplyTemplates.processLeavingTail(ApplyTemplates.java:252)
	at net.sf.saxon.expr.instruct.Block.processLeavingTail(Block.java:687)
	at net.sf.saxon.expr.LetExpression.processLeavingTail(LetExpression.java:699)
	at net.sf.saxon.expr.instruct.TemplateRule.applyLeavingTail(TemplateRule.java:347)
	at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:502)
	at net.sf.saxon.expr.instruct.ApplyTemplates.apply(ApplyTemplates.java:295)
	at net.sf.saxon.expr.instruct.ApplyTemplates.processLeavingTail(ApplyTemplates.java:252)
	at net.sf.saxon.expr.instruct.Block.processLeavingTail(Block.java:687)
	at net.sf.saxon.expr.LetExpression.processLeavingTail(LetExpression.java:699)
	at net.sf.saxon.expr.instruct.TemplateRule.applyLeavingTail(TemplateRule.java:347)
	at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:502)
	at net.sf.saxon.trans.TextOnlyCopyRuleSet.process(TextOnlyCopyRuleSet.java:66)
	at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:478)
	at net.sf.saxon.expr.instruct.ApplyTemplates.apply(ApplyTemplates.java:295)
	at net.sf.saxon.expr.instruct.ApplyTemplates.processLeavingTail(ApplyTemplates.java:252)
	at net.sf.saxon.expr.instruct.Block.processLeavingTail(Block.java:687)
	at net.sf.saxon.expr.instruct.Instruction.process(Instruction.java:151)
	at net.sf.saxon.expr.instruct.ElementCreator.processLeavingTail(ElementCreator.java:337)
	at net.sf.saxon.expr.instruct.ElementCreator.processLeavingTail(ElementCreator.java:284)
	at net.sf.saxon.expr.instruct.Instruction.process(Instruction.java:151)
	at net.sf.saxon.expr.instruct.DocumentInstr.evaluateItem(DocumentInstr.java:302)
	at net.sf.saxon.expr.instruct.DocumentInstr.evaluateItem(DocumentInstr.java:50)
	at net.sf.saxon.expr.parser.ExpressionTool.evaluate(ExpressionTool.java:326)
	at net.sf.saxon.expr.LetExpression.eval(LetExpression.java:509)
	at net.sf.saxon.expr.LetExpression.processLeavingTail(LetExpression.java:690)
	at net.sf.saxon.expr.instruct.TemplateRule.applyLeavingTail(TemplateRule.java:347)
	at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:502)
	at net.sf.saxon.trans.TextOnlyCopyRuleSet.process(TextOnlyCopyRuleSet.java:66)
	at net.sf.saxon.trans.Mode.applyTemplates(Mode.java:478)
	at net.sf.saxon.Controller.transformDocument(Controller.java:2396)
	at net.sf.saxon.s9api.XsltTransformer.close(XsltTransformer.java:689)
	... 15 more
````